### PR TITLE
Don't calculate column offset per-char

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -161,15 +161,13 @@ function DocView:get_col_x_offset(line, col)
   local xoffset = 0
   for _, type, text in self.doc.highlighter:each_token(line) do
     local font = style.syntax_fonts[type] or default_font
-    for char in common.utf8_chars(text) do
-      if column == col then
-        return xoffset / font:subpixel_scale()
-      end
-      xoffset = xoffset + font:get_width_subpixel(char)
-      column = column + #char
+    local remainder = math.min(col - column, #text)
+    xoffset = xoffset + font:get_width_subpixel(string.sub(text, 1, remainder))
+    column = column + remainder
+    if column == col then
+      return xoffset / font:subpixel_scale()
     end
   end
-
   return xoffset / default_font:subpixel_scale()
 end
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -283,8 +283,8 @@ end
 function DocView:on_mouse_moved(x, y, ...)
   DocView.super.on_mouse_moved(self, x, y, ...)
 
-  if self:scrollbar_overlaps_point(x, y) or self.dragging_scrollbar
-     or self:h_scrollbar_overlaps_point(x, y) or self.dragging_h_scrollbar then
+  if self.hovered_scrollbar or self.dragging_scrollbar
+     or self.hovered_h_scrollbar or self.dragging_h_scrollbar then
     self.cursor = "arrow"
   else
     self.cursor = "ibeam"


### PR DESCRIPTION
We were calling `font:get_width_subpixel` on each character. Now the entire token gets calculated at once.
This should significantly improve performance in the presence of long lines.

Note that I also removed the call to `common.utf8_chars` to obtain characters.
Should I reintroduce its functionality? If so, what should we do if we are given a column that is not at the end of a character? Should we consider to the end of the character or should we go back to the previous one?
I guess the previous implementation stopped short, and also removed any invalid characters. Is this necessary?

~This also reverts #481.~