### PR TITLE
Added missing resource files in build-packages.sh

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -130,12 +130,15 @@ lite_build_package_linux () {
   if [ "$portable" == "-portable" ]; then
     local bindir="$pdir"
     local datadir="$pdir/data"
+    local docdir="$pdir/doc"
   else
     local bindir="$pdir/bin"
     local datadir="$pdir/share/lite-xl"
+    local docdir="$pdir/share/doc/lite-xl"
   fi
   mkdir -p "$bindir"
   mkdir -p "$datadir"
+  mkdir -p "$docdir"
   for module_name in core plugins colors fonts; do
     copy_directory_from_repo --strip-components=1 "data/$module_name" "$datadir"
   done
@@ -145,10 +148,12 @@ lite_build_package_linux () {
     cp -r "$build/third/data/$module_name" "$datadir"
   done
   cp "$build/src/lite-xl" "$bindir"
+  cp "licenses/licenses.md" "$docdir"
   strip "$bindir/lite-xl"
   if [ -z "$portable" ]; then
-    mkdir -p "$pdir/share/applications" "$pdir/share/icons/hicolor/scalable/apps"
-    cp "resources/linux/lite-xl.desktop" "$pdir/share/applications"
+    mkdir -p "$pdir/share/applications" "$pdir/share/icons/hicolor/scalable/apps" "$pdir/share/metainfo"
+    cp "resources/linux/org.lite-xl.lite-xl.desktop" "$pdir/share/applications"
+    cp "resources/linux/org.lite-xl.lite-xl.appdata.xml" "$pdir/share/metainfo"
     cp "resources/icons/lite-xl.svg" "$pdir/share/icons/hicolor/scalable/apps/lite-xl.svg"
   fi
   pushd ".package-build"


### PR DESCRIPTION
Fixes #402.
I missed to add/update some files in `build-packages.sh` assuming it was using the `meson install` step, but it doesn't, so I fixed the changed name of the icon and copied the missing  AppStream file. In addition I also copied the licenses.md doc file.
I'm not sure if only Linux package is affected, so please check.
At some point I'll need some help to merge all features from the "CI" scripts in this one (which in turn seems to miss some colors themes).