### PR TITLE
Added in two new VSC-style multicursor shortcuts.

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -366,16 +366,20 @@ function DocView:draw_line_body(idx, x, y)
       local x1 = x + self:get_col_x_offset(idx, col1)
       local x2 = x + self:get_col_x_offset(idx, col2)
       local lh = self:get_line_height()
-      renderer.draw_rect(x1, y, x2 - x1, lh, style.selection)
+      if x1 ~= x2 then
+        renderer.draw_rect(x1, y, x2 - x1, lh, style.selection)
+      end
     end
   end
+  local draw_highlight = nil
   for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do
     -- draw line highlight if caret is on this line
-    if config.highlight_current_line and (line1 == line2 and col1 == col2)
+    if draw_highlight ~= false and config.highlight_current_line
     and line1 == idx and core.active_view == self then
-      self:draw_line_highlight(x + self.scroll.x, y)
+      draw_highlight = (line1 == line2 and col1 == col2)
     end
   end
+  if draw_highlight then self:draw_line_highlight(x + self.scroll.x, y) end
 
   -- draw line's text
   self:draw_line_text(idx, x, y)

--- a/data/core/keymap-macos.lua
+++ b/data/core/keymap-macos.lua
@@ -66,6 +66,7 @@ local function keymap_macos(keymap)
     ["cmd+a"] = "doc:select-all",
     ["cmd+d"] = { "find-replace:select-next", "doc:select-word" },
     ["cmd+l"] = "doc:select-lines",
+    ["cmd+shift+l"] = { "find-replace:select-all", "doc:select-word" },
     ["cmd+/"] = "doc:toggle-line-comments",
     ["cmd+up"] = "doc:move-lines-up",
     ["cmd+down"] = "doc:move-lines-down",

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -170,6 +170,7 @@ keymap.add_direct {
   ["ctrl+a"] = "doc:select-all",
   ["ctrl+d"] = { "find-replace:select-next", "doc:select-word" },
   ["ctrl+l"] = "doc:select-lines",
+  ["ctrl+shift+l"] = { "find-replace:select-all", "doc:select-word" },
   ["ctrl+/"] = "doc:toggle-line-comments",
   ["ctrl+up"] = "doc:move-lines-up",
   ["ctrl+down"] = "doc:move-lines-down",


### PR DESCRIPTION
Closes #417 . Refactors ctrl+d to add a cursor at the next occurrence, instead of moving the cursor to the next occurrence. Also adds in ctrl+shift+l, which will select all occurrences of a word in the document, and then add a multicursor to each that doesn't already have one.