### PR TITLE
Tab splitting

### DIFF
--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -786,6 +786,7 @@ function RootView:on_mouse_pressed(button, x, y, clicks)
     if button == "middle" or node.hovered_close == idx then
       node:close_view(self.root_node, node.views[idx])
     else
+      system.capture_mouse(true)
       self.dragged_node = { node, idx }
       node:set_active_view(node.views[idx])
     end
@@ -798,14 +799,25 @@ function RootView:on_mouse_pressed(button, x, y, clicks)
 end
 
 
-function RootView:on_mouse_released(...)
+function RootView:on_mouse_released(button, x, y)
   if self.dragged_divider then
     self.dragged_divider = nil
   end
   if self.dragged_node then
+    local _, _, _, h = Node.get_tab_rect(self.dragged_node[1], self.dragged_node[2])
+    if x < 0 or x > self.size.x or y < 0 or y > h then
+      local tab = self.dragged_node[1].views[self.dragged_node[2]]
+      if tab:is(DocView) then
+        local filename = tab.doc.abs_filename or tab.doc.filename or "unsaved"
+        core.fork(filename)
+      else
+        core.log("tab splitting is not supported for this View")
+      end
+    end
+    system.capture_mouse(false)
     self.dragged_node = nil
   end
-  self.root_node:on_mouse_released(...)
+  self.root_node:on_mouse_released(button, x, y)
 end
 
 

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -858,7 +858,9 @@ function RootView:on_mouse_moved(x, y, dx, dy)
   local node = self.root_node:get_child_overlapping_point(x, y)
   local div = self.root_node:get_divider_overlapping_point(x, y)
   local tab_index = node and node:get_tab_overlapping_point(x, y)
-  if node and node:get_scroll_button_index(x, y) then
+  if self.dragged_node then
+    core.request_cursor("arrow")
+  elseif node and node:get_scroll_button_index(x, y) then
     core.request_cursor("arrow")
   elseif div then
     core.request_cursor(div.type == "hsplit" and "sizeh" or "sizev")

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -804,8 +804,8 @@ function RootView:on_mouse_released(button, x, y)
     self.dragged_divider = nil
   end
   if self.dragged_node then
-    local _, _, _, h = Node.get_tab_rect(self.dragged_node[1], self.dragged_node[2])
-    if x < 0 or x > self.size.x or y < 0 or y > h then
+    local ox, oy = self:get_content_offset()
+    if x < ox or x > self.size.x or y < oy or y > self.size.y then
       local tab = self.dragged_node[1].views[self.dragged_node[2]]
       if tab:is(DocView) then
         local filename = tab.doc.abs_filename or tab.doc.filename or "unsaved"

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -274,6 +274,13 @@ static int f_set_cursor(lua_State *L) {
 }
 
 
+static int f_capture_mouse(lua_State *L) {
+  int enable = lua_toboolean(L, 1);
+  SDL_CaptureMouse(enable);
+  return 0;
+}
+
+
 static int f_set_window_title(lua_State *L) {
   const char *title = luaL_checkstring(L, 1);
   SDL_SetWindowTitle(window, title);
@@ -642,6 +649,7 @@ static const luaL_Reg lib[] = {
   { "poll_event",          f_poll_event          },
   { "wait_event",          f_wait_event          },
   { "set_cursor",          f_set_cursor          },
+  { "capture_mouse",       f_capture_mouse       },
   { "set_window_title",    f_set_window_title    },
   { "set_window_mode",     f_set_window_mode     },
   { "get_window_mode",     f_get_window_mode     },


### PR DESCRIPTION
resolves #444 . 

Note: Drag-and-drop tabs into lite-xl **will not** be supported. This is virtually impossible without:
- linking to system libraries
- implement IPC, which is way more complex.