### PR TITLE
Bundle DLLs in MSYS2 package script

### DIFF
--- a/scripts/msys2-package.sh
+++ b/scripts/msys2-package.sh
@@ -53,4 +53,10 @@ fi
 
 DESTDIR="$(pwd)/${DEST_DIR}" meson install --skip-subprojects -C ${BUILD_DIR}
 
+cp $MINGW_PREFIX/bin/libfreetype-* \
+   $MINGW_PREFIX/bin/libpcre2-8-* \
+   $MINGW_PREFIX/bin/libwinpthread-* \
+   $MINGW_PREFIX/bin/SDL2* \
+   ${DEST_DIR}
+
 zip -9rv ${DEST_DIR}.zip ${DEST_DIR}/*


### PR DESCRIPTION
Unlike Linux and macOS (with brew), Windows have no package manager and not anyone uses MSYS2,
so bundle dependencies also in the built non-release package.

~~Takase made me notice that in some machines with WSL2 libs in PATH the package works, in others not,
so for those without MSYS2 or WSL2 it would be difficult to provide them easily.~~

Let me know if other libraries needs to be bundled, so for now I make this as draft PR until confirmation.