### PR TITLE
[plugin/contextmenu] Append itemsets that where registered.

### DIFF
--- a/data/plugins/contextmenu.lua
+++ b/data/plugins/contextmenu.lua
@@ -64,14 +64,19 @@ end
 
 function ContextMenu:show(x, y)
   self.items = nil
+  local items_list = { width = 0, height = 0 }
   for _, items in ipairs(self.itemset) do
     if items.predicate(x, y) then
-      self.items = items.items
-      break
+      items_list.width = math.max(items_list.width, items.items.width)
+      items_list.height = items_list.height + items.items.height
+      for _, subitems in ipairs(items.items) do
+        table.insert(items_list, subitems)
+      end
     end
   end
 
-  if self.items then
+  if #items_list > 0 then
+    self.items = items_list
     local w, h = self.items.width, self.items.height
 
     -- by default the box is opened on the right and below


### PR DESCRIPTION
Small modification to new shiny contextmenu plugin for appending all itemsets with matching predicate in order to easily use it by other plugins that want to add some items as shown:

![2021-06-06_04:39:27](https://user-images.githubusercontent.com/1702572/120918540-ed0c8180-c682-11eb-86e5-ed81af2c99e8.png)

![2021-06-06_04:39:06](https://user-images.githubusercontent.com/1702572/120918543-f0077200-c682-11eb-9fd2-a904dad2f473.png)

As seen here: https://github.com/jgmdev/lite-xl-lsp/blob/master/lsp/init.lua#L1473-L1527
