### PR TITLE
Skip -psn_x_xxxxxx argument in macOS

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -448,20 +448,23 @@ function core.init()
   local project_dir_explicit = false
   local files = {}
   local delayed_error
+  local macos = rawget(_G, "MACOS")
   for i = 2, #ARGS do
-    local arg_filename = strip_trailing_slash(ARGS[i])
-    local info = system.get_file_info(arg_filename) or {}
-    if info.type == "file" then
-      local file_abs = system.absolute_path(arg_filename)
-      if file_abs then
-        table.insert(files, file_abs)
-        project_dir = file_abs:match("^(.+)[/\\].+$")
+    if not (macos and ARGS[i]:match("^-psn_[%d]+_[%d]+")) then
+      local arg_filename = strip_trailing_slash(ARGS[i])
+      local info = system.get_file_info(arg_filename) or {}
+      if info.type == "file" then
+        local file_abs = system.absolute_path(arg_filename)
+        if file_abs then
+          table.insert(files, file_abs)
+          project_dir = file_abs:match("^(.+)[/\\].+$")
+        end
+      elseif info.type == "dir" then
+        project_dir = arg_filename
+        project_dir_explicit = true
+      else
+        delayed_error = string.format("error: invalid file or directory %q", ARGS[i])
       end
-    elseif info.type == "dir" then
-      project_dir = arg_filename
-      project_dir_explicit = true
-    else
-      delayed_error = string.format("error: invalid file or directory %q", ARGS[i])
     end
   end
 


### PR DESCRIPTION
The -psn_x_xxxxxx argument appears on mac OS in some cases. Having found information about this, it was concluded that this argument is useless and it can and should be skipped. Initially, I thought that the problem appeared before 2.0, but later I discovered that it exists in earlier versions.

![image](https://user-images.githubusercontent.com/5556081/131514996-37fac3b6-f43f-495c-923b-62b4b1ebc56c.png)

This problem is not so critical (it does not affect the editor's work in any way), but it gets into the log when the editor is launched.

Thanks @Guldoman for help in solving the problem.
