### PR TITLE
Implement horizontal scrolling

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -393,4 +393,12 @@ function common.rm(path, recursively)
   return true
 end
 
+function common.get_table_size(t)
+  local count = 0
+  for _ in pairs(t) do
+    count = count + 1
+  end
+  return count
+end
+
 return common

--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -393,12 +393,5 @@ function common.rm(path, recursively)
   return true
 end
 
-function common.get_table_size(t)
-  local count = 0
-  for _ in pairs(t) do
-    count = count + 1
-  end
-  return count
-end
 
 return common

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -72,7 +72,7 @@ function Doc:load(filename)
       self.crlf = true
     end
     table.insert(self.lines, line .. "\n")
-    local line_len = string.len(line)
+    local line_len = string.len(line) + 1 -- account for newline
     if line_len > max_length then
       max_length = line_len
       line_numbers = { [i] = true } -- new longest line

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -557,7 +557,7 @@ function Doc:update_max_line_len_range(start_line, end_line)
     elseif line_len == max_length then
       line_numbers[line] = true
     else
-      line_numbers[line] = nil
+      if line_numbers[line] then line_numbers[line] = nil end
     end
   end
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -32,6 +32,7 @@ end
 
 function Doc:reset()
   self.lines = { "\n" }
+  self.long_lines = { line_numbers = { [1] = true }, length = 0 }
   self.selections = { 1, 1, 1, 1 }
   self.cursor_clipboard = {}
   self.undo_stack = { idx = 1 }
@@ -60,19 +61,32 @@ end
 
 function Doc:load(filename)
   local fp = assert( io.open(filename, "rb") )
+  local max_length = 0
+  local line_numbers = { [1] = true }
   self:reset()
   self.lines = {}
+  local i = 1
   for line in fp:lines() do
     if line:byte(-1) == 13 then
       line = line:sub(1, -2)
       self.crlf = true
     end
     table.insert(self.lines, line .. "\n")
+    local line_len = string.len(line)
+    if line_len > max_length then
+      max_length = line_len
+      line_numbers = { [i] = true } -- new longest line
+    elseif line_len == max_length then
+      line_numbers[i] = true -- add to longest lines
+    end
+    i = i + 1
   end
   if #self.lines == 0 then
     table.insert(self.lines, "\n")
   end
   fp:close()
+  self.long_lines.line_numbers = line_numbers
+  self.long_lines.length = max_length
   self:reset_syntax()
 end
 
@@ -325,6 +339,20 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
   push_undo(undo_stack, time, "selection", unpack(self.selections))
   push_undo(undo_stack, time, "remove", line, col, line2, col2)
 
+  if #lines > 1 then
+    -- Need to shift all the subsequent long lines
+    local line_numbers = {}
+    for n in pairs(self.long_lines.line_numbers) do
+      if n > line then
+        line_numbers[n + #lines - 1] = true
+      else
+        line_numbers[n] = true
+      end
+    end
+    self.long_lines.line_numbers = line_numbers
+  end
+  self:update_max_line_len_range(line, line2)
+
   -- update highlighter and assure selection is in bounds
   self.highlighter:invalidate(line)
   self:sanitize_selection()
@@ -343,6 +371,23 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
 
   -- splice line into line array
   common.splice(self.lines, line1, line2 - line1 + 1, { before .. after })
+
+  local nlines = line2 - line1 + 1
+  if nlines > 1 then
+    -- Need to shift all the subsequent long lines
+    local line_numbers = {}
+    for n in pairs(self.long_lines.line_numbers) do
+      if n > line2 then
+        line_numbers[n - nlines + 1] = true
+      elseif n > line1 then
+        line_numbers[n] = nil -- invalidate any line that has been deleted
+      else
+        line_numbers[n] = true
+      end
+    end
+    self.long_lines.line_numbers = line_numbers
+  end
+  self:update_max_line_len_range(line1, line2)
 
   -- update highlighter and assure selection is in bounds
   self.highlighter:invalidate(line1)
@@ -497,6 +542,34 @@ function Doc:indent_text(unindent, line1, col1, line2, col2)
   end
   self:insert(line1, col1, text)
   return line1, col1 + #text, line1, col1 + #text
+end
+
+function Doc:update_max_line_len_range(start_line, end_line)
+  local line_numbers = self.long_lines.line_numbers
+  local max_length = self.long_lines.length
+  end_line = math.min(end_line, #self.lines)
+
+  for line=start_line,end_line do
+    local line_len = string.len(self.lines[line])
+    if line_len > max_length then
+      max_length = line_len
+      line_numbers = { [line] = true }
+    elseif line_len == max_length then
+      line_numbers[line] = true
+    else
+      line_numbers[line] = nil
+    end
+  end
+
+  if common.get_table_size(line_numbers) == 0 then
+    -- Recalc needed
+    self.long_lines.length = 0
+    self.long_lines.line_numbers = { [1] = true }
+    return self:update_max_line_len_range(1, #self.lines)
+  end
+
+  self.long_lines.line_numbers = line_numbers
+  self.long_lines.length = max_length
 end
 
 -- For plugins to add custom actions of document change

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -32,7 +32,7 @@ end
 
 function Doc:reset()
   self.lines = { "\n" }
-  self.long_lines = { line_numbers = { [1] = true }, length = 0 }
+  self.long_lines = { line_numbers = { }, length = 0 }
   self.selections = { 1, 1, 1, 1 }
   self.cursor_clipboard = {}
   self.undo_stack = { idx = 1 }
@@ -62,7 +62,7 @@ end
 function Doc:load(filename)
   local fp = assert( io.open(filename, "rb") )
   local max_length = 0
-  local line_numbers = { [1] = true }
+  local line_numbers = { }
   self:reset()
   self.lines = {}
   local i = 1
@@ -72,14 +72,15 @@ function Doc:load(filename)
       self.crlf = true
     end
     table.insert(self.lines, line .. "\n")
-    local line_len = string.len(line) + 1 -- account for newline
-    if line_len > max_length then
+    local line_len = #line + 1 -- account for newline
+    if line_len >= max_length then
       max_length = line_len
-      line_numbers = { [i] = true } -- new longest line
-    elseif line_len == max_length then
-      line_numbers[i] = true -- add to longest lines
+      line_numbers[i] = line_len
     end
     i = i + 1
+  end
+  for n, len in pairs(line_numbers) do
+    line_numbers[n] = len >= max_length and len or nil
   end
   if #self.lines == 0 then
     table.insert(self.lines, "\n")
@@ -341,12 +342,12 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
 
   if #lines > 1 then
     -- Need to shift all the subsequent long lines
-    local line_numbers = {}
-    for n in pairs(self.long_lines.line_numbers) do
+    local line_numbers = { }
+    for n, len in pairs(self.long_lines.line_numbers) do
       if n > line then
-        line_numbers[n + #lines - 1] = true
+        line_numbers[n + #lines - 1] = len
       else
-        line_numbers[n] = true
+        line_numbers[n] = len
       end
     end
     self.long_lines.line_numbers = line_numbers
@@ -375,14 +376,14 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
   local nlines = line2 - line1 + 1
   if nlines > 1 then
     -- Need to shift all the subsequent long lines
-    local line_numbers = {}
-    for n in pairs(self.long_lines.line_numbers) do
+    local line_numbers = { }
+    for n, len in pairs(self.long_lines.line_numbers) do
       if n > line2 then
-        line_numbers[n - nlines + 1] = true
+        line_numbers[n - nlines + 1] = len
       elseif n > line1 then
         line_numbers[n] = nil -- invalidate any line that has been deleted
       else
-        line_numbers[n] = true
+        line_numbers[n] = len
       end
     end
     self.long_lines.line_numbers = line_numbers
@@ -550,27 +551,28 @@ function Doc:update_max_line_len_range(start_line, end_line)
   end_line = math.min(end_line, #self.lines)
 
   for line=start_line,end_line do
-    local line_len = string.len(self.lines[line])
-    if line_len > max_length then
+    local line_len = #self.lines[line]
+    if line_len >= max_length then
       max_length = line_len
-      line_numbers = { [line] = true }
-    elseif line_len == max_length then
-      line_numbers[line] = true
+      line_numbers[line] = line_len
     else
       if line_numbers[line] then line_numbers[line] = nil end
     end
   end
-
-  if common.get_table_size(line_numbers) == 0 then
+  for n, len in pairs(line_numbers) do
+    line_numbers[n] = len >= max_length and len or nil
+  end
+  if not next(line_numbers) then
     -- Recalc needed
     self.long_lines.length = 0
-    self.long_lines.line_numbers = { [1] = true }
+    self.long_lines.line_numbers = { }
     return self:update_max_line_len_range(1, #self.lines)
   end
 
   self.long_lines.line_numbers = line_numbers
   self.long_lines.length = max_length
 end
+
 
 -- For plugins to add custom actions of document change
 function Doc:on_text_change(type)

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -545,6 +545,7 @@ function Doc:indent_text(unindent, line1, col1, line2, col2)
   return line1, col1 + #text, line1, col1 + #text
 end
 
+
 function Doc:update_max_line_len_range(start_line, end_line)
   local line_numbers = self.long_lines.line_numbers
   local max_length = self.long_lines.length
@@ -565,7 +566,7 @@ function Doc:update_max_line_len_range(start_line, end_line)
   if not next(line_numbers) then
     -- Recalc needed
     self.long_lines.length = 0
-    self.long_lines.line_numbers = { }
+    self.long_lines.line_numbers = line_numbers
     return self:update_max_line_len_range(1, #self.lines)
   end
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -103,8 +103,10 @@ function DocView:get_scrollable_size()
     long_line = l
     break
   end
-  return self:get_line_height() * (#self.doc.lines - 1) + self.size.y, 
-         self:get_col_x_offset(long_line, self.doc.long_lines.length) + self.size.x - xmargin
+  local size_v = self:get_line_height() * (#self.doc.lines - 1) + self.size.y
+  local size_h = self:get_col_x_offset(long_line, self.doc.long_lines.length)
+                 + self.size.x - (self.size.x - self:get_gutter_width()) + xmargin
+  return size_v, size_h
 end
 
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -278,7 +278,8 @@ end
 function DocView:on_mouse_moved(x, y, ...)
   DocView.super.on_mouse_moved(self, x, y, ...)
 
-  if self:scrollbar_overlaps_point(x, y) or self.dragging_scrollbar then
+  local overlap_v, overlap_h = self:scrollbar_overlaps_point(x, y)
+  if overlap_v or overlap_h or self.dragging_v_scrollbar or self.dragging_h_scrollbar then
     self.cursor = "arrow"
   else
     self.cursor = "ibeam"

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -97,7 +97,14 @@ end
 
 
 function DocView:get_scrollable_size()
-  return self:get_line_height() * (#self.doc.lines - 1) + self.size.y
+  local xmargin = 3 * self:get_font():get_width(' ') -- from DocView:scroll_to_make_visible
+  local long_line = 1
+  for l,_ in pairs(self.doc.long_lines.line_numbers) do -- get any of the longest lines
+    long_line = l
+    break
+  end
+  return self:get_line_height() * (#self.doc.lines - 1) + self.size.y, 
+         self:get_col_x_offset(long_line, self.doc.long_lines.length) + self.size.x - xmargin
 end
 
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -97,18 +97,15 @@ end
 
 
 function DocView:get_scrollable_size()
-  local xmargin = 3 * self:get_font():get_width(' ') -- from DocView:scroll_to_make_visible
-  local long_line = 1
-  for l,_ in pairs(self.doc.long_lines.line_numbers) do -- get any of the longest lines
-    long_line = l
-    break
-  end
-  local size_v = self:get_line_height() * (#self.doc.lines - 1) + self.size.y
-  local size_h = self:get_col_x_offset(long_line, self.doc.long_lines.length)
-                 + self.size.x - (self.size.x - self:get_gutter_width()) + xmargin
-  return size_v, size_h
+  return self:get_line_height() * (#self.doc.lines - 1) + self.size.y
 end
 
+function DocView:get_h_scrollable_size()
+  local xmargin = 3 * self:get_font():get_width(' ') -- from DocView:scroll_to_make_visible
+  local long_line = next(self.doc.long_lines.line_numbers) or 1
+  return self:get_col_x_offset(long_line, self.doc.long_lines.length)
+         + self:get_gutter_width() + xmargin
+end
 
 function DocView:get_font()
   return style[self.font]
@@ -280,8 +277,8 @@ end
 function DocView:on_mouse_moved(x, y, ...)
   DocView.super.on_mouse_moved(self, x, y, ...)
 
-  local overlap_v, overlap_h = self:scrollbar_overlaps_point(x, y)
-  if overlap_v or overlap_h or self.dragging_v_scrollbar or self.dragging_h_scrollbar then
+  if self:scrollbar_overlaps_point(x, y) or self.dragging_scrollbar
+     or self:h_scrollbar_overlaps_point(x, y) or self.dragging_h_scrollbar then
     self.cursor = "arrow"
   else
     self.cursor = "ibeam"
@@ -448,6 +445,7 @@ function DocView:draw()
   core.pop_clip_rect()
 
   self:draw_scrollbar()
+  self:draw_h_scrollbar()
 end
 
 

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -3,6 +3,7 @@ local config = require "core.config"
 local style = require "core.style"
 local common = require "core.common"
 local Object = require "core.object"
+local keymap = require "core.keymap"
 
 
 local View = Object:extend()
@@ -46,9 +47,9 @@ function View:get_name()
   return "---"
 end
 
-
+-- Returns `y, x` for compatibility
 function View:get_scrollable_size()
-  return math.huge
+  return math.huge, 0 -- TODO: invert y and x
 end
 
 
@@ -99,9 +100,13 @@ function View:on_text_input(text)
 end
 
 
-function View:on_mouse_wheel(y)
+function View:on_mouse_wheel(quant)
   if self.scrollable then
-    self.scroll.to.y = self.scroll.to.y + y * -config.mouse_wheel_scroll
+    if keymap.modkeys["shift"] then
+      self.scroll.to.x = self.scroll.to.x + quant * -config.mouse_wheel_scroll
+    else
+      self.scroll.to.y = self.scroll.to.y + quant * -config.mouse_wheel_scroll
+    end
   end
 end
 
@@ -121,8 +126,12 @@ end
 
 
 function View:clamp_scroll_position()
-  local max = self:get_scrollable_size() - self.size.y
-  self.scroll.to.y = common.clamp(self.scroll.to.y, 0, max)
+  local scrollsize_y, scrollsize_x = self:get_scrollable_size()
+  scrollsize_x = scrollsize_x or 0 -- FIXME: not every subclass returns the second value
+  local max_x = scrollsize_x - self.size.x
+  local max_y = scrollsize_y - self.size.y
+  self.scroll.to.x = common.clamp(self.scroll.to.x, 0, max_x)
+  self.scroll.to.y = common.clamp(self.scroll.to.y, 0, max_y)
 end
 
 

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -53,45 +53,71 @@ function View:get_scrollable_size()
 end
 
 
-function View:get_scrollbar_rect()
-  local sz = self:get_scrollable_size()
-  if sz <= self.size.y or sz == math.huge then
-    return 0, 0, 0, 0
+function View:get_scrollbar_rect() -- TODO: make plugins use `View:get_scrollbars_rect`
+  local rect = self:get_get_scrollbars_rect()
+  return rect.x, rect.y, rect.w, rect.h
+end
+
+function View:get_scrollbars_rect()
+  local v_sizes = { x = 0, y = 0, w = 0, h = 0 }
+  local h_sizes = { x = 0, y = 0, w = 0, h = 0 }
+  local v_sz, h_sz = self:get_scrollable_size()
+  h_sz = h_sz or 0 -- FIXME: not every subclass returns the second value
+
+  if v_sz > self.size.y and v_sz ~= math.huge then
+    local h = math.max(20, self.size.y * self.size.y / v_sz)
+    v_sizes.x = self.position.x + self.size.x - style.scrollbar_size
+    v_sizes.y = self.position.y + self.scroll.y * (self.size.y - h) / (v_sz - self.size.y)
+    v_sizes.w = style.scrollbar_size
+    v_sizes.h = h
   end
-  local h = math.max(20, self.size.y * self.size.y / sz)
-  return
-    self.position.x + self.size.x - style.scrollbar_size,
-    self.position.y + self.scroll.y * (self.size.y - h) / (sz - self.size.y),
-    style.scrollbar_size,
-    h
+
+  if h_sz > self.size.x and h_sz ~= math.huge then
+    local w = math.max(20, self.size.x * self.size.x / h_sz)
+    h_sizes.x = self.position.x + self.scroll.x * (self.size.x - w) / (h_sz - self.size.x)
+    h_sizes.y = self.position.y + self.size.y - style.scrollbar_size
+    h_sizes.w = w
+    h_sizes.h = style.scrollbar_size
+  end
+
+  return v_sizes, h_sizes
 end
 
 
 function View:scrollbar_overlaps_point(x, y)
-  local sx, sy, sw, sh = self:get_scrollbar_rect()
-  return x >= sx - sw * 3 and x < sx + sw and y >= sy and y < sy + sh
+  local v, h = self:get_scrollbars_rect()
+  local v_overlap = x >= v.x - v.w * 3 and x < v.x + v.w and y >= v.y and y < v.y + v.h
+  local h_overlap = x >= h.x and x < h.x + h.w and y >= h.y - h.h * 3 and y <= h.y + h.h
+  return v_overlap, not v_overlap and h_overlap -- precedence to vertical scrollbar
 end
 
 
 function View:on_mouse_pressed(button, x, y, clicks)
-  if self:scrollbar_overlaps_point(x, y) then
-    self.dragging_scrollbar = true
-    return true
-  end
+  self.dragging_v_scrollbar, self.dragging_h_scrollbar = self:scrollbar_overlaps_point(x, y)
+  self.dragging_scrollbar = self.dragging_v_scrollbar -- TODO: make plugins use `self.dragging_v_scrollbar`
+  return self.dragging_v_scrollbar or self.dragging_h_scrollbar
 end
 
 
 function View:on_mouse_released(button, x, y)
-  self.dragging_scrollbar = false
+  self.dragging_v_scrollbar = false
+  self.dragging_h_scrollbar = false
+  self.dragging_scrollbar = self.dragging_v_scrollbar -- TODO: make plugins use `self.dragging_v_scrollbar`
 end
 
 
 function View:on_mouse_moved(x, y, dx, dy)
-  if self.dragging_scrollbar then
-    local delta = self:get_scrollable_size() / self.size.y * dy
+  if self.dragging_v_scrollbar then
+    local v_sz,_ = self:get_scrollable_size()
+    local delta = v_sz / self.size.y * dy
     self.scroll.to.y = self.scroll.to.y + delta
+  elseif self.dragging_h_scrollbar then
+    local _,h_sz = self:get_scrollable_size()
+    local delta = h_sz / self.size.x * dx
+    self.scroll.to.x = self.scroll.to.x + delta
   end
-  self.hovered_scrollbar = self:scrollbar_overlaps_point(x, y)
+  self.hovered_v_scrollbar, self.hovered_h_scrollbar = self:scrollbar_overlaps_point(x, y)
+  self.hovered_scrollbar = self.hovered_v_scrollbar -- TODO: make plugins use `self.hovered_v_scrollbar`
 end
 
 
@@ -150,10 +176,13 @@ end
 
 
 function View:draw_scrollbar()
-  local x, y, w, h = self:get_scrollbar_rect()
-  local highlight = self.hovered_scrollbar or self.dragging_scrollbar
-  local color = highlight and style.scrollbar2 or style.scrollbar
-  renderer.draw_rect(x, y, w, h, color)
+  local v, h = self:get_scrollbars_rect()
+  local v_highlight = self.hovered_v_scrollbar or self.dragging_v_scrollbar
+  local h_highlight = self.hovered_h_scrollbar or self.dragging_h_scrollbar
+  local v_color = v_highlight and style.scrollbar2 or style.scrollbar
+  local h_color = h_highlight and style.scrollbar2 or style.scrollbar
+  renderer.draw_rect(v.x, v.y, v.w, v.h, v_color)
+  renderer.draw_rect(h.x, h.y, h.w, h.h, h_color)
 end
 
 

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -47,77 +47,84 @@ function View:get_name()
   return "---"
 end
 
--- Returns `y, x` for compatibility
+
 function View:get_scrollable_size()
-  return math.huge, 0 -- TODO: invert y and x
+  return math.huge
 end
 
 
-function View:get_scrollbar_rect() -- TODO: make plugins use `View:get_scrollbars_rect`
-  local rect = self:get_get_scrollbars_rect()
-  return rect.x, rect.y, rect.w, rect.h
+function View:get_h_scrollable_size()
+  return 0
 end
 
-function View:get_scrollbars_rect()
-  local v_sizes = { x = 0, y = 0, w = 0, h = 0 }
-  local h_sizes = { x = 0, y = 0, w = 0, h = 0 }
-  local v_sz, h_sz = self:get_scrollable_size()
-  h_sz = h_sz or 0 -- FIXME: not every subclass returns the second value
 
-  if v_sz > self.size.y and v_sz ~= math.huge then
-    local h = math.max(20, self.size.y * self.size.y / v_sz)
-    v_sizes.x = self.position.x + self.size.x - style.scrollbar_size
-    v_sizes.y = self.position.y + self.scroll.y * (self.size.y - h) / (v_sz - self.size.y)
-    v_sizes.w = style.scrollbar_size
-    v_sizes.h = h
+function View:get_scrollbar_rect()
+  local sz = self:get_scrollable_size()
+  if sz <= self.size.y or sz == math.huge then
+    return 0, 0, 0, 0
   end
+  local h = math.max(20, self.size.y * self.size.y / sz)
+  return
+    self.position.x + self.size.x - style.scrollbar_size,
+    self.position.y + self.scroll.y * (self.size.y - h) / (sz - self.size.y),
+    style.scrollbar_size,
+    h
+end
 
-  if h_sz > self.size.x and h_sz ~= math.huge then
-    local w = math.max(20, self.size.x * self.size.x / h_sz)
-    h_sizes.x = self.position.x + self.scroll.x * (self.size.x - w) / (h_sz - self.size.x)
-    h_sizes.y = self.position.y + self.size.y - style.scrollbar_size
-    h_sizes.w = w
-    h_sizes.h = style.scrollbar_size
+
+function View:get_h_scrollbar_rect()
+  local sz = self:get_h_scrollable_size()
+  if sz <= self.size.x or sz == math.huge then
+    return 0, 0, 0, 0
   end
-
-  return v_sizes, h_sizes
+  local w = math.max(20, self.size.x * self.size.x / sz)
+  return
+    self.position.x + self.scroll.x * (self.size.x - w) / (sz - self.size.x),
+    self.position.y + self.size.y - style.scrollbar_size,
+    w,
+    style.scrollbar_size
 end
 
 
 function View:scrollbar_overlaps_point(x, y)
-  local v, h = self:get_scrollbars_rect()
-  local v_overlap = x >= v.x - v.w * 3 and x < v.x + v.w and y >= v.y and y < v.y + v.h
-  local h_overlap = x >= h.x and x < h.x + h.w and y >= h.y - h.h * 3 and y <= h.y + h.h
-  return v_overlap, not v_overlap and h_overlap -- precedence to vertical scrollbar
+  local sx, sy, sw, sh = self:get_scrollbar_rect()
+  return x >= sx - sw * 3 and x < sx + sw and y >= sy and y <= sy + sh
+end
+
+
+function View:h_scrollbar_overlaps_point(x, y)
+  local sx, sy, sw, sh = self:get_h_scrollbar_rect()
+  return x >= sx and x <= sx + sw and y > sy - sh * 3 and y <= sy + sh
 end
 
 
 function View:on_mouse_pressed(button, x, y, clicks)
-  self.dragging_v_scrollbar, self.dragging_h_scrollbar = self:scrollbar_overlaps_point(x, y)
-  self.dragging_scrollbar = self.dragging_v_scrollbar -- TODO: make plugins use `self.dragging_v_scrollbar`
-  return self.dragging_v_scrollbar or self.dragging_h_scrollbar
+  if self:scrollbar_overlaps_point(x, y) then
+    self.dragging_scrollbar = true
+    return true
+  elseif self:h_scrollbar_overlaps_point(x, y) then
+    self.dragging_h_scrollbar = true
+    return true
+  end
 end
 
 
 function View:on_mouse_released(button, x, y)
-  self.dragging_v_scrollbar = false
+  self.dragging_scrollbar = false
   self.dragging_h_scrollbar = false
-  self.dragging_scrollbar = self.dragging_v_scrollbar -- TODO: make plugins use `self.dragging_v_scrollbar`
 end
 
 
 function View:on_mouse_moved(x, y, dx, dy)
-  if self.dragging_v_scrollbar then
-    local v_sz,_ = self:get_scrollable_size()
-    local delta = v_sz / self.size.y * dy
+  if self.dragging_scrollbar then
+    local delta = self:get_scrollable_size() / self.size.y * dy
     self.scroll.to.y = self.scroll.to.y + delta
   elseif self.dragging_h_scrollbar then
-    local _,h_sz = self:get_scrollable_size()
-    local delta = h_sz / self.size.x * dx
+    local delta = self:get_h_scrollable_size() / self.size.x * dx
     self.scroll.to.x = self.scroll.to.x + delta
   end
-  self.hovered_v_scrollbar, self.hovered_h_scrollbar = self:scrollbar_overlaps_point(x, y)
-  self.hovered_scrollbar = self.hovered_v_scrollbar -- TODO: make plugins use `self.hovered_v_scrollbar`
+  self.hovered_scrollbar = self:scrollbar_overlaps_point(x, y)
+  self.hovered_h_scrollbar = self:h_scrollbar_overlaps_point(x, y)
 end
 
 
@@ -152,10 +159,8 @@ end
 
 
 function View:clamp_scroll_position()
-  local scrollsize_y, scrollsize_x = self:get_scrollable_size()
-  scrollsize_x = scrollsize_x or 0 -- FIXME: not every subclass returns the second value
-  local max_x = scrollsize_x - self.size.x
-  local max_y = scrollsize_y - self.size.y
+  local max_x = self:get_h_scrollable_size() - self.size.x
+  local max_y = self:get_scrollable_size() - self.size.y
   self.scroll.to.x = common.clamp(self.scroll.to.x, 0, max_x)
   self.scroll.to.y = common.clamp(self.scroll.to.y, 0, max_y)
 end
@@ -176,13 +181,19 @@ end
 
 
 function View:draw_scrollbar()
-  local v, h = self:get_scrollbars_rect()
-  local v_highlight = self.hovered_v_scrollbar or self.dragging_v_scrollbar
-  local h_highlight = self.hovered_h_scrollbar or self.dragging_h_scrollbar
-  local v_color = v_highlight and style.scrollbar2 or style.scrollbar
-  local h_color = h_highlight and style.scrollbar2 or style.scrollbar
-  renderer.draw_rect(v.x, v.y, v.w, v.h, v_color)
-  renderer.draw_rect(h.x, h.y, h.w, h.h, h_color)
+  local x, y, w, h = self:get_scrollbar_rect()
+  local highlight = self.hovered_scrollbar or self.dragging_scrollbar
+  local color = highlight and style.scrollbar2 or style.scrollbar
+  renderer.draw_rect(x, y, w, h, color)
+end
+
+
+function View:draw_h_scrollbar()
+  local x, y, w, h = self:get_h_scrollbar_rect()
+  local highlight = self.hovered_h_scrollbar and not self.hovered_scrollbar
+                    or self.dragging_h_scrollbar
+  local color = highlight and style.scrollbar2 or style.scrollbar
+  renderer.draw_rect(x, y, w, h, color)
 end
 
 


### PR DESCRIPTION
This allows horizontal scrolling via `shift+scroll`.
For now only `DocView` can scroll, but anything that extends `View` should be able to horizontally scroll by returning a second value from `get_scrollable_size`.

Most of the complexity of this PR is due to the need to keep track of the longest lines. This avoids re-scanning the entire document every time it changes. Instead only altered lines are checked.
The only occasion that a full re-scan is required, is when there is only one longest line and it got shortened.

Fixes #424.