### PR TITLE
Set default documents line endings behavior

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+# See https://help.github.com/en/articles/dealing-with-line-endings
+* text=auto
+
 winlib/*  linguist-vendored
 src/lib/* linguist-vendored
 icon.inl  linguist-vendored


### PR DESCRIPTION
I've found some line endings problem today while I was using git on Windows, I usually use this setting to avoid line endings misbehavior, so that people is not forced to use a specified one and git will care to convert them between platforms and doesn't hurts anyone, including who (like me :þ ) doesn't set it in git config.