### PR TITLE
Integrate mkdirp function in common module

### DIFF
--- a/data/core/commands/files.lua
+++ b/data/core/commands/files.lua
@@ -1,37 +1,11 @@
 local core = require "core"
 local command = require "core.command"
-
-local function mkdirp(path)
-  local segments = {}
-  local pos = 1
-  while true do
-    local s, e = string.find(path, "[/\\]+", pos)
-    if not s then break end
-    table.insert(segments, string.sub(str, pos, s - 1))
-    pos = e + 1
-  end
-  table.insert(segments, string.sub(str, pos))
-  if segments[#segments] == '' then
-    table.remove(segments)
-  end
-
-  for i = 1, #segments do
-    local p = table.concat(segments, PATHSEP, 1, i)
-    local stat = system.get_file_info(p)
-    if stat and stat.type == "file" then
-      return nil, "path exists", p
-    end
-    local success, err = system.mkdir(p)
-    if not success then
-      return nil, err, p
-    end
-  end
-end
+local common = require "core.common"
 
 command.add(nil, {
   ["files:create-directory"] = function()
     core.command_view:enter("New directory name", function(text)
-      local success, err, path = mkdirp(text)
+      local success, err, path = common.mkdirp(text)
       if not success then
         core.error("cannot create directory %q: %s", path, err)
       end

--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -273,4 +273,26 @@ function common.relative_path(ref_dir, dir)
 end
 
 
+function common.mkdirp(path)
+  local stat = system.get_file_info(path)
+  if stat and stat.type then
+    return false, "path exists", path
+  end
+  local subdirs = {}
+  while path and path ~= "" do
+    local success_mkdir = system.mkdir(path)
+    if success_mkdir then break end
+    local updir, basedir = path:match("(.*)[/\\](.+)$")
+    table.insert(subdirs, 1, basedir or path)
+    path = updir
+  end
+  for _, dirname in ipairs(subdirs) do
+    path = path and path .. PATHSEP .. dirname or dirname
+    if not system.mkdir(path) then
+      return false, "cannot create directory", path
+    end
+  end
+  return true
+end
+
 return common

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -276,25 +276,12 @@ end
 -- create a directory using mkdir but may need to create the parent
 -- directories as well.
 local function create_user_directory()
-  local dirname_create = USERDIR
-  local basedir
-  local subdirs = {}
-  while dirname_create and dirname_create ~= "" do
-    local success_mkdir = system.mkdir(dirname_create)
-    if success_mkdir then break end
-    dirname_create, basedir = dirname_create:match("(.*)[/\\](.+)$")
-    if basedir then
-      subdirs[#subdirs + 1] = basedir
-    end
-  end
-  for _, dirname in ipairs(subdirs) do
-    dirname_create = dirname_create .. '/' .. dirname
-    if not system.mkdir(dirname_create) then
-      error("cannot create directory: \"" .. dirname_create .. "\"")
-    end
+  local success, err = common.mkdirp(USERDIR)
+  if not success then
+    error("cannot create directory \"" .. USERDIR .. "\": " .. err)
   end
   for _, modname in ipairs {'plugins', 'colors', 'fonts'} do
-    local subdirname = dirname_create .. '/' .. modname
+    local subdirname = USERDIR .. PATHSEP .. modname
     if not system.mkdir(subdirname) then
       error("cannot create directory: \"" .. subdirname .. "\"")
     end


### PR DESCRIPTION
Move the function mkdirp into common to be generally available.

Use the new common.mkdirp from create_user_directory() from
core/init.lua replacing previous parent directory creation code
within the function.

The previous mkdirp function did not work on Windows where
absolute paths starts with a drive letter. The code from
create_user_directory() did not have this problem but was wrong
in the way it was creating the nested directories.

The new implementation in common.mkdirp fix both problems.