### PR TITLE
Fix `treeview:open-in-system` command on Windows

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -536,7 +536,7 @@ command.add(function() return view.hovered_item ~= nil end, {
     local hovered_item = view.hovered_item
 
     if PLATFORM == "Windows" then
-      system.exec("start " .. hovered_item.abs_filename)
+      system.exec(string.format("start \"\" %q", hovered_item.abs_filename))
     elseif string.find(PLATFORM, "Mac") then
       system.exec(string.format("open %q", hovered_item.abs_filename))
     elseif PLATFORM == "Linux" then


### PR DESCRIPTION
The first argument of `START` is the title for the `CMD` window.

I think this could be added to `fix-2.0.2`.

Fixes #500.