### PR TITLE
Simplify DPI code

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,6 @@ endif
 #===============================================================================
 libm = cc.find_library('m', required : false)
 libdl = cc.find_library('dl', required : false)
-libx11 = dependency('x11', required : false)
 lua_dep = dependency('lua5.2', required : false)
 pcre2_dep = dependency('libpcre2-8')
 sdl_dep = dependency('sdl2', method: 'config-tool')
@@ -73,7 +72,7 @@ reproc_subproject = subproject('reproc',
 )
 reproc_dep = reproc_subproject.get_variable('reproc_dep')
 
-lite_deps = [lua_dep, sdl_dep, reproc_dep, pcre2_dep, libm, libdl, libx11]
+lite_deps = [lua_dep, sdl_dep, reproc_dep, pcre2_dep, libm, libdl]
 
 if host_machine.system() == 'windows'
     # Note that we need to explicitly add the windows socket DLL because

--- a/src/main.c
+++ b/src/main.c
@@ -9,10 +9,6 @@
   #include <windows.h>
 #elif __linux__
   #include <unistd.h>
-  #include <SDL_syswm.h>
-  #include <X11/Xlib.h>
-  #include <X11/Xatom.h>
-  #include <X11/Xresource.h>
   #include <signal.h>
 #elif __APPLE__
   #include <mach-o/dyld.h>
@@ -22,35 +18,9 @@
 SDL_Window *window;
 
 static double get_scale(void) {
-#ifdef _WIN32
-  float dpi;
+  float dpi = 96.0;
   SDL_GetDisplayDPI(0, NULL, &dpi, NULL);
   return dpi / 96.0;
-#elif __linux__
-  SDL_SysWMinfo info;
-  XrmDatabase db;
-  XrmValue value;
-  char *type = NULL;
-
-  SDL_VERSION(&info.version);
-  if (!SDL_GetWindowWMInfo(window, &info)
-      || info.subsystem != SDL_SYSWM_X11)
-    return 1.0;
-
-  char *resource = XResourceManagerString(info.info.x11.display);
-  if (resource == NULL)
-    return 1.0;
-
-  XrmInitialize();
-  db = XrmGetStringDatabase(resource);
-  if (XrmGetResource(db, "Xft.dpi", "String", &type, &value) == False
-      || value.addr == NULL)
-    return 1.0;
-
-  return atof(value.addr) / 96.0;
-#else
-  return 1.0;
-#endif
 }
 
 


### PR DESCRIPTION
In [this commit](https://github.com/libsdl-org/SDL/commit/c289bad9007cb672c994f726d967f6e5682f200d), SDL2 reads `Xft.dpi` . 

There is no need to link to X11 anymore. This would be beneficial to Wayland users.