### PR TITLE
Specify the WM_CLASS of the application, used by some Linux DEs

### DIFF
--- a/resources/linux/org.lite_xl.lite_xl.desktop
+++ b/resources/linux/org.lite_xl.lite_xl.desktop
@@ -5,6 +5,6 @@ Comment=A lightweight text editor written in Lua
 Exec=lite-xl %F
 Icon=lite-xl
 Terminal=false
-StartupNotify=false
+StartupWMClass=lite-xl
 Categories=Development;IDE;
 MimeType=text/plain;


### PR DESCRIPTION
Quoting a today report:
> just want to share that the linux .desktop file is missing a StartupWMClass=lite-xl line, is it intentional?
the only effect it has for me (fedora 34, gnome) is that the instances of lite-xl don't get stacked on top of the dock icon

This is briefly explained at the bottom of this [specification][1] page (see also the `StartupNotify` section about why the removal) and more explicitly in [this answer][2].

[1]: https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html
[2]: https://askubuntu.com/questions/367396/what-does-the-startupwmclass-field-of-a-desktop-file-represent
