### PR TITLE
Added Doc:on_close() method.

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -1,5 +1,6 @@
 local Object = require "core.object"
 local Highlighter = require "core.doc.highlighter"
+local core = require "core"
 local syntax = require "core.syntax"
 local config = require "core.config"
 local common = require "core.common"
@@ -181,10 +182,10 @@ local function selection_iterator(invariant, idx)
   end
 end
 
--- If idx_reverse is true, it'll reverse iterate. If nil, or false, regular iterate. 
+-- If idx_reverse is true, it'll reverse iterate. If nil, or false, regular iterate.
 -- If a number, runs for exactly that iteration.
 function Doc:get_selections(sort_intra, idx_reverse)
-  return selection_iterator, { self.selections, sort_intra, idx_reverse }, 
+  return selection_iterator, { self.selections, sort_intra, idx_reverse },
     idx_reverse == true and ((#self.selections / 4) + 1) or ((idx_reverse or -1)+1)
 end
 -- End of cursor seciton.
@@ -491,6 +492,11 @@ end
 
 -- For plugins to add custom actions of document change
 function Doc:on_text_change(type)
+end
+
+-- For plugins to get notified when a document is closed
+function Doc:on_close()
+  core.log_quiet("Closed doc \"%s\"", self:get_name())
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -972,7 +972,7 @@ function core.step()
     local doc = core.docs[i]
     if #core.get_views_referencing_doc(doc) == 0 then
       table.remove(core.docs, i)
-      core.log_quiet("Closed doc \"%s\"", doc:get_name())
+      doc:on_close()
     end
   end
 


### PR DESCRIPTION
This was already on dev branch and is needed for the LSP plugin, after testing works well so next step is to merge in master, but since the previous __save hook__ was removed I wonder if this should be reworked to instead introduce a:
```lua
function Doc:on_close()
```
that is called when document is closed and which could be overwritten as typically done by lite plugins, or if others don't have issues with the method used on this pull request just merge it. Anyways, if the method above is preferred I can change this pull request to that and change the LSP plugin accordingly. Waiting for comments, suggestions :)