### PR TITLE
use dependency fallbacks, use system reproc if available

### DIFF
--- a/lib/font_renderer/meson.build
+++ b/lib/font_renderer/meson.build
@@ -1,10 +1,6 @@
 freetype_dep = dependency('freetype2')
 
-libagg_dep = dependency('libagg', required: false)
-if not libagg_dep.found()
-  libagg_subproject = subproject('libagg')
-  libagg_dep = libagg_subproject.get_variable('libagg_dep')
-endif
+libagg_dep = dependency('libagg', fallback: ['libagg', 'libagg_dep'])
 
 font_renderer_sources = [
     'agg_font_freetype.cpp',

--- a/meson.build
+++ b/meson.build
@@ -53,24 +53,15 @@ endif
 #===============================================================================
 libm = cc.find_library('m', required : false)
 libdl = cc.find_library('dl', required : false)
-lua_dep = dependency('lua5.2', required : false)
+lua_dep = dependency('lua5.2', fallback: ['lua', 'lua_dep'])
 pcre2_dep = dependency('libpcre2-8')
 sdl_dep = dependency('sdl2', method: 'config-tool')
-
-if not lua_dep.found()
-    lua_subproject = subproject('lua',
-        default_options: ['shared=false', 'use_readline=false', 'app=false']
-    )
-    lua_dep = lua_subproject.get_variable('lua_dep')
-endif
-
-reproc_subproject = subproject('reproc',
+reproc_dep = dependency('reproc', fallback: ['reproc', 'reproc_dep'],
     default_options: [
         'default_library=static', 'multithreaded=false',
         'reproc-cpp=false', 'examples=false'
     ]
 )
-reproc_dep = reproc_subproject.get_variable('reproc_dep')
 
 lite_deps = [lua_dep, sdl_dep, reproc_dep, pcre2_dep, libm, libdl]
 


### PR DESCRIPTION
follow up to #396 because I believe this is good to have

the lua subproject throws these warnings
> lua| WARNING: Library target 'lua' has 'name_prefix' set. Compilers may not find it from its '-llua' linker flag in the 'lua5.2.pc' pkg-config file.
lua| WARNING: Library target 'lua' has 'name_prefix' set. Compilers may not find it from its '-llua' linker flag in the 'lua5.2-uninstalled.pc' pkg-config file.

because it sets `name_prefix` to `lua_library_prefix` in lua/src/meson.build (`lua_library_prefix` being set to `lib` resulting in a liblua.so` or `liblua.a`)

I made it check on for reproc on the system once again because, for Fedora at least, it makes builds easier and makes builds without an internet connection possible.
I'm open to reverting that