### PR TITLE
AppVeyor CI macOS universal binary build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,48 @@
+version: build-{build}
+configuration: Release
+#skip_non_tags: true
+
+environment:
+  matrix:
+  - job_name: macOS
+    appveyor_build_worker_image: macos
+    INSTALL_NAME: lite-xl-$(APPVEYOR_REPO_TAG_NAME)-macos
+
+for:
+- matrix:
+    only:
+    - job_name: macOS
+  init: |
+    system_profiler SPSoftwareDataType
+    bash --version
+    gcc -v
+    xcodebuild -version
+  install: |
+    brew install bash meson
+    cd ~; npm install appdmg; cd -
+    ~/node_modules/appdmg/bin/appdmg.js --version
+  build_script: |
+    pushd ${APPVEYOR_BUILD_FOLDER}
+    bash --version
+    bash scripts/build.sh --prefix "${APPVEYOR_BUILD_FOLDER}/Lite XL.app" --static --universal
+    popd
+  after_build: |
+    pushd ${APPVEYOR_BUILD_FOLDER}
+    meson install --skip-subprojects -C build
+    bash scripts/appdmg.sh ${INSTALL_NAME}
+    popd
+  test: off
+  artifacts:
+  - name: macOS DMG Image
+    path: "lite-xl-*.dmg"
+
+deploy:
+- provider: GitHub
+  auth_token:
+    secure: tLA00Q1sedyGxYAY9m8ZO//dMJ/HLQ5v8pFWSfUqKMcssQSa3zjQaoAWisKQsvYf
+  artifact: macOS DMG Image
+  draft: false
+  prerelease: false
+  force_update: true
+  on:
+    APPVEYOR_REPO_TAG: true

--- a/scripts/meson-macos-arm64.ini
+++ b/scripts/meson-macos-arm64.ini
@@ -1,0 +1,24 @@
+[host_machine]
+system = 'darwin'
+cpu_family = 'aarch64'
+cpu = 'arm64'
+endian = 'little'
+
+[binaries]
+ar = '/usr/bin/ar'
+as = '/usr/bin/as'
+c = '/usr/bin/clang'
+cpp = '/usr/bin/clang++'
+ld = '/usr/bin/ld'
+objc = '/usr/bin/clang'
+objcpp = '/usr/bin/clang++'
+ranlib = '/usr/bin/ranlib'
+strip = '/usr/bin/strip'
+cmake = '/usr/local/bin/cmake'
+pkgconfig = '/usr/local/bin/pkg-config'
+
+[built-in options]
+cpp_args = ['-arch', 'arm64']
+cpp_link_args = ['-arch', 'arm64']
+objcpp_args = ['-arch', 'arm64']
+objcpp_link_args = ['-arch', 'arm64']

--- a/scripts/meson-macos-x86_64.ini
+++ b/scripts/meson-macos-x86_64.ini
@@ -1,0 +1,24 @@
+[host_machine]
+system = 'darwin'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[binaries]
+ar = '/usr/bin/ar'
+as = '/usr/bin/as'
+c = '/usr/bin/clang'
+cpp = '/usr/bin/clang++'
+ld = '/usr/bin/ld'
+objc = '/usr/bin/clang'
+objcpp = '/usr/bin/clang++'
+ranlib = '/usr/bin/ranlib'
+strip = '/usr/bin/strip'
+cmake = '/usr/local/bin/cmake'
+pkgconfig = '/usr/local/bin/pkg-config'
+
+[built-in options]
+cpp_args = ['-arch', 'x86_64']
+cpp_link_args = ['-arch', 'x86_64']
+objcpp_args = ['-arch', 'x86_64']
+objcpp_link_args = ['-arch', 'x86_64']


### PR DESCRIPTION
WIP Draft:
- It's not clear to me how LHelper should be configured to produce both arm64 and x86_64 builds
- Adjust the cross files/CFLAGS to use `-arch` for both systems
- Setup a new [access token][1] with `repo` permissions, which should be [encrypted][2] to be used in the `.appveyor.yml` configuration, currently it's using a personal token in my own account for testing.
- Remove the commented line in `.appveyor.yml`

Replaces #316 and fixes #218.

[1]: https://github.com/settings/tokens
[2]: https://ci.appveyor.com/tools/encrypt
