### PR TITLE
Renamed freedesktop resources

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -167,8 +167,8 @@ lite_build_package_linux () {
   strip "$bindir/lite-xl"
   if [ -z "$portable" ]; then
     mkdir -p "$pdir/share/applications" "$pdir/share/icons/hicolor/scalable/apps" "$pdir/share/metainfo"
-    cp "resources/linux/org.lite-xl.lite-xl.desktop" "$pdir/share/applications"
-    cp "resources/linux/org.lite-xl.lite-xl.appdata.xml" "$pdir/share/metainfo"
+    cp "resources/linux/org.lite_xl.lite_xl.desktop" "$pdir/share/applications"
+    cp "resources/linux/org.lite_xl.lite_xl.appdata.xml" "$pdir/share/metainfo"
     cp "resources/icons/lite-xl.svg" "$pdir/share/icons/hicolor/scalable/apps/lite-xl.svg"
   fi
   pushd ".package-build"

--- a/meson.build
+++ b/meson.build
@@ -92,10 +92,10 @@ else
         install_data('resources/icons/lite-xl.svg',
             install_dir : 'share/icons/hicolor/scalable/apps'
         )
-        install_data('resources/linux/org.lite-xl.lite-xl.desktop',
+        install_data('resources/linux/org.lite_xl.lite_xl.desktop',
             install_dir : 'share/applications'
         )
-        install_data('resources/linux/org.lite-xl.lite-xl.appdata.xml',
+        install_data('resources/linux/org.lite_xl.lite_xl.appdata.xml',
             install_dir : 'share/metainfo'
         )
     endif

--- a/resources/linux/org.lite_xl.lite_xl.appdata.xml
+++ b/resources/linux/org.lite_xl.lite_xl.appdata.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>org.lite-xl.lite-xl</id>
+  <id>org.lite_xl.lite_xl</id>
   <metadata_license>MIT</metadata_license>
   <project_license>MIT</project_license>
   <name>Lite XL</name>
   <summary>A lightweight text editor written in Lua</summary>
+  <content_rating type="oars-1.0" />
 
   <description>
     <p>
@@ -25,4 +26,8 @@
   <provides>
     <binary>lite-xl</binary>
   </provides>
+
+  <releases>
+    <release version="2.0.1" date="2021-08-28" />
+  </releases>
 </component>

--- a/resources/linux/org.lite_xl.lite_xl.desktop
+++ b/resources/linux/org.lite_xl.lite_xl.desktop
@@ -6,5 +6,5 @@ Exec=lite-xl %F
 Icon=lite-xl
 Terminal=false
 StartupNotify=false
-Categories=Utility;TextEditor;Development;
+Categories=Development;IDE;
 MimeType=text/plain;

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -117,7 +117,7 @@ generate_appimage(){
   mv AppRun LiteXL.AppDir/
   # These could be symlinks but it seems they doesn't work with AppimageLauncher
   cp resources/icons/lite-xl.svg LiteXL.AppDir/
-  cp resources/linux/org.lite-xl.lite-xl.desktop LiteXL.AppDir/
+  cp resources/linux/org.lite_xl.lite_xl.desktop LiteXL.AppDir/
 
   if [[ $STATIC_BUILD == false ]]; then
     echo "Copying libraries..."


### PR DESCRIPTION
These files was already renamed recently due the addition of the AppStream compatibility, but I didn't notice [the warning][1] about using the hyphens in the application id.
The problem arose while making some work on Flatpak, so let's fix this now. Sorry for the noise.

EDIT: Added/fixed also some information required by Flatpak, it warns raising errors about missing content rating, missing release(s) tag and about multiple places on Freedesktop menu, so I removed the generic category `Utility` (Accessories menu) with its `TextEditor` subcategory and replaced with `Development;IDE`, which is the same used by Geany text editor.

[1]: https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic