### PR TITLE
Retry `detectindent` only on save/reload

### DIFF
--- a/data/plugins/detectindent.lua
+++ b/data/plugins/detectindent.lua
@@ -151,3 +151,78 @@ function DocView:draw(...)
   return with_indent_override(self.doc, draw, self, ...)
 end
 
+
+local function set_indent_type(doc, type)
+  cache[doc] = {type = type,
+                size = cache[doc].value or config.indent_size,
+                confirmed = true}
+  doc.indent_info = cache[doc]
+end
+
+local function set_indent_type_command()
+  core.command_view:enter(
+    "Specify indent style for this file",
+    function(value) -- submit
+      local doc = core.active_view.doc
+      value = value:lower()
+      set_indent_type(doc, value == "tabs" and "hard" or "soft")
+    end,
+    function(text) -- suggest
+      return common.fuzzy_match({"tabs", "spaces"}, text)
+    end,
+    nil, -- cancel
+    function(text) -- validate
+      local t = text:lower()
+      return t == "tabs" or t == "spaces"
+    end
+  )
+end
+
+
+local function set_indent_size(doc, size)
+  cache[doc] = {type = cache[doc].type or config.tab_type,
+                size = size,
+                confirmed = true}
+  doc.indent_info = cache[doc]
+end
+
+local function set_indent_size_command()
+  core.command_view:enter(
+    "Specify indent size for current file",
+    function(value) -- submit
+      local value = math.floor(tonumber(value))
+      local doc = core.active_view.doc
+      set_indent_size(doc, value)
+    end,
+    nil, -- suggest
+    nil, -- cancel
+    function(value) -- validate
+      local value = tonumber(value)
+      return value ~= nil and value >= 1
+    end
+  )
+end
+
+
+command.add("core.docview", {
+  ["indent:set-file-indent-type"] = set_indent_type_command,
+  ["indent:set-file-indent-size"] = set_indent_size_command
+})
+
+
+command.add(function()
+    return core.active_view:is(DocView)
+           and cache[core.active_view.doc]
+           and cache[core.active_view.doc].type == "soft"
+  end, {
+  ["indent:switch-file-to-tabs-indentation"] = function() set_indent_type(core.active_view.doc, "hard") end
+})
+
+
+command.add(function()
+    return core.active_view:is(DocView)
+           and cache[core.active_view.doc]
+           and cache[core.active_view.doc].type == "hard"
+  end, {
+  ["indent:switch-file-to-spaces-indentation"] = function() set_indent_type(core.active_view.doc, "soft") end
+})

--- a/data/plugins/detectindent.lua
+++ b/data/plugins/detectindent.lua
@@ -114,8 +114,11 @@ function Doc:new(...)
   if not cache[self].confirmed then
     core.add_thread(function ()
       while not cache[self].confirmed do
-        update_cache(self)
-        coroutine.yield(1)
+        if cache[self].need_update then
+          update_cache(self)
+          cache[self].need_update = false
+        end
+        coroutine.yield()
       end
     end, self)
   end
@@ -124,7 +127,7 @@ end
 local clean = Doc.clean
 function Doc:clean(...)
   clean(self, ...)
-  update_cache(self)
+  cache[self].need_update = true
 end
 
 

--- a/data/plugins/detectindent.lua
+++ b/data/plugins/detectindent.lua
@@ -102,6 +102,11 @@ end
 local function update_cache(doc)
   local type, size, score = detect_indent_stat(doc)
   local score_threshold = 4
+  if score < score_threshold then
+    -- use default values
+    type = config.tab_type
+    size = config.indent_size
+  end
   cache[doc] = { type = type, size = size, confirmed = (score >= score_threshold) }
   doc.indent_info = cache[doc]
 end

--- a/data/plugins/detectindent.lua
+++ b/data/plugins/detectindent.lua
@@ -116,23 +116,14 @@ local new = Doc.new
 function Doc:new(...)
   new(self, ...)
   update_cache(self)
-  if not cache[self].confirmed then
-    core.add_thread(function ()
-      while not cache[self].confirmed do
-        if cache[self].need_update then
-          update_cache(self)
-          cache[self].need_update = false
-        end
-        coroutine.yield()
-      end
-    end, self)
-  end
 end
 
 local clean = Doc.clean
 function Doc:clean(...)
   clean(self, ...)
-  cache[self].need_update = true
+  if not cache[self].confirmed then
+    update_cache(self)
+  end
 end
 
 


### PR DESCRIPTION
If `detectindent` couldn't detect the indent style of a file, it would retry every second. With files with long lines this can cause stutter.
Now `detectindent` retries only on save/reload.

Also respect user preferences if the detection fails.