### PR TITLE
RFC: Initial implementation to allow any `View` to specify what to load/save in a workspace

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -7,9 +7,46 @@ local translate = require "core.doc.translate"
 local View = require "core.view"
 
 
-local DocView = View:extend()
+local DocView = View:extend("DocView")
 
 DocView.context = "session"
+
+
+function DocView:get_content()
+  return {
+      active = (core.active_view == self),
+      filename = self.doc.filename,
+      selection = { self.doc:get_selection() },
+      scroll = { x = self.scroll.to.x, y = self.scroll.to.y },
+      text = not self.doc.filename and self.doc:get_text(1, 1, math.huge, math.huge)
+    }
+end
+
+
+function DocView.from_content(t)
+  local dv
+  if not t.filename then
+    -- document not associated to a file
+    dv = DocView(core.open_doc())
+    if t.text then dv.doc:insert(1, 1, t.text) end
+  else
+    -- we have a filename, try to read the file
+    local ok, doc = pcall(core.open_doc, t.filename)
+    if ok then
+      dv = DocView(doc)
+    end
+  end
+  -- doc view "dv" can be nil here if the filename associated to the document
+  -- cannot be read.
+  if dv and dv.doc then
+    dv.doc:set_selection(table.unpack(t.selection))
+    dv.last_line, dv.last_col = dv.doc:get_selection()
+    dv.scroll.x, dv.scroll.to.x = t.scroll.x, t.scroll.x
+    dv.scroll.y, dv.scroll.to.y = t.scroll.y, t.scroll.y
+  end
+  return dv
+end
+
 
 local function move_to_line_offset(dv, line, col, offset)
   local xo = dv.last_x_offset

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -36,6 +36,16 @@ local function save_session()
 end
 
 
+local registered_views = { }
+function core.register_view(name, class)
+  registered_views[name] = class
+end
+
+function core.get_registered_view(name)
+  return registered_views[name]
+end
+
+
 local function update_recents_project(action, dir_path_abs)
   local dirname = common.normalize_path(dir_path_abs)
   if not dirname then return end

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -7,6 +7,16 @@ local Object = require "core.object"
 
 local View = Object:extend()
 
+-- Override how objects are created. This allows for automatic Views registration
+function View:extend(register_name)
+  local new_class = View.super.extend(self)
+  if register_name then
+    new_class.registered_name = register_name
+    core.register_view(register_name, new_class)
+  end
+  return new_class
+end
+
 -- context can be "application" or "session". The instance of objects
 -- with context "session" will be closed when a project session is
 -- terminated. The context "application" is for functional UI elements.

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -7,6 +7,7 @@ local Object = require "core.object"
 
 local View = Object:extend()
 
+
 -- Override how objects are created. This allows for automatic Views registration
 function View:extend(register_name)
   local new_class = View.super.extend(self)
@@ -17,10 +18,25 @@ function View:extend(register_name)
   return new_class
 end
 
+
 -- context can be "application" or "session". The instance of objects
 -- with context "session" will be closed when a project session is
 -- terminated. The context "application" is for functional UI elements.
 View.context = "application"
+
+
+-- Returns a table that contains what shall be saved in a workspace file.
+function View:get_content()
+  return { }
+end
+
+
+-- Returns a View created from the specified parameter `content`, which contains
+-- what was returned from `View:get_content`.
+function View.from_content(content)
+  return View()
+end
+
 
 function View:new()
   self.position = { x = 0, y = 0 }
@@ -29,6 +45,7 @@ function View:new()
   self.cursor = "arrow"
   self.scrollable = false
 end
+
 
 function View:move_towards(t, k, dest, rate)
   if type(t) ~= "table" then

--- a/data/plugins/workspace.lua
+++ b/data/plugins/workspace.lua
@@ -75,55 +75,22 @@ end
 
 
 local function save_view(view)
-  local mt = getmetatable(view)
-  if mt == DocView then
-    return {
-      type = "doc",
-      active = (core.active_view == view),
-      filename = view.doc.filename,
-      selection = { view.doc:get_selection() },
-      scroll = { x = view.scroll.to.x, y = view.scroll.to.y },
-      text = not view.doc.filename and view.doc:get_text(1, 1, math.huge, math.huge)
-    }
-  end
-  if mt == LogView then return end
-  for name, mod in pairs(package.loaded) do
-    if mod == mt then
-      return {
-        type = "view",
-        active = (core.active_view == view),
-        module = name
-      }
-    end
-  end
+  if view.context ~= "session" then return end -- only save `session` View classes
+  if not view.registered_name then return end -- View didn't register
+  if not view.get_content then return end
+  local content = view:get_content()
+  content.type = view.registered_name
+  return content
 end
 
 
 local function load_view(t)
-  if t.type == "doc" then
-    local dv
-    if not t.filename then
-      -- document not associated to a file
-      dv = DocView(core.open_doc())
-      if t.text then dv.doc:insert(1, 1, t.text) end
-    else
-      -- we have a filename, try to read the file
-      local ok, doc = pcall(core.open_doc, t.filename)
-      if ok then
-        dv = DocView(doc)
-      end
-    end
-    -- doc view "dv" can be nil here if the filename associated to the document
-    -- cannot be read.
-    if dv and dv.doc then
-      dv.doc:set_selection(table.unpack(t.selection))
-      dv.last_line, dv.last_col = dv.doc:get_selection()
-      dv.scroll.x, dv.scroll.to.x = t.scroll.x, t.scroll.x
-      dv.scroll.y, dv.scroll.to.y = t.scroll.y, t.scroll.y
-    end
-    return dv
+  local class = core.get_registered_view(t.type)
+  if class then
+    t.type = nil
+    return class.from_content and class.from_content(t)
   end
-  return require(t.module)()
+  return require(t.module)() -- FIXME: is this needed? If a class is not registered, it should not be loaded
 end
 
 

--- a/data/plugins/workspace.lua
+++ b/data/plugins/workspace.lua
@@ -90,7 +90,7 @@ local function load_view(t)
     t.type = nil
     return class.from_content and class.from_content(t)
   end
-  return require(t.module)() -- FIXME: is this needed? If a class is not registered, it should not be loaded
+  core.error("Could not restore view %q", t.type)
 end
 
 


### PR DESCRIPTION
This allows `View`s to specify what data to save when closing a project, and how to restore itself with this data when the project is opened again.

When a `View` needs to be saved, its `get_content` function is called. What `get_content` returns is then serialized and saved in the workspace file.
When the `View` needs to be restored, its `from_content` function is called. This function receives the saved data as parameter, and returns a new `View`.

To allow a `View` object to be loaded/stored, it must pass a name as parameter when it calls `View:extend`. This name is used in the workspace file to distinguish it from other `View` types, so it shall be unique. If a name is not provided, the `View` won't be eligible to be loaded/stored.
The `View` also needs to specify that its context is `session`. I think that this last requirement could be removed, considering that if a `View` wants to be saved, it already has to specify a name and the `get_content` and `from_content` functions.