### PR TITLE
Try to fix problem with js syntax of '/=' operator

### DIFF
--- a/data/plugins/language_js.lua
+++ b/data/plugins/language_js.lua
@@ -7,7 +7,7 @@ syntax.add {
   patterns = {
     { pattern = "//.-\n",               type = "comment"  },
     { pattern = { "/%*", "%*/" },       type = "comment"  },
-    { pattern = { '/%g', '/', '\\' },   type = "string"   },
+    { pattern = { '/[^= ]', '/', '\\' },type = "string"   },
     { pattern = { '"', '"', '\\' },     type = "string"   },
     { pattern = { "'", "'", '\\' },     type = "string"   },
     { pattern = { "`", "`", '\\' },     type = "string"   },


### PR DESCRIPTION
The operator '/=' was wrongly considered by the js syntax file as the
beginning of a regexp literal.

With this modification we modify the pattern for regexp literals to not
match expressions starting with '/='.

This doesn't seem entirely correct because apparently javascript can accept
regexp literals starting with '/=' but the rule used by the javascript
lexer is not known.