### PR TITLE
Make opened files point to their renamed name

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -437,8 +437,10 @@ menu:register(
 command.add(nil, {
   ["treeview:toggle"] = function()
     view.visible = not view.visible
-  end,
+  end})
 
+
+command.add(function() return view.hovered_item ~= nil end, {
   ["treeview:rename"] = function()
     local old_filename = view.hovered_item.filename
     local old_abs_filename = view.hovered_item.abs_filename


### PR DESCRIPTION
When an opened `Doc` is renamed via the `treeview` context menu, the `Doc` should also point to the new filename.

Also avoid exposing `treeview` commands in the `CommandView` when not appropriate.

Should we add a confirmation dialog when the user tries to overwrite a file?