### PR TITLE
MacOS update Info.plist

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,7 +83,13 @@ elif get_option('bundle') and host_machine.system() == 'darwin'
     lite_docdir = 'Contents/Resources'
     lite_datadir = 'Contents/Resources'
     install_data('resources/icons/icon.icns', install_dir : 'Contents/Resources')
-    install_data('resources/macos/Info.plist', install_dir : 'Contents')
+    configure_file(
+        input : 'resources/macos/Info.plist.in',
+        output : 'Info.plist',
+        configuration : conf_data,
+        install : true,
+        install_dir : 'Contents'
+    )
 else
     lite_bindir = 'bin'
     lite_docdir = 'share/doc/lite-xl'

--- a/resources/macos/Info.plist
+++ b/resources/macos/Info.plist
@@ -17,11 +17,13 @@
     <key>NSHighResolutionCapable</key>
     <true />
     <key>LSMinimumSystemVersion</key>
-    <string>10.11.0</string>
-    <key>NSQuitAlwaysKeepsWindows</key>
-    <false />
-    <key>NSRequiresAquaSystemAppearance</key>
-    <false />
+    <string>10.13</string>
+    <key>CFBundleSignature</key>
+    <string>lite</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+      <string>MacOSX</string>
+    </array>
     <key>NSDocumentsFolderUsageDescription</key>
     <string>To access, edit and index your projects.</string>
     <key>NSDesktopFolderUsageDescription</key>
@@ -29,7 +31,7 @@
     <key>NSDownloadsFolderUsageDescription</key>
     <string>To access, edit and index your projects.</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0</string>
+    <string>2.0.1</string>
     <key>NSHumanReadableCopyright</key>
     <string>© 2019-2021 Francesco Abbate</string>
   </dict>

--- a/resources/macos/Info.plist
+++ b/resources/macos/Info.plist
@@ -1,26 +1,36 @@
- <?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-<key>CFBundleExecutable</key>
-	<string>lite-xl</string>
-	<key>CFBundleGetInfoString</key>
-	<string>lite-xl</string>
-	<key>CFBundleIconFile</key>
-	<string>icon</string>
-	<key>CFBundleName</key>
-	<string>lite-xl</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>NSHighResolutionCapable</key>
-	<true/>
-	<key>MinimumOSVersion</key><string>10.13</string>
-	<key>NSDocumentsFolderUsageDescription</key><string>To access, edit and index your projects.</string>
-	<key>NSDesktopFolderUsageDescription</key><string>To access, edit and index your projects.</string>
-	<key>NSDownloadsFolderUsageDescription</key><string>To access, edit and index your projects.</string>
-	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>© 2019-2021 Francesco Abbate</string>
-</dict>
-</plist> 
+  <dict>
+    <key>CFBundleDisplayName</key>
+    <string>Lite XL</string>
+    <key>CFBundleExecutable</key>
+    <string>lite-xl</string>
+    <key>CFBundleGetInfoString</key>
+    <string>lite-xl</string>
+    <key>CFBundleIconFile</key>
+    <string>icon.icns</string>
+    <key>CFBundleName</key>
+    <string>Lite XL</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>NSHighResolutionCapable</key>
+    <true />
+    <key>LSMinimumSystemVersion</key>
+    <string>10.11.0</string>
+    <key>NSQuitAlwaysKeepsWindows</key>
+    <false />
+    <key>NSRequiresAquaSystemAppearance</key>
+    <false />
+    <key>NSDocumentsFolderUsageDescription</key>
+    <string>To access, edit and index your projects.</string>
+    <key>NSDesktopFolderUsageDescription</key>
+    <string>To access, edit and index your projects.</string>
+    <key>NSDownloadsFolderUsageDescription</key>
+    <string>To access, edit and index your projects.</string>
+    <key>CFBundleShortVersionString</key>
+    <string>2.0</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>© 2019-2021 Francesco Abbate</string>
+  </dict>
+</plist>

--- a/resources/macos/Info.plist.in
+++ b/resources/macos/Info.plist.in
@@ -31,7 +31,7 @@
     <key>NSDownloadsFolderUsageDescription</key>
     <string>To access, edit and index your projects.</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0.1</string>
+    <string>@PROJECT_VERSION@</string>
     <key>NSHumanReadableCopyright</key>
     <string>© 2019-2021 Francesco Abbate</string>
   </dict>


### PR DESCRIPTION
I updated the Info.plist file a little. At least it looks a little better now, but it's still worth sorting out all the arguments and adding support for types that the editor can run 100%.

Main changes:
* Now the application should be displayed as "Lite XL", not "lite-xl"
* Useless arguments have been removed or replaced with more suitable ones

I was still thinking about how to add an application call from the terminal (like the same vim) and/or an application call from the context menu, but I haven't been able to figure it out yet.

I ask all mac OS owners to test these changes if possible.