### PR TITLE
Replaced fill loop with SDL_FillRect.

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -309,12 +309,8 @@ void ren_draw_rect(RenRect rect, RenColor color) {
   int dr = surface->w - (x2 - x1);
 
   if (color.a == 0xff) {
-    #if defined(__arm__) || defined(__aarch64__)
-        rect_draw_loop(color);
-    #else
-        SDL_Rect rect = { x1, y1, x2 - x1, y2 - y1 };
-        SDL_FillRect(surface, &rect, SDL_MapRGBA(surface->format, color.r, color.g, color.b, color.a));
-    #endif
+    SDL_Rect rect = { x1, y1, x2 - x1, y2 - y1 };
+    SDL_FillRect(surface, &rect, SDL_MapRGBA(surface->format, color.r, color.g, color.b, color.a));
   } else {
     rect_draw_loop(blend_pixel(*d, color));
   }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -309,8 +309,12 @@ void ren_draw_rect(RenRect rect, RenColor color) {
   int dr = surface->w - (x2 - x1);
 
   if (color.a == 0xff) {
-    SDL_Rect rect = { x1, y1, x2 - x1, y2 - y1 };
-    SDL_FillRect(surface, &rect, 255 << 24 | color.r << 16 | color.g << 8 | color.r);
+    #if defined(__arm__) || defined(__aarch64__)
+        rect_draw_loop(color);
+    #else
+        SDL_Rect rect = { x1, y1, x2 - x1, y2 - y1 };
+        SDL_FillRect(surface, &rect, SDL_MapRGBA(surface->format, color.r, color.g, color.b, color.a));
+    #endif
   } else {
     rect_draw_loop(blend_pixel(*d, color));
   }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -309,7 +309,8 @@ void ren_draw_rect(RenRect rect, RenColor color) {
   int dr = surface->w - (x2 - x1);
 
   if (color.a == 0xff) {
-    rect_draw_loop(color);
+    SDL_Rect rect = { x1, y1, x2 - x1, y2 - y1 };
+    SDL_FillRect(surface, &rect, 255 << 24 | color.r << 16 | color.g << 8 | color.r);
   } else {
     rect_draw_loop(blend_pixel(*d, color));
   }


### PR DESCRIPTION
This reduces the time taken to fill a rectangle by like 80%, and reduces total CPU load by like ~40% while scrolling, or during any full redraw, as per the results in #113 .