### PR TITLE
Added in XDG_CONFIG_HOME env variable.

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -12,7 +12,7 @@ else
   local prefix = EXEDIR:match("^(.+)[/\\]bin$")
   DATADIR = prefix and (prefix .. '/share/lite-xl') or (EXEDIR .. '/data')
 end
-USERDIR = HOME and (HOME .. '/.config/lite-xl') or (EXEDIR .. '/user')
+USERDIR = os.getenv("XDG_CONFIG_HOME") or (HOME and (HOME .. '/.config/lite-xl') or (EXEDIR .. '/user'))
 
 package.path = DATADIR .. '/?.lua;' .. package.path
 package.path = DATADIR .. '/?/init.lua;' .. package.path


### PR DESCRIPTION
Should close #69.

Lite doesn't make a distinction currently between user data, user config and user state settings; we just chuck everything in the same folder, which honestly I'm fine with. We could talk about separating this out, but I'm not sure it's necessary. 

So as it stands, I think the only variable we should pay attention to should be `XDG_CONFIG_HOME`, even though we do have some data in the form of plugins, and some state in the form of the window sizes, files open, and location. Work for everyone?  
@mmatongo, specifically?