### PR TITLE
Find Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ build*
 .lite-debug.log
 subprojects/lua
 subprojects/libagg
-sybprojects/lua
+subprojects/reproc
+lite
+error.txt

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 cflags+="-Wall -O3 -g -std=gnu11 -fno-strict-aliasing -Isrc -Ilib/font_renderer"
 cflags+=" $(pkg-config --cflags lua5.2) $(sdl2-config --cflags)"
 lflags="-static-libgcc -static-libstdc++"
-for package in libagg freetype2 lua5.2 x11 libpcre2-8; do
+for package in libagg freetype2 lua5.2 x11 libpcre2-8 reproc; do
   lflags+=" $(pkg-config --libs $package)"
 done
 lflags+=" $(sdl2-config --libs) -lm"

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -170,7 +170,7 @@ local commands = {
   ["doc:select-lines"] = function()
     for idx, line1, _, line2 in doc():get_selections(true) do
       append_line_if_last_line(line2)
-      doc():set_selections(idx, line1, 1, line2 + 1, 1, swap)
+      doc():set_selections(idx, line1, 1, line2 + 1, 1)
     end
   end,
 
@@ -221,7 +221,7 @@ local commands = {
       local text = doc():get_text(line1, 1, line2 + 1, 1)
       doc():insert(line2 + 1, 1, text)
       local n = line2 - line1 + 1
-      doc():set_selections(idx, line1 + n, col1, line2 + n, col2, swap)
+      doc():set_selections(idx, line1 + n, col1, line2 + n, col2)
     end
   end,
 

--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -2,67 +2,70 @@ local core = require "core"
 local command = require "core.command"
 local config = require "core.config"
 local search = require "core.doc.search"
+local keymap = require "core.keymap"
 local DocView = require "core.docview"
+local CommandView = require "core.commandview"
+local StatusView = require "core.statusview"
 
-local max_previous_finds = 50
+local max_last_finds = 50
+local last_finds, last_view, last_fn, last_text, last_sel
 
+local case_insensitive = config.find_case_insensitive or false
+local plain = config.find_plain or false
 
 local function doc()
-  return core.active_view.doc
+  return last_view and last_view.doc or core.active_view.doc
 end
 
-
-local previous_finds
-local last_doc
-local last_fn, last_text
-
-
-local function push_previous_find(doc, sel)
-  if last_doc ~= doc then
-    last_doc = doc
-    previous_finds = {}
-  end
-  if #previous_finds >= max_previous_finds then
-    table.remove(previous_finds, 1)
-  end
-  table.insert(previous_finds, sel or { doc:get_selection() })
+local function get_find_tooltip()
+  local rf = keymap.get_binding("find-replace:repeat-find")
+  local ti = keymap.get_binding("find-replace:toggle-insensitivity")
+  local tr = keymap.get_binding("find-replace:toggle-plain")
+  return (plain and "[Plain] " or "") ..
+    (case_insensitive and "[Insensitive] " or "") ..
+    (rf and ("Press " .. rf .. " to select the next match.") or "") ..
+    (ti and (" " .. ti .. " toggles case sensitivity.") or "") ..
+    (tr and (" " .. tr .. " toggles plain find.") or "")
 end
 
+local function update_preview(sel, search_fn, text)
+  local ok, line1, col1, line2, col2 =
+    pcall(search_fn, last_view.doc, sel[1], sel[2], text, case_insensitive, plain)
+  if ok and line1 and text ~= "" then
+    last_view.doc:set_selection(line2, col2, line1, col1)
+    last_view:scroll_to_line(line2, true)
+    return true
+  else
+    last_view.doc:set_selection(unpack(sel))
+    return false
+  end
+end
 
 local function find(label, search_fn)
-  local dv = core.active_view
-  local sel = { dv.doc:get_selection() }
-  local text = dv.doc:get_text(table.unpack(sel))
-  local found = false
+  last_view, last_sel, last_finds = core.active_view,
+    { core.active_view.doc:get_selection() }, {}
+  local text, found = last_view.doc:get_text(unpack(last_sel)), false
 
   core.command_view:set_text(text, true)
+  core.status_view:show_tooltip(get_find_tooltip())
 
   core.command_view:enter(label, function(text)
+    core.status_view:remove_tooltip()
     if found then
       last_fn, last_text = search_fn, text
-      previous_finds = {}
-      push_previous_find(dv.doc, sel)
     else
       core.error("Couldn't find %q", text)
-      dv.doc:set_selection(table.unpack(sel))
-      dv:scroll_to_make_visible(sel[1], sel[2])
+      last_view.doc:set_selection(unpack(last_sel))
+      last_view:scroll_to_make_visible(unpack(last_sel))
     end
-
   end, function(text)
-    local ok, line1, col1, line2, col2 = pcall(search_fn, dv.doc, sel[1], sel[2], text)
-    if ok and line1 and text ~= "" then
-      dv.doc:set_selection(line2, col2, line1, col1)
-      dv:scroll_to_line(line2, true)
-      found = true
-    else
-      dv.doc:set_selection(table.unpack(sel))
-      found = false
-    end
-
+    found = update_preview(last_sel, search_fn, text)
+    last_fn, last_text = search_fn, text
   end, function(explicit)
+    core.status_view:remove_tooltip()
     if explicit then
-      dv.doc:set_selection(table.unpack(sel))
-      dv:scroll_to_make_visible(sel[1], sel[2])
+      last_view.doc:set_selection(unpack(last_sel))
+      last_view:scroll_to_make_visible(unpack(last_sel))
     end
   end)
 end
@@ -71,6 +74,7 @@ end
 local function replace(kind, default, fn)
   core.command_view:set_text(default, true)
 
+  core.status_view:show_tooltip(get_find_tooltip())
   core.command_view:enter("Find To Replace " .. kind, function(old)
     core.command_view:set_text(old, true)
 
@@ -80,75 +84,39 @@ local function replace(kind, default, fn)
         return fn(text, old, new)
       end)
       core.log("Replaced %d instance(s) of %s %q with %q", n, kind, old, new)
+    end, function() end, function()
+      core.status_view:remove_tooltip()
     end)
   end)
 end
 
-
 local function has_selection()
-  return core.active_view:is(DocView)
-     and core.active_view.doc:has_selection()
+  return core.active_view:is(DocView) and core.active_view.doc:has_selection()
 end
-
 
 command.add(has_selection, {
   ["find-replace:select-next"] = function()
     local l1, c1, l2, c2 = doc():get_selection(true)
     local text = doc():get_text(l1, c1, l2, c2)
-    local l1, c1, l2, c2 = search.find(doc(), l2, c2, text, { wrap = true })
+    l1, c1, l2, c2 = search.find(doc(), l2, c2, text, { wrap = true })
     if l2 then doc():set_selection(l2, c2, l1, c1) end
   end
 })
 
 command.add("core.docview", {
   ["find-replace:find"] = function()
-    find("Find Text", function(doc, line, col, text)
-      local opt = { wrap = true, no_case = true }
+    find("Find Text", function(doc, line, col, text, case_insensitive, plain)
+      local opt = { wrap = true, no_case = case_insensitive, regex = not plain }
       return search.find(doc, line, col, text, opt)
     end)
-  end,
-
-  ["find-replace:find-regex"] = function()
-    find("Find Text Regex", function(doc, line, col, text)
-      local opt = { wrap = true, no_case = true, regex = true }
-      return search.find(doc, line, col, text, opt)
-    end)
-  end,
-
-  ["find-replace:repeat-find"] = function()
-    if not last_fn then
-      core.error("No find to continue from")
-    else
-      local line, col = doc():get_selection()
-      local line1, col1, line2, col2 = last_fn(doc(), line, col, last_text)
-      if line1 then
-        push_previous_find(doc())
-        doc():set_selection(line2, col2, line1, col1)
-        core.active_view:scroll_to_line(line2, true)
-      end
-    end
-  end,
-
-  ["find-replace:previous-find"] = function()
-    local sel = table.remove(previous_finds)
-    if not sel or doc() ~= last_doc then
-      core.error("No previous finds")
-      return
-    end
-    doc():set_selection(table.unpack(sel))
-    core.active_view:scroll_to_line(sel[3], true)
   end,
 
   ["find-replace:replace"] = function()
-    replace("Text", "", function(text, old, new)
-      return text:gsub(old:gsub("%W", "%%%1"), new:gsub("%%", "%%%%"), nil)
-    end)
-  end,
-
-  ["find-replace:replace-regex"] = function()
-    replace("Regex", "", function(text, old, new)
-      local re = regex.compile(old)
-      return regex.gsub(re, text, new)
+    replace("Text", function(text, old, new)
+      if plain then
+        return text:gsub(old:gsub("%W", "%%%1"), new:gsub("%%", "%%%%"), nil)
+      end
+      return regex.gsub(regex.compile(old), text, new)
     end)
   end,
 
@@ -169,4 +137,54 @@ command.add("core.docview", {
       return res, n
     end)
   end,
+})
+
+local function valid_for_finding()
+  return core.active_view:is(DocView) or core.active_view:is(CommandView)
+end
+
+command.add(valid_for_finding, {
+  ["find-replace:repeat-find"] = function()
+    if not last_fn then
+      core.error("No find to continue from")
+    else
+      local line, col = doc():get_selection()
+      local line1, col1, line2, col2 = last_fn(doc(), line, col, last_text, case_insensitive, plain)
+      if line1 then
+        if last_view.doc ~= doc() then
+          last_finds = {}
+        end
+        if #last_finds >= max_last_finds then
+          table.remove(last_finds, 1)
+        end
+        table.insert(last_finds, { line, col })
+        doc():set_selection(line2, col2, line1, col1)
+        last_view:scroll_to_line(line2, true)
+      end
+    end
+  end,
+
+  ["find-replace:previous-find"] = function()
+    local sel = table.remove(last_finds)
+    if not sel or doc() ~= last_view.doc then
+      core.error("No previous finds")
+      return
+    end
+    doc():set_selection(table.unpack(sel))
+    last_view:scroll_to_line(sel[3], true)
+  end,
+})
+
+command.add("core.commandview", {
+  ["find-replace:toggle-insensitivity"] = function()
+    case_insensitive = not case_insensitive
+    core.status_view:show_tooltip(get_find_tooltip())
+    update_preview(last_sel, last_fn, last_text)
+  end,
+
+  ["find-replace:toggle-plain"] = function()
+    plain = not plain
+    core.status_view:show_tooltip(get_find_tooltip())
+    update_preview(last_sel, last_fn, last_text)
+  end
 })

--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -148,8 +148,8 @@ command.add(valid_for_finding, {
     if not last_fn then
       core.error("No find to continue from")
     else
-      local line, col = doc():get_selection()
-      local line1, col1, line2, col2 = last_fn(doc(), line, col, last_text, case_insensitive, plain)
+      local sl1, sc1, sl2, sc2 = doc():get_selection(true)
+      local line1, col1, line2, col2 = last_fn(doc(), sl1, sc2, last_text, case_insensitive, plain)
       if line1 then
         if last_view.doc ~= doc() then
           last_finds = {}
@@ -157,7 +157,7 @@ command.add(valid_for_finding, {
         if #last_finds >= max_last_finds then
           table.remove(last_finds, 1)
         end
-        table.insert(last_finds, { line, col })
+        table.insert(last_finds, { sl1, sc1, sl2, sc2 })
         doc():set_selection(line2, col2, line1, col1)
         last_view:scroll_to_line(line2, true)
       end

--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -112,11 +112,12 @@ command.add("core.docview", {
   end,
 
   ["find-replace:replace"] = function()
-    replace("Text", function(text, old, new)
+    replace("Text", doc():get_text(doc():get_selection(true)), function(text, old, new)
       if plain then
         return text:gsub(old:gsub("%W", "%%%1"), new:gsub("%%", "%%%%"), nil)
       end
-      return regex.gsub(regex.compile(old), text, new)
+      local result, matches = regex.gsub(regex.compile(old), text, new)
+      return result, #matches
     end)
   end,
 

--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -61,6 +61,26 @@ function common.color(str)
 end
 
 
+function common.splice(t, at, remove, insert)
+  insert = insert or {}
+  local offset = #insert - remove
+  local old_len = #t
+  if offset < 0 then
+    for i = at - offset, old_len - offset do
+      t[i + offset] = t[i]
+    end
+  elseif offset > 0 then
+    for i = old_len, at, -1 do
+      t[i + offset] = t[i]
+    end
+  end
+  for i, item in ipairs(insert) do
+    t[at + i - 1] = item
+  end
+end
+
+
+
 local function compare_score(a, b)
   return a.score > b.score
 end

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -24,6 +24,7 @@ config.animation_rate = 1.0
 config.blink_period = 0.8
 config.draw_whitespace = false
 config.borderless = false
+config.tab_close_button = true
 
 -- Disable plugin loading setting to false the config entry
 -- of the same name.

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -1,5 +1,6 @@
 local Object = require "core.object"
 local Highlighter = require "core.doc.highlighter"
+local core = require "core"
 local syntax = require "core.syntax"
 local config = require "core.config"
 local common = require "core.common"
@@ -181,10 +182,10 @@ local function selection_iterator(invariant, idx)
   end
 end
 
--- If idx_reverse is true, it'll reverse iterate. If nil, or false, regular iterate. 
+-- If idx_reverse is true, it'll reverse iterate. If nil, or false, regular iterate.
 -- If a number, runs for exactly that iteration.
 function Doc:get_selections(sort_intra, idx_reverse)
-  return selection_iterator, { self.selections, sort_intra, idx_reverse }, 
+  return selection_iterator, { self.selections, sort_intra, idx_reverse },
     idx_reverse == true and ((#self.selections / 4) + 1) or ((idx_reverse or -1)+1)
 end
 -- End of cursor seciton.
@@ -491,6 +492,11 @@ end
 
 -- For plugins to add custom actions of document change
 function Doc:on_text_change(type)
+end
+
+-- For plugins to get notified when a document is closed
+function Doc:on_close()
+  core.log_quiet("Closed doc \"%s\"", self:get_name())
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -972,7 +972,7 @@ function core.step()
     local doc = core.docs[i]
     if #core.get_views_referencing_doc(doc) == 0 then
       table.remove(core.docs, i)
-      core.log_quiet("Closed doc \"%s\"", doc:get_name())
+      doc:on_close()
     end
   end
 

--- a/data/core/keymap-macos.lua
+++ b/data/core/keymap-macos.lua
@@ -101,6 +101,8 @@ local function keymap_macos(keymap)
     ["cmd+shift+end"] = "doc:select-to-end-of-doc",
     ["shift+pageup"] = "doc:select-to-previous-page",
     ["shift+pagedown"] = "doc:select-to-next-page",
+    ["cmd+shift+up"] = "doc:create-cursor-previous-line",
+    ["cmd+shift+down"] = "doc:create-cursor-next-line"
   }
 end
 

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -137,6 +137,8 @@ keymap.add_direct {
   ["ctrl+r"] = "find-replace:replace",
   ["f3"] = "find-replace:repeat-find",
   ["shift+f3"] = "find-replace:previous-find",
+  ["ctrl+i"] = "find-replace:toggle-insensitivity",
+  ["ctrl+shift+i"] = "find-replace:toggle-plain",
   ["ctrl+g"] = "doc:go-to-line",
   ["ctrl+s"] = "doc:save",
   ["ctrl+shift+s"] = "doc:save-as",

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -202,6 +202,8 @@ keymap.add_direct {
   ["ctrl+shift+end"] = "doc:select-to-end-of-doc",
   ["shift+pageup"] = "doc:select-to-previous-page",
   ["shift+pagedown"] = "doc:select-to-next-page",
+  ["ctrl+shift+up"] = "doc:create-cursor-previous-line",
+  ["ctrl+shift+down"] = "doc:create-cursor-next-line"
 }
 
 return keymap

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -295,7 +295,7 @@ function Node:tab_hovered_update(px, py)
   if tab_index then
     local x, y, w, h = self:get_tab_rect(tab_index)
     local cx, cw = close_button_location(x, w)
-    if px >= cx and px < cx + cw and py >= y and py < y + h then
+    if px >= cx and px < cx + cw and py >= y and py < y + h and config.tab_close_button then
       self.hovered_close = tab_index
     end
   else
@@ -529,7 +529,7 @@ function Node:draw_tabs()
       renderer.draw_rect(x - ds, y, ds, h, style.divider)
     end
     local cx, cw, cspace = close_button_location(x, w)
-    local show_close_button = (view == self.active_view or i == self.hovered_tab)
+    local show_close_button = ((view == self.active_view or i == self.hovered_tab) and config.tab_close_button)
     if show_close_button then
       local close_style = self.hovered_close == i and style.text or style.dim
       common.draw_text(style.icon_font, close_style, "C", nil, cx, y, 0, h)

--- a/data/plugins/scale.lua
+++ b/data/plugins/scale.lua
@@ -32,6 +32,9 @@ local function set_scale(scale)
   local s = scale / current_scale
   current_scale = scale
 
+  -- we set scale_level in case this was called by user
+  scale_level = (scale - default_scale) / scale_steps
+
   if config.scale_mode == "ui" then
     SCALE = scale
 
@@ -58,7 +61,7 @@ local function set_scale(scale)
   core.redraw = true
 end
 
-local function get_scale() 
+local function get_scale()
   return current_scale
 end
 
@@ -101,9 +104,9 @@ keymap.add {
   ["ctrl+="] = "scale:increase",
 }
 
-return { 
-  ["set"] = set_scale, 
-  ["get"] = get_scale, 
+return {
+  ["set"] = set_scale,
+  ["get"] = get_scale,
   ["increase"] = inc_scale,
   ["decrease"] = dec_scale,
   ["reset"] = res_scale

--- a/meson.build
+++ b/meson.build
@@ -10,13 +10,23 @@ libdl = cc.find_library('dl', required : false)
 libx11 = dependency('x11', required : false)
 lua_dep = dependency('lua5.2', required : false)
 pcre2_dep = dependency('libpcre2-8')
+sdl_dep = dependency('sdl2', method: 'config-tool')
 
 if not lua_dep.found()
     lua_subproject = subproject('lua', default_options: ['shared=false', 'use_readline=false', 'app=false'])
     lua_dep = lua_subproject.get_variable('lua_dep')
 endif
 
-sdl_dep = dependency('sdl2', method: 'config-tool')
+reproc_subproject = subproject('reproc', default_options: ['default_library=static', 'multithreaded=false', 'reproc-cpp=false', 'examples=false'])
+reproc_dep = reproc_subproject.get_variable('reproc_dep')
+
+lite_deps = [lua_dep, sdl_dep, reproc_dep, pcre2_dep, libm, libdl, libx11]
+
+if host_machine.system() == 'windows'
+    # Note that we need to explicitly add the windows socket DLL because
+    # the pkg-config file from reproc does not include it.
+    lite_deps += meson.get_compiler('cpp').find_library('ws2_32', required: true)
+endif
 
 lite_cargs = []
 if get_option('portable')
@@ -55,4 +65,3 @@ endif
 
 subdir('lib/font_renderer')
 subdir('src')
-

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -4,12 +4,14 @@
 int luaopen_system(lua_State *L);
 int luaopen_renderer(lua_State *L);
 int luaopen_regex(lua_State *L);
+int luaopen_process(lua_State *L);
 
 
 static const luaL_Reg libs[] = {
   { "system",    luaopen_system     },
   { "renderer",  luaopen_renderer   },
   { "regex",     luaopen_regex   },
+  { "process",   luaopen_process    },
   { NULL, NULL }
 };
 

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -1,0 +1,430 @@
+/**
+ * Basic binding of reproc into Lua.
+ * @copyright Jefferson Gonzalez
+ * @license MIT
+ */
+
+#include <string.h>
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+#include <reproc/reproc.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+typedef struct {
+    reproc_t * process;
+    lua_State* L;
+
+} process_t;
+
+static int process_new(lua_State* L)
+{
+    process_t* self = (process_t*) lua_newuserdata(
+        L, sizeof(process_t)
+    );
+
+    memset(self, 0, sizeof(process_t));
+
+    self->process = NULL;
+    self->L = L;
+
+    luaL_getmetatable(L, "PROCESS");
+    lua_setmetatable(L, -2);
+
+    return 1;
+}
+
+static int process_strerror(lua_State* L)
+{
+    int error_code = luaL_checknumber(L, 1);
+
+    if(error_code){
+        lua_pushstring(
+            L,
+            reproc_strerror(error_code)
+        );
+    } else {
+        lua_pushnil(L);
+    }
+
+    return 1;
+}
+
+static int process_gc(lua_State* L)
+{
+    process_t* self = (process_t*) luaL_checkudata(L, 1, "PROCESS");
+
+    if(self->process){
+        reproc_kill(self->process);
+        reproc_destroy(self->process);
+        self->process = NULL;
+    }
+
+    return 0;
+}
+
+static int process_start(lua_State* L)
+{
+    process_t* self = (process_t*) lua_touserdata(L, 1);
+
+    luaL_checktype(L, 2, LUA_TTABLE);
+
+    char* path = NULL;
+    size_t path_len = 0;
+
+    if(lua_type(L, 3) == LUA_TSTRING){
+        path = (char*) lua_tolstring(L, 3, &path_len);
+    }
+
+    size_t deadline = 0;
+
+    if(lua_type(L, 4) == LUA_TNUMBER){
+        deadline = lua_tonumber(L, 4);
+    }
+
+    size_t table_len = luaL_len(L, 2);
+    char* command[table_len+1];
+    command[table_len] = NULL;
+
+    int i;
+    for(i=1; i<=table_len; i++){
+        lua_pushnumber(L, i);
+        lua_gettable(L, 2);
+
+        command[i-1] = (char*) lua_tostring(L, -1);
+
+        lua_remove(L, -1);
+    }
+
+    if(self->process){
+        reproc_kill(self->process);
+        reproc_destroy(self->process);
+    }
+
+    self->process = reproc_new();
+
+    int out = reproc_start(
+        self->process,
+        (const char* const*) command,
+        (reproc_options){
+            .working_directory = path,
+            .deadline = deadline,
+            .nonblocking=true,
+            .redirect.err.type=REPROC_REDIRECT_PIPE
+        }
+    );
+
+    if(out > 0) {
+        lua_pushboolean(L, 1);
+    }
+    else {
+        reproc_destroy(self->process);
+        self->process = NULL;
+        lua_pushnumber(L, out);
+    }
+
+    return 1;
+}
+
+static int process_pid(lua_State* L)
+{
+    process_t* self = (process_t*) lua_touserdata(L, 1);
+
+    if(self->process){
+        lua_pushnumber(L, reproc_pid(self->process));
+    } else {
+        lua_pushnumber(L, 0);
+    }
+
+    return 1;
+}
+
+static int process_read(lua_State* L)
+{
+    process_t* self = (process_t*) lua_touserdata(L, 1);
+
+    if(self->process){
+        int read_size = 4096;
+        if (lua_type(L, 2) == LUA_TNUMBER){
+            read_size = (int) lua_tonumber(L, 2);
+        }
+
+        int tries = 1;
+        if (lua_type(L, 3) == LUA_TNUMBER){
+            tries = (int) lua_tonumber(L, 3);
+        }
+
+        int out = 0;
+        uint8_t buffer[read_size];
+
+        int runs;
+        for (runs=0; runs<tries; runs++){
+            out = reproc_read(
+                self->process,
+                REPROC_STREAM_OUT,
+                buffer,
+                read_size
+            );
+
+            if (out >= 0)
+                break;
+        }
+
+        // if request for tries was set and nothing
+        // read kill the process
+        if(tries > 1 && out < 0)
+            out = REPROC_EPIPE;
+
+        if(out == REPROC_EPIPE){
+            reproc_kill(self->process);
+            reproc_destroy(self->process);
+            self->process = NULL;
+
+            lua_pushnil(L);
+        } else if(out > 0) {
+            lua_pushlstring(L, (const char*) buffer, out);
+        } else {
+            lua_pushnil(L);
+        }
+    } else {
+        lua_pushnil(L);
+    }
+
+    return 1;
+}
+
+static int process_read_errors(lua_State* L)
+{
+    process_t* self = (process_t*) lua_touserdata(L, 1);
+
+    if(self->process){
+        int read_size = 4096;
+        if (lua_type(L, 2) == LUA_TNUMBER){
+            read_size = (int) lua_tonumber(L, 2);
+        }
+
+        int tries = 1;
+        if (lua_type(L, 3) == LUA_TNUMBER){
+            tries = (int) lua_tonumber(L, 3);
+        }
+
+        int out = 0;
+        uint8_t buffer[read_size];
+
+        int runs;
+        for (runs=0; runs<tries; runs++){
+            out = reproc_read(
+                self->process,
+                REPROC_STREAM_ERR,
+                buffer,
+                read_size
+            );
+
+            if (out >= 0)
+                break;
+        }
+
+        // if request for tries was set and nothing
+        // read kill the process
+        if(tries > 1 && out < 0)
+            out = REPROC_EPIPE;
+
+        if(out == REPROC_EPIPE){
+            reproc_kill(self->process);
+            reproc_destroy(self->process);
+            self->process = NULL;
+
+            lua_pushnil(L);
+        } else if(out > 0) {
+            lua_pushlstring(L, (const char*) buffer, out);
+        } else {
+            lua_pushnil(L);
+        }
+    } else {
+        lua_pushnil(L);
+    }
+
+    return 1;
+}
+
+static int process_write(lua_State* L)
+{
+    process_t* self = (process_t*) lua_touserdata(L, 1);
+
+    if(self->process){
+        size_t data_size = 0;
+        const char* data = luaL_checklstring(L, 2, &data_size);
+
+        int out = 0;
+
+        out = reproc_write(
+            self->process,
+            (uint8_t*) data,
+            data_size
+        );
+
+        if(out == REPROC_EPIPE){
+            reproc_kill(self->process);
+            reproc_destroy(self->process);
+            self->process = NULL;
+        }
+
+        lua_pushnumber(L, out);
+    } else {
+        lua_pushnumber(L, REPROC_EPIPE);
+    }
+
+    return 1;
+}
+
+static int process_close_stream(lua_State* L)
+{
+    process_t* self = (process_t*) lua_touserdata(L, 1);
+
+    if(self->process){
+        size_t stream = luaL_checknumber(L, 2);
+
+        int out = reproc_close(self->process, stream);
+
+        lua_pushnumber(L, out);
+    } else {
+        lua_pushnumber(L, REPROC_EINVAL);
+    }
+
+    return 1;
+}
+
+static int process_wait(lua_State* L)
+{
+    process_t* self = (process_t*) lua_touserdata(L, 1);
+
+    if(self->process){
+        size_t timeout = luaL_checknumber(L, 2);
+
+        int out = reproc_wait(self->process, timeout);
+
+        if(out >= 0){
+            reproc_destroy(self->process);
+            self->process = NULL;
+        }
+
+        lua_pushnumber(L, out);
+    } else {
+        lua_pushnumber(L, REPROC_EINVAL);
+    }
+
+    return 1;
+}
+
+static int process_terminate(lua_State* L)
+{
+    process_t* self = (process_t*) lua_touserdata(L, 1);
+
+    if(self->process){
+        int out = reproc_terminate(self->process);
+
+        if(out < 0){
+            lua_pushnumber(L, out);
+        } else {
+            reproc_destroy(self->process);
+            self->process = NULL;
+            lua_pushboolean(L, 1);
+        }
+    } else {
+        lua_pushnumber(L, REPROC_EINVAL);
+    }
+
+    return 1;
+}
+
+static int process_kill(lua_State* L)
+{
+    process_t* self = (process_t*) lua_touserdata(L, 1);
+
+    if(self->process){
+        int out = reproc_kill(self->process);
+
+        if(out < 0){
+            lua_pushnumber(L, out);
+        } else {
+            reproc_destroy(self->process);
+            self->process = NULL;
+            lua_pushboolean(L, 1);
+        }
+    } else {
+        lua_pushnumber(L, REPROC_EINVAL);
+    }
+
+    return 1;
+}
+
+static int process_running(lua_State* L)
+{
+    process_t* self = (process_t*) lua_touserdata(L, 1);
+
+    if(self->process){
+        lua_pushboolean(L, 1);
+    } else {
+        lua_pushboolean(L, 0);
+    }
+
+    return 1;
+}
+
+static const struct luaL_Reg process_methods[] = {
+    { "__gc", process_gc},
+    {"start", process_start},
+    {"pid", process_pid},
+    {"read", process_read},
+    {"read_errors", process_read_errors},
+    {"write", process_write},
+    {"close_stream", process_close_stream},
+    {"wait", process_wait},
+    {"terminate", process_terminate},
+    {"kill", process_kill},
+    {"running", process_running},
+    {NULL, NULL}
+};
+
+static const struct luaL_Reg process[] = {
+    {"new", process_new},
+    {"strerror", process_strerror},
+    {"ERROR_PIPE", NULL},
+    {"ERROR_WOULDBLOCK", NULL},
+    {"ERROR_TIMEDOUT", NULL},
+    {"STREAM_STDIN", NULL},
+    {"STREAM_STDOUT", NULL},
+    {"STREAM_STDERR", NULL},
+    {NULL, NULL}
+};
+
+int luaopen_process(lua_State *L)
+{
+    luaL_newmetatable(L, "PROCESS");
+    luaL_setfuncs(L, process_methods, 0);
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -2, "__index");
+
+    luaL_newlib(L, process);
+
+    lua_pushnumber(L, REPROC_EPIPE);
+    lua_setfield(L, -2, "ERROR_PIPE");
+
+    lua_pushnumber(L, REPROC_EWOULDBLOCK);
+    lua_setfield(L, -2, "ERROR_WOULDBLOCK");
+
+    lua_pushnumber(L, REPROC_ETIMEDOUT);
+    lua_setfield(L, -2, "ERROR_TIMEDOUT");
+
+    lua_pushnumber(L, REPROC_STREAM_IN);
+    lua_setfield(L, -2, "STREAM_STDIN");
+
+    lua_pushnumber(L, REPROC_STREAM_OUT);
+    lua_setfield(L, -2, "STREAM_STDOUT");
+
+    lua_pushnumber(L, REPROC_STREAM_ERR);
+    lua_setfield(L, -2, "STREAM_STDERR");
+
+    return 1;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
   #include <X11/Xlib.h>
   #include <X11/Xatom.h>
   #include <X11/Xresource.h>
+  #include <signal.h>
 #elif __APPLE__
   #include <mach-o/dyld.h>
 #endif
@@ -112,6 +113,8 @@ int main(int argc, char **argv) {
   HINSTANCE lib = LoadLibrary("user32.dll");
   int (*SetProcessDPIAware)() = (void*) GetProcAddress(lib, "SetProcessDPIAware");
   SetProcessDPIAware();
+#else
+  signal(SIGPIPE, SIG_IGN);
 #endif
 
   SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS);

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,6 +5,7 @@ lite_sources = [
     'api/renderer_font.c',
     'api/regex.c',
     'api/system.c',
+    'api/process.c',
     'renderer.c',
     'renwindow.c',
     'fontdesc.c',
@@ -19,11 +20,10 @@ endif
 executable('lite',
     lite_sources + lite_rc,
     include_directories: [lite_include, font_renderer_include],
-    dependencies: [lua_dep, sdl_dep, pcre2_dep, libm, libdl, libx11],
+    dependencies: lite_deps,
     c_args: lite_cargs,
     link_with: libfontrenderer,
     link_args: lite_link_args,
     install: true,
     gui_app: true,
 )
-

--- a/subprojects/reproc.wrap
+++ b/subprojects/reproc.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory = reproc
+url = https://github.com/franko/reproc
+revision = v14.2.2-meson-1


### PR DESCRIPTION
Implements changes discussed in #104 . Should close #104 .

- Find now has a tooltip on the status bar that reports the find-next keybind, improving discoverability. Also reports whether the search is a regex, or case insensitive.
- ctrl+i toggles case insensitivity on the find. This persists through different finds, and can be customised on startup through config.find_case_insensitive. By default, it is case sensitive.
- ctrl+shift+i toggles regex matching. By default, this is on, and can be customised with config.find_plain.
- F3 now works during a find; no need to hit enter anymore.

Nothing about this is intended to be final, so please let me know what you think.