### PR TITLE
Only cause commands to swallow the input if they match the predicate

### DIFF
--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -66,9 +66,8 @@ function keymap.on_key_pressed(k)
     if commands then
       for _, cmd in ipairs(commands) do
         local performed = command.perform(cmd)
-        if performed then break end
+        if performed then return true end
       end
-      return true
     end
   end
   return false


### PR DESCRIPTION
The current behaviour makes it hard to nicely implement vi style modal editing, because any time you add a command that's also normal text (e.g. "h") that ends up meaning the associated letter can never end up as textinput.

From my relatively limited testing, the editor seems to work fine this way instead, allowing things as textinput when they don't match any command. This is, after all, the default behaviour if no command is matched at all, so to me it seems consistent to have this as the behaviour if all the predicates are rejected when there are commands.

See https://github.com/wryun/litevi/blob/main/litevi.lua for more context (here I had to override `keymap.on_key_pressed`, but only to make this particular change, so it would be nice to just rely on upstream and be able to just add the key bindings).