### PR TITLE
fix error in predicate

### DIFF
--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -96,7 +96,8 @@ local function has_selection()
   return core.active_view:is(DocView) and core.active_view.doc:has_selection()
 end
 
-local function has_unique_selection() 
+local function has_unique_selection()
+  if not core.active_view:is(DocView) then return false end
   local text = nil
   for idx, line1, col1, line2, col2 in doc():get_selections(true, true) do
     if line1 == line2 and col1 == col2 then return false end


### PR DESCRIPTION
This causes a lot of things to break because the command system does not expect errors in predicate.