### PR TITLE
Use plain `string:find` when matching plugin directories

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -692,7 +692,7 @@ function core.load_plugins()
     if is_lua_file then
       if not version_match then
         core.log_quiet("Version mismatch for plugin %q from %s", basename, plugin_dir)
-        local list = refused_list[plugin_dir:find(USERDIR) == 1 and 'userdir' or 'datadir'].plugins
+        local list = refused_list[plugin_dir:find(USERDIR, 1, true) == 1 and 'userdir' or 'datadir'].plugins
         table.insert(list, filename)
       end
       if version_match and config.plugins[basename] ~= false then


### PR DESCRIPTION
If `USERDIR` contained special pattern characters (like `-` in `/home/user/.config/lite-xl`), every refused plugin would have been included in `refused_list["datadir"]`.