### PR TITLE
Command line switch parsing.

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -423,7 +423,7 @@ local function reload_on_user_module_save()
 end
 
 
-function core.init()
+function core.init(options)
   command = require "core.command"
   keymap = require "core.keymap"
   RootView = require "core.rootview"

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -22,9 +22,9 @@ package.path = USERDIR .. '/?/init.lua;' .. package.path
 local function arg_error(error) io.stderr:write(ARGV[1] .. ": " .. error .. "\n") os.exit(-1) end
 -- returns a lua table with both numeric and non-numeric keys like getoptlong
 local function parse_args_to_dict_and_array(argv, t)
-  local options, arg = {}
+  local options, arg = { argv[1] }
   local function parse_value(value)
-    if t[arg] == "i" and not tonumber(value) then
+    if t[arg] == "i" and not tonumber(value) or (#t[arg] and #value == 0) then
      arg_error("error parsing argument " .. value)
    end
     options[arg], arg = t[arg] == "i" and tonumber(value) or value, nil

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -1,4 +1,4 @@
--- this file is used by lite-xl to setup the Lua environment when starting
+-- this file is used by lite-xl to setup the Lua environment when starting, parse command line options, and return the desired core, in a normal flow
 VERSION = "1.16.11"
 MOD_VERSION = "1"
 
@@ -18,4 +18,40 @@ package.path = DATADIR .. '/?.lua;' .. package.path
 package.path = DATADIR .. '/?/init.lua;' .. package.path
 package.path = USERDIR .. '/?.lua;' .. package.path
 package.path = USERDIR .. '/?/init.lua;' .. package.path
+
+local function arg_error(error) io.stderr:write(ARGV[1] .. ": " .. error .. "\n") os.exit(-1) end
+-- returns a lua table with both numeric and non-numeric keys like getoptlong
+local function parse_args_to_dict_and_array(argv, t)
+  local options, arg = {}
+  local function parse_value(value)
+    if t[arg] == "i" and not tonumber(value) then
+     arg_error("error parsing argument " .. value)
+   end
+    options[arg], arg = t[arg] == "i" and tonumber(value) or value, nil
+  end
+  for i=2, #argv do
+    if argv[i]:sub(1,1) == "-" then
+      local equal, value = argv[i]:find("="), ""
+      arg = argv[i]:sub(argv[i]:find("[^-]"), equal and equal - 1 or #argv[i])
+      if t[arg] == nil then arg_error("unknown argument " .. argv[i]) end
+      if #t[arg] == 0 or equal then
+        parse_value(argv[i]:sub((equal or #argv[i])+1))
+      end
+    elseif arg then
+      parse_value(argv[i])
+    else
+      table.insert(options, argv[i])
+    end
+  end
+  if arg then arg_error("expected argument for " .. arg) end
+  return options
+end
+
+ARGS = parse_args_to_dict_and_array(ARGV, {
+  ["core"] = "s",
+  ["version"] = "", ["v"] = ""
+});
+if ARGS["version"] or ARGS["v"] then print(VERSION) os.exit(0) end
+
+return require(ARGS["core"] or 'core')
 

--- a/src/main.c
+++ b/src/main.c
@@ -150,7 +150,7 @@ init_lua:
     lua_pushstring(L, argv[i]);
     lua_rawseti(L, -2, i + 1);
   }
-  lua_setglobal(L, "ARGS");
+  lua_setglobal(L, "ARGV");
 
   lua_pushstring(L, SDL_GetPlatform());
   lua_setglobal(L, "PLATFORM");
@@ -174,10 +174,11 @@ init_lua:
     "  HOME = os.getenv('" LITE_OS_HOME "')\n"
     "  local exedir = EXEFILE:match(\"^(.*)" LITE_PATHSEP_PATTERN LITE_NONPATHSEP_PATTERN "$\")\n"
     "  local prefix = exedir:match(\"^(.*)" LITE_PATHSEP_PATTERN "bin$\")\n"
-    "  dofile((MACOS_RESOURCES or (prefix and prefix .. '/share/lite-xl' or exedir .. '/data')) .. '/core/start.lua')\n"
-    "  core = require('core')\n"
-    "  core.init()\n"
-    "  core.run()\n"
+    "  core = dofile((MACOS_RESOURCES or (prefix and prefix .. '/share/lite-xl' or exedir .. '/data')) .. '/core/start.lua')\n"
+    "  if core then\n"
+    "    core.init()\n"
+    "    core.run()\n"
+    "  end\n"
     "end, function(err)\n"
     "  local error_dir\n"
     "  io.stdout:write('Error: '..tostring(err)..'\\n')\n"


### PR DESCRIPTION
Added in a routine that allows you to specify an alternate `core` via the command line. Also, as an example, put in a `--version` option.

Should close #317 .

This is meant to be up for discussion, and there's not necessarily any particular timeline for this getting accepted. I think this kind of thing would be quite useful for debugging, and just general CLI control of the editor.