### PR TITLE
Fix inactive divider intercepting mouse clicks

### DIFF
--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -240,12 +240,15 @@ end
 
 function Node:get_divider_overlapping_point(px, py)
   if self.type ~= "leaf" then
-    local p = 6
-    local x, y, w, h = self:get_divider_rect()
-    x, y = x - p, y - p
-    w, h = w + p * 2, h + p * 2
-    if px > x and py > y and px < x + w and py < y + h then
-      return self
+    local axis = self.type == "hsplit" and "x" or "y"
+    if self.a:is_resizable(axis) and self.b:is_resizable(axis) then
+      local p = 6
+      local x, y, w, h = self:get_divider_rect()
+      x, y = x - p, y - p
+      w, h = w + p * 2, h + p * 2
+      if px > x and py > y and px < x + w and py < y + h then
+        return self
+      end
     end
     return self.a:get_divider_overlapping_point(px, py)
         or self.b:get_divider_overlapping_point(px, py)
@@ -823,10 +826,7 @@ function RootView:on_mouse_moved(x, y, dx, dy)
   if node and node:get_scroll_button_index(x, y) then
     core.request_cursor("arrow")
   elseif div then
-    local axis = (div.type == "hsplit" and "x" or "y")
-    if div.a:is_resizable(axis) and div.b:is_resizable(axis) then
-      core.request_cursor(div.type == "hsplit" and "sizeh" or "sizev")
-    end
+    core.request_cursor(div.type == "hsplit" and "sizeh" or "sizev")
   elseif tab_index then
     core.request_cursor("arrow")
   elseif node then


### PR DESCRIPTION
In the function Node:get_divider_overlapping_point() we check if we
hit a divider (separator between two nodes). If yes the event is
intercepted and used to set the cursor and drag the separator if
appropriate.

In reality, on mouse move events, when one of the node is a split
and one of its child is not resizable we don't set the cursor to
and we don't intercept the event. However on a mouse pressed event
the event was intercepted regardless of the fact that the child
nodes are resizable or not. This latter behavior was unwanted as it
prevents mouse clicks to be processed because of a divided that is
inactive.

In addition it prevented processing of mouse clicks when the child
node was invisible leading to issue #363. For this latter the issue
was the invisible NagView in the upper part of the window.

To fix the problem we provide a divider with
Node:get_divider_overlapping_point() only if its child node are
resizable. In this way the mouse clicks or movements are intercepted
only if the divider is actually active.