### PR TITLE
Multicursor Implementation

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -118,7 +118,7 @@ local commands = {
   end,
 
   ["doc:newline-below"] = function()
-    for idx, line in doc():get_selections() do
+    for idx, line in doc():get_selections(false, true) do
       local indent = doc().lines[line]:match("^[\t ]*")
       doc():insert(line, math.huge, "\n" .. indent)
       doc():set_selections(idx, line + 1, math.huge)
@@ -126,7 +126,7 @@ local commands = {
   end,
 
   ["doc:newline-above"] = function()
-    for idx, line in doc():get_selections() do
+    for idx, line in doc():get_selections(false, true) do
       local indent = doc().lines[line]:match("^[\t ]*")
       doc():insert(line, 1, indent .. "\n")
       doc():set_selections(idx, line, math.huge)

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -110,7 +110,7 @@ local commands = {
   end,
 
   ["doc:newline"] = function()
-    for idx, line, col in doc():get_selections() do
+    for idx, line, col in doc():get_selections(false, true) do
       local indent = doc().lines[line]:match("^[\t ]*")
       if col <= #indent then
         indent = indent:sub(#indent + 2 - col)
@@ -208,7 +208,6 @@ local commands = {
 
   ["doc:indent"] = function()
     for idx, line1, col1, line2, col2 in doc_multiline_selections(true) do
-      print("LINE", line1, col1, line2, col2)
       local l1, c1, l2, c2 = doc():indent_text(false, line1, col1, line2, col2)
       if l1 then
         doc():set_selections(idx, l1, c1, l2, c2)

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -55,7 +55,7 @@ local function cut_or_copy(delete)
     if line1 ~= line2 or col1 ~= col2 then
       local text = doc():get_text(line1, col1, line2, col2)
       if delete then
-        doc():delete_to(0)
+        doc():delete_to_cursor(idx, 0)
       end
       full_text = full_text == "" and text or (full_text .. "\n" .. text)
       doc().cursor_clipboard[idx] = text

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -398,10 +398,12 @@ local commands = {
 
   ["doc:create-cursor-previous-line"] = function()
     split_cursor(-1)
+    doc():merge_cursors()
   end,
   
   ["doc:create-cursor-next-line"] = function()
     split_cursor(1)
+    doc():merge_cursors()
   end,
 
 }

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -384,7 +384,7 @@ local commands = {
     end
     os.remove(filename)
     core.log("Removed \"%s\"", filename)
-  end
+  end,
 
   ["doc:create-cursor-previous-line"] = function()
     split_cursor(-1)
@@ -394,7 +394,7 @@ local commands = {
   ["doc:create-cursor-next-line"] = function()
     split_cursor(1)
     doc():merge_cursors()
-  end,
+  end
 
 }
 

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -80,9 +80,7 @@ local function split_cursor(direction)
       table.insert(new_cursors, { line1 + direction, col1 })
     end
   end
-  for i,v in ipairs(new_cursors) do
-    doc():set_selections(#doc().selections/4 + 1, v[1], v[2])
-  end
+  for i,v in ipairs(new_cursors) do doc():add_selection(v[1], v[2]) end
 end
 
 local commands = {

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -77,7 +77,7 @@ local function split_cursor(direction)
       end
     end
     if not exists and line1 > 1 and line1 < #doc().lines then
-      table.insert(new_cursors, { line1 - 1, col1 })
+      table.insert(new_cursors, { line1 + direction, col1 })
     end
   end
   for i,v in ipairs(new_cursors) do

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -69,14 +69,7 @@ end
 local function split_cursor(direction)
   local new_cursors = {}
   for _, line1, col1 in doc():get_selections() do
-    local exists = false
-    for _, line2, col2 in doc():get_selections() do
-      if line1+direction == line2 and col1 == col2 then
-        exists = true
-        break
-      end
-    end
-    if not exists and line1 > 1 and line1 < #doc().lines then
+    if line1 > 1 and line1 < #doc().lines then
       table.insert(new_cursors, { line1 + direction, col1 })
     end
   end

--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -61,6 +61,26 @@ function common.color(str)
 end
 
 
+function common.splice(t, at, remove, insert)
+  insert = insert or {}
+  local offset = #insert - remove
+  local old_len = #t
+  if offset < 0 then
+    for i = at - offset, old_len - offset do
+      t[i + offset] = t[i]
+    end
+  elseif offset > 0 then
+    for i = old_len, at, -1 do
+      t[i + offset] = t[i]
+    end
+  end
+  for i, item in ipairs(insert) do
+    t[at + i - 1] = item
+  end
+end
+
+
+
 local function compare_score(a, b)
   return a.score > b.score
 end

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -169,18 +169,17 @@ function Doc:get_selection_count()
 end
 
 function Doc:get_selections(sort)
-  local idx = 1
-  return function()
-    if idx >= #self.selections then
+  return function(selections, idx)
+    local target = idx*4 + 1
+    if target >= #selections then
       return
     end
-    idx = idx + 4
     if sort then
-      return ((idx - 5) / 4) + 1, sort_positions(self.selections[idx - 4], self.selections[idx - 3], self.selections[idx - 2], self.selections[idx - 1])
+      return idx+1, sort_positions(selections[target], selections[target+1], selections[target+2], selections[target+3])
     else
-      return ((idx - 5) / 4) + 1, self.selections[idx - 4], self.selections[idx - 3], self.selections[idx - 2], self.selections[idx - 1]
+      return idx+1, selections[target], selections[target+1], selections[target+2], selections[target+3]
     end
-  end
+  end, self.selections, 0
 end
 
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -130,7 +130,7 @@ end
 
 function Doc:get_selection(sort)
   local idx, line1, col1, line2, col2 = self:get_selections(sort)(self.selections, 0)
-  return line1, col1, line2, col2
+  return line1, col1, line2, col2, sort
 end
 
 function Doc:get_selections(sort)
@@ -342,10 +342,10 @@ function Doc:text_input(text, idx)
   for sidx, line1, col1, line2, col2 in self:get_selections() do
     if not idx or idx == sidx then
       if line1 ~= line2 or col1 ~= col2 then
-        self:delete_to(sidx)
+        self:delete_to_cursor(sidx)
       end
       self:insert(line1, col1, text)
-      self:move_to(sidx, #text)
+      self:move_to_cursor(sidx, #text)
     end
   end
 end
@@ -370,7 +370,7 @@ function Doc:replace(fn)
 end
 
 
-function Doc:delete_to(idx, ...)
+function Doc:delete_to_cursor(idx, ...)
   for sidx, line1, col1, line2, col2 in self:get_selections(true) do
     if not idx or sidx == idx then
       if line1 ~= line2 or col1 ~= col2 then
@@ -384,18 +384,19 @@ function Doc:delete_to(idx, ...)
     end
   end
 end
+function Doc:delete_to(...) return self:delete_to(nil, ...) end
 
-
-function Doc:move_to(idx, ...)
+function Doc:move_to_cursor(idx, ...)
   for sidx, line, col in self:get_selections() do
     if not idx or sidx == idx then
       self:set_selections(sidx, self:position_offset(line, col, ...))
     end
   end
 end
+function Doc:move_to(...) return self:move_to_cursor(nil, ...) end
 
 
-function Doc:select_to(idx, ...)
+function Doc:select_to_cursor(idx, ...)
   for sidx, line, col, line2, col2 in self:get_selections() do
     if not idx or idx == sidx then
       line, col = self:position_offset(line, col, ...)
@@ -403,6 +404,7 @@ function Doc:select_to(idx, ...)
     end
   end
 end
+function Doc:select_to(...) return self:select_to_cursor(nil, ...) end
 
 
 local function get_indent_string()

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -159,9 +159,16 @@ end
 
 function Doc:get_selection(sort)
   if sort then
-    return sort_positions(self.selections[1], self.selections[2], self.selections[3], self.selections[4])
+    local result = {}
+    for sidx, line1, col1, line2, col2 in self:get_selections(true) do
+      table.insert(result, line1)
+      table.insert(result, col1)
+      table.insert(result, line2)
+      table.insert(result, col2)            
+    end
+    return result
   end
-  return self.selections[1], self.selections[2], self.selections[3], self.selections[4]
+  return unpack(self.selections)
 end
 
 function Doc:get_selection_count()
@@ -292,14 +299,11 @@ local function pop_undo(self, undo_stack, redo_stack, modified)
   if cmd.type == "insert" then
     local line, col, text = table.unpack(cmd)
     self:raw_insert(line, col, text, redo_stack, cmd.time)
-
   elseif cmd.type == "remove" then
     local line1, col1, line2, col2 = table.unpack(cmd)
     self:raw_remove(line1, col1, line2, col2, redo_stack, cmd.time)
-
   elseif cmd.type == "selection" then
-    self.selection.a.line, self.selection.a.col = cmd[1], cmd[2]
-    self.selection.b.line, self.selection.b.col = cmd[3], cmd[4]
+    self.selections = { unpack(cmd) }
   end
 
   modified = modified or (cmd.type ~= "selection")

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -361,7 +361,7 @@ function Doc:replace(fn)
   if old_text ~= new_text then
     self:insert(line2, col2, new_text)
     self:remove(line1, col1, line2, col2)
-    if had_selection then
+    if line1 == line2 and col1 == col2 then
       line2, col2 = self:position_offset(line1, col1, #new_text)
       self:set_selection(line1, col1, line2, col2)
     end

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -294,7 +294,7 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
 
   -- push undo
   local line2, col2 = self:position_offset(line, col, #text)
-  push_undo(undo_stack, time, "selection", self:get_selection())
+  push_undo(undo_stack, time, "selection", unpack(self.selections))
   push_undo(undo_stack, time, "remove", line, col, line2, col2)
 
   -- update highlighter and assure selection is in bounds
@@ -306,7 +306,7 @@ end
 function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
   -- push undo
   local text = self:get_text(line1, col1, line2, col2)
-  push_undo(undo_stack, time, "selection", self:get_selection())
+  push_undo(undo_stack, time, "selection", unpack(self.selections))
   push_undo(undo_stack, time, "insert", line1, col1, text)
 
   -- get line content before/after removed text

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -143,7 +143,7 @@ function Doc:set_selections(idx, line1, col1, line2, col2, swap, rm)
 end
 
 function Doc:add_selection(line1, col1, line2, col2, swap)
-  local l1, c1 = sort_positions(line1, col1, line2, col2)
+  local l1, c1 = sort_positions(line1, col1, line2 or line1, col2 or col1)
   local target = #self.selections / 4 + 1
   for idx, tl1, tc1 in self:get_selections(true) do
     if l1 < tl1 or l1 == tl1 and c1 < tc1 then

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -411,7 +411,7 @@ function Doc:delete_to_cursor(idx, ...)
   end
   self:merge_cursors(idx)
 end
-function Doc:delete_to(...) return self:delete_to(nil, ...) end
+function Doc:delete_to(...) return self:delete_to_cursor(nil, ...) end
 
 function Doc:move_to_cursor(idx, ...)
   for sidx, line, col in self:get_selections(false, idx) do

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -121,6 +121,18 @@ function Doc:set_selection(line1, col1, line2, col2, swap)
   self.cursor_clipboard = {}
 end
 
+function Doc:merge_cursors(idx)
+  for i = (idx or (#self.selections - 3)), (idx or 5), -4 do
+    for j = 1, i - 4, 4 do
+      if self.selections[i] == self.selections[j] and
+        self.selections[i+1] == self.selections[j+1] then
+          common.splice(self.selections, i, 4)
+          break
+      end
+    end
+  end
+end
+
 local function sort_positions(line1, col1, line2, col2)
   if line1 > line2 or line1 == line2 and col1 > col2 then
     return line2, col2, line1, col1
@@ -383,6 +395,7 @@ function Doc:delete_to_cursor(idx, ...)
       self:set_selections(sidx, line1, col1)
     end
   end
+  self:merge_cursors(idx)
 end
 function Doc:delete_to(...) return self:delete_to(nil, ...) end
 
@@ -392,6 +405,7 @@ function Doc:move_to_cursor(idx, ...)
       self:set_selections(sidx, self:position_offset(line, col, ...))
     end
   end
+  self:merge_cursors(idx)
 end
 function Doc:move_to(...) return self:move_to_cursor(nil, ...) end
 
@@ -403,6 +417,7 @@ function Doc:select_to_cursor(idx, ...)
       self:set_selections(sidx, line, col, line2, col2)
     end
   end
+  self:merge_cursors(idx)
 end
 function Doc:select_to(...) return self:select_to_cursor(nil, ...) end
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -47,6 +47,7 @@ end
 function Doc:reset()
   self.lines = { "\n" }
   self.selections = { 1, 1, 1, 1 }
+  self.cursor_clipboard = {}
   self.undo_stack = { idx = 1 }
   self.redo_stack = { idx = 1 }
   self.clean_change_id = 1
@@ -126,6 +127,12 @@ function Doc:get_change_id()
   return self.undo_stack.idx
 end
 
+function Doc:get_cursor_clipboard(idx)
+  return self.cursor_clipboard[idx]
+end
+function Doc:set_cursor_clipboard(idx, value)
+  self.cursor_clipboard[idx] = value
+end
 
 function Doc:set_selection(line1, col1, line2, col2, swap)
   assert(not line2 == not col2, "expected 2 or 4 arguments")
@@ -133,6 +140,7 @@ function Doc:set_selection(line1, col1, line2, col2, swap)
   line1, col1 = self:sanitize_position(line1, col1)
   line2, col2 = self:sanitize_position(line2 or line1, col2 or col1) 
   self.selections = { line1, col1, line2, col2 }
+  self.cursor_clipboard = {}
 end
 
 function Doc:set_selections(idx, line1, col1, line2, col2, swap)
@@ -171,7 +179,7 @@ function Doc:get_selection(sort)
   return unpack(self.selections)
 end
 
-function Doc:get_selection_count()
+function Doc:get_cursor_count()
   return #self.selections / 4
 end
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -526,6 +526,7 @@ function Doc:indent_text(unindent, line1, col1, line2, col2)
     end
   else
     self:insert(line1, col1, text)
+    return line1, col1 + #text, line1, col1 + #text
   end
 end
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -351,7 +351,7 @@ end
 
 
 function Doc:text_input(text, idx)
-  for sidx, line1, col1, line2, col2 in self:get_selections() do
+  for sidx, line1, col1, line2, col2 in self:get_selections(true) do
     if not idx or idx == sidx then
       if line1 ~= line2 or col1 ~= col2 then
         self:delete_to_cursor(sidx)

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -518,14 +518,14 @@ function Doc:indent_text(unindent, line1, col1, line2, col2)
         unindent and rnded:sub(1, #rnded - #text) or rnded .. text)
     end
     l1d, l2d = #self.lines[line1] - l1d, #self.lines[line2] - l2d
-    if (unindent or in_beginning_whitespace) and not self:has_selection() then
+    if (unindent or in_beginning_whitespace) and not has_selection then
       local start_cursor = (se and se + 1 or 1) + l1d or #(self.lines[line1])
       return line1, start_cursor, line2, start_cursor
     else
       return line1, col1 + l1d, line2, col2 + l2d
     end
   else
-    self:text_input(text)
+    self:insert(line1, col1, text)
   end
 end
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -172,17 +172,17 @@ function Doc:merge_cursors(idx)
 end
 
 local function selection_iterator(invariant, idx)
-  local target = invariant[3] and (#invariant[1] - 3 - idx * 4) or (idx*4 + 1)
-  if idx * 4 >= #invariant[1] then return end
+  local target = invariant[3] and (idx*4 - 7) or (idx*4 + 1)
+  if target > #invariant[1] or target <= 0 then return end
   if invariant[2] then
-    return idx+1, sort_positions(unpack(invariant[1], target, target+4))
+    return idx+(invariant[3] and -1 or 1), sort_positions(unpack(invariant[1], target, target+4))
   else
-    return idx+1, unpack(invariant[1], target, target+4)
+    return idx+(invariant[3] and -1 or 1), unpack(invariant[1], target, target+4)
   end
 end
 
 function Doc:get_selections(sort_intra, reverse)
-  return selection_iterator, { self.selections, sort_intra, reverse }, 0
+  return selection_iterator, { self.selections, sort_intra, reverse }, reverse and (#self.selections / 4) + 1 or 0
 end
 -- End of cursor seciton.
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -455,13 +455,11 @@ function Doc:indent_text(unindent, line1, col1, line2, col2)
     if (unindent or in_beginning_whitespace) and not has_selection then
       local start_cursor = (se and se + 1 or 1) + l1d or #(self.lines[line1])
       return line1, start_cursor, line2, start_cursor
-    else
-      return line1, col1 + l1d, line2, col2 + l2d
     end
-  else
-    self:insert(line1, col1, text)
-    return line1, col1 + #text, line1, col1 + #text
+    return line1, col1 + l1d, line2, col2 + l2d
   end
+  self:insert(line1, col1, text)
+  return line1, col1 + #text, line1, col1 + #text
 end
 
 -- For plugins to add custom actions of document change

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -361,7 +361,7 @@ function DocView:draw_line_body(idx, x, y)
   end
   for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do 
     -- draw line highlight if caret is on this line
-    if config.highlight_current_line and not self.doc:has_selection(lidx)
+    if config.highlight_current_line and (line1 == line2 and col1 == col2)
     and line1 == idx and core.active_view == self then
       self:draw_line_highlight(x + self.scroll.x, y)
     end

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -278,6 +278,7 @@ function DocView:on_mouse_moved(x, y, ...)
     local clicks = self.mouse_selecting.clicks
     if keymap.modkeys["ctrl"] then
       if l1 > l2 then l1, l2 = l2, l1 end
+      self.doc.selections = { }
       for i = l1, l2 do
         self.doc:set_selections(i - l1 + 1, i, math.min(c1, #self.doc.lines[i]), i, math.min(c2, #self.doc.lines[i]))
       end

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -277,12 +277,9 @@ function DocView:on_mouse_moved(x, y, ...)
     local l2, c2 = table.unpack(self.mouse_selecting)
     local clicks = self.mouse_selecting.clicks
     if keymap.modkeys["ctrl"] then
-      if l1 > l2 then
-        l1, l2 = l2, l1
-      end
-      local idx = 1
+      if l1 > l2 then l1, l2 = l2, l1 end
       for i = l1, l2 do
-        self.doc:set_selections(i - l1 + 1, i, math.min(c1, #self.doc.lines[i]), i, math.min(c1, #self.doc.lines[i]))
+        self.doc:set_selections(i - l1 + 1, i, math.min(c1, #self.doc.lines[i]), i, math.min(c2, #self.doc.lines[i]))
       end
     else
       self.doc:set_selection(mouse_selection(self.doc, clicks, l1, c1, l2, c2))

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -278,12 +278,11 @@ function DocView:on_mouse_moved(x, y, ...)
     local clicks = self.mouse_selecting.clicks
     if keymap.modkeys["ctrl"] then
       if l1 > l2 then
-        l2 = l1
+        l1, l2 = l2, l1
       end
       local idx = 1
       for i = l1, l2 do
-        idx = idx + 1
-        self.doc:set_selections(idx, i, math.min(c1, #self.doc.lines[i]), i, math.min(c1, #self.doc.lines[i]))
+        self.doc:set_selections(i - l1 + 1, i, math.min(c1, #self.doc.lines[i]), i, math.min(c1, #self.doc.lines[i]))
       end
     else
       self.doc:set_selection(mouse_selection(self.doc, clicks, l1, c1, l2, c2))

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -276,7 +276,18 @@ function DocView:on_mouse_moved(x, y, ...)
     local l1, c1 = self:resolve_screen_position(x, y)
     local l2, c2 = table.unpack(self.mouse_selecting)
     local clicks = self.mouse_selecting.clicks
-    self.doc:set_selection(mouse_selection(self.doc, clicks, l1, c1, l2, c2))
+    if keymap.modkeys["ctrl"] then
+      if l1 > l2 then
+        l2 = l1
+      end
+      local idx = 1
+      for i = l1, l2 do
+        idx = idx + 1
+        self.doc:set_selections(idx, i, math.min(c1, #self.doc.lines[i]), i, math.min(c1, #self.doc.lines[i]))
+      end
+    else
+      self.doc:set_selection(mouse_selection(self.doc, clicks, l1, c1, l2, c2))
+    end
   end
 end
 
@@ -340,46 +351,50 @@ end
 
 
 function DocView:draw_line_body(idx, x, y)
-  local line, col = self.doc:get_selection()
-
   -- draw selection if it overlaps this line
-  local line1, col1, line2, col2 = self.doc:get_selection(true)
-  if idx >= line1 and idx <= line2 then
-    local text = self.doc.lines[idx]
-    if line1 ~= idx then col1 = 1 end
-    if line2 ~= idx then col2 = #text + 1 end
-    local x1 = x + self:get_col_x_offset(idx, col1)
-    local x2 = x + self:get_col_x_offset(idx, col2)
-    local lh = self:get_line_height()
-    renderer.draw_rect(x1, y, x2 - x1, lh, style.selection)
+  for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do 
+    if idx >= line1 and idx <= line2 then
+      local text = self.doc.lines[idx]
+      if line1 ~= idx then col1 = 1 end
+      if line2 ~= idx then col2 = #text + 1 end
+      local x1 = x + self:get_col_x_offset(idx, col1)
+      local x2 = x + self:get_col_x_offset(idx, col2)
+      local lh = self:get_line_height()
+      renderer.draw_rect(x1, y, x2 - x1, lh, style.selection)
+    end
   end
-
-  -- draw line highlight if caret is on this line
-  if config.highlight_current_line and not self.doc:has_selection()
-  and line == idx and core.active_view == self then
-    self:draw_line_highlight(x + self.scroll.x, y)
+  for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do 
+    -- draw line highlight if caret is on this line
+    if config.highlight_current_line and not self.doc:has_selection(lidx)
+    and line1 == idx and core.active_view == self then
+      self:draw_line_highlight(x + self.scroll.x, y)
+    end
   end
-
+  
   -- draw line's text
   self:draw_line_text(idx, x, y)
 
   -- draw caret if it overlaps this line
   local T = config.blink_period
-  if line == idx and core.active_view == self
-  and (core.blink_timer - core.blink_start) % T < T / 2
-  and system.window_has_focus() then
-    local lh = self:get_line_height()
-    local x1 = x + self:get_col_x_offset(line, col)
-    renderer.draw_rect(x1, y, style.caret_width, lh, style.caret)
+  for _, line, col in self.doc:get_selections() do 
+    if line == idx and core.active_view == self
+    and (core.blink_timer - core.blink_start) % T < T / 2
+    and system.window_has_focus() then
+      local lh = self:get_line_height()
+      local x1 = x + self:get_col_x_offset(line, col)
+      renderer.draw_rect(x1, y, style.caret_width, lh, style.caret)
+    end
   end
 end
 
 
 function DocView:draw_line_gutter(idx, x, y)
   local color = style.line_number
-  local line1, _, line2, _ = self.doc:get_selection(true)
-  if idx >= line1 and idx <= line2 then
-    color = style.line_number2
+  for _, line1, _, line2 in self.doc:get_selections(true) do 
+    if idx >= line1 and idx <= line2 then
+      color = style.line_number2
+      break
+    end
   end
   local yoffset = self:get_line_text_y_offset()
   x = x + style.padding.x

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -256,7 +256,11 @@ function DocView:on_mouse_pressed(button, x, y, clicks)
     end
   else
     local line, col = self:resolve_screen_position(x, y)
-    self.doc:set_selection(mouse_selection(self.doc, clicks, line, col, line, col))
+    if keymap.modkeys["ctrl"] then
+      self.doc:add_selection(mouse_selection(self.doc, clicks, line, col, line, col))
+    else
+      self.doc:set_selection(mouse_selection(self.doc, clicks, line, col, line, col))
+    end
     self.mouse_selecting = { line, col, clicks = clicks }
   end
   core.blink_reset()

--- a/data/core/keymap-macos.lua
+++ b/data/core/keymap-macos.lua
@@ -101,6 +101,8 @@ local function keymap_macos(keymap)
     ["cmd+shift+end"] = "doc:select-to-end-of-doc",
     ["shift+pageup"] = "doc:select-to-previous-page",
     ["shift+pagedown"] = "doc:select-to-next-page",
+    ["cmd+shift+up"] = "doc:create-cursor-previous-line",
+    ["cmd+shift+down"] = "doc:create-cursor-next-line"
   }
 end
 

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -202,6 +202,8 @@ keymap.add_direct {
   ["ctrl+shift+end"] = "doc:select-to-end-of-doc",
   ["shift+pageup"] = "doc:select-to-previous-page",
   ["shift+pagedown"] = "doc:select-to-next-page",
+  ["ctrl+shift+up"] = "doc:create-cursor-previous-line",
+  ["ctrl+shift+down"] = "doc:create-cursor-next-line"
 }
 
 return keymap


### PR DESCRIPTION
Rewrote things to be compatible with a multicursor implementation.

**Major Features**
- Should be fully backwards compatible with all plugins (i.e. if you're using a single cursor, nothing changes). If you have a multicursor, could have some weird stuff happening, but *should* have things occur to the first cursor.
- All translations, and newlines, and text input and stuff can now be targeted per-cursor; by default, they target all cursors if prefixed with an nil; otherwise, they take a cursor index.
- Multiple selections possible.
- Multiple clipboard buffers; one per cursor are used. System clipboard contains a copy separated by the line separator.
- Holding control, and dragging will create multiple cursors.
- All in all, only about 60 SLOC added.

There are likely *many* bugs. This is a first iteration; but I thought I'd throw up the pull request so people could leave comments, request features, and try the thing out if they want.

I am not super familiar with using multicursors in for day-to-day usage, so would heavily appreciate feature requests!