### PR TITLE
fix workspace folders on different drives in Windows

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -285,9 +285,9 @@ end
 
 
 function common.relative_path(ref_dir, dir)
-  if #ref_dir>2 and ref_dir:sub(2,2)==':'
-    and #dir>2 and dir:sub(2,2)==':'
-      and ref_dir:sub(1,1)~=dir:sub(1,1) then
+  local drive_pattern = "^(%a):\\"
+  local drive, ref_drive = dir:match(drive_pattern), ref_dir:match(drive_pattern)
+  if drive and ref_drive and drive ~= ref_drive then
     -- Windows, different drives, system.absolute_path fails for C:\..\D:\
     return dir
   end    

--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -285,6 +285,12 @@ end
 
 
 function common.relative_path(ref_dir, dir)
+  if #ref_dir>2 and ref_dir:sub(2,2)==':'
+    and #dir>2 and dir:sub(2,2)==':'
+      and ref_dir:sub(1,1)~=dir:sub(1,1) then
+    -- Windows, different drives, system.absolute_path fails for C:\..\D:\
+    return dir
+  end    
   local ref_ls = split_on_slash(ref_dir)
   local dir_ls = split_on_slash(dir)
   local i = 1


### PR DESCRIPTION
The issue being:
when a new directory from another drive is added to the workspace, it cannot be opened after restart of lite-xl
The directories are saved to workspace file as `common.relative_path`

`system.absolute_path(common.relative_path(A,B)) ~= B` when A and B are on different drives on Windows,
`common.relative_path("C:\","D:\")` is `"..\D:\"` which is then improperly parsed by `system.absolute_path` . 

I propose the following fix, which bluntly checks for different drives in `X:\` notation and if drives are indeed different, `common.relative_path` returns absolute path to destination