### PR TITLE
Add a C API copy method for font_desc objects

### DIFF
--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -22,9 +22,9 @@ style.tab_width = common.round(170 * SCALE)
 -- On High DPI monitor or non RGB monitor you may consider using antialiasing grayscale instead.
 -- The antialiasing grayscale with full hinting is interesting for crisp font rendering.
 style.font = renderer.font.load(DATADIR .. "/fonts/FiraSans-Regular.ttf", 13 * SCALE)
-style.big_font = renderer.font.load(DATADIR .. "/fonts/FiraSans-Regular.ttf", 40 * SCALE)
+style.big_font = style.font:copy(40 * SCALE)
 style.icon_font = renderer.font.load(DATADIR .. "/fonts/icons.ttf", 14 * SCALE, {antialiasing="grayscale", hinting="full"})
-style.icon_big_font = renderer.font.load(DATADIR .. "/fonts/icons.ttf", 20 * SCALE, {antialiasing="grayscale", hinting="full"})
+style.icon_big_font = style.icon_font:copy(20 * SCALE)
 style.code_font = renderer.font.load(DATADIR .. "/fonts/JetBrainsMono-Regular.ttf", 13 * SCALE)
 
 style.background = { common.color "#2e2e32" }

--- a/src/api/renderer_font.c
+++ b/src/api/renderer_font.c
@@ -55,6 +55,21 @@ static int f_load(lua_State *L) {
 }
 
 
+static int f_copy(lua_State *L) {
+  FontDesc *self = luaL_checkudata(L, 1, API_TYPE_FONT);
+  float size;
+  if (lua_gettop(L) >= 2) {
+    size = luaL_checknumber(L, 2);
+  } else {
+    size = self->size;
+  }
+  FontDesc *new_font_desc = lua_newuserdata(L, font_desc_alloc_size(self->filename));
+  font_desc_init(new_font_desc, self->filename, size, self->options);
+  luaL_setmetatable(L, API_TYPE_FONT);
+  return 1;
+}
+
+
 static int f_set_tab_size(lua_State *L) {
   FontDesc *self = luaL_checkudata(L, 1, API_TYPE_FONT);
   int n = luaL_checknumber(L, 2);
@@ -123,6 +138,7 @@ static int f_set_size(lua_State *L) {
 static const luaL_Reg lib[] = {
   { "__gc",               f_gc                 },
   { "load",               f_load               },
+  { "copy",               f_copy               },
   { "set_tab_size",       f_set_tab_size      },
   { "get_width",          f_get_width          },
   { "get_width_subpixel", f_get_width_subpixel },


### PR DESCRIPTION
Add a renderer.font's method "copy" to clone the font object by specifying an optional new size. In the size is not given the size of the original object is used.

Should fulfill the request from issue #288.