### PR TITLE
Fix checking if sibling is locked when removing `View`s

### DIFF
--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -143,7 +143,7 @@ function Node:remove_view(root, view)
     local is_a = (parent.a == self)
     local other = parent[is_a and "b" or "a"]
     local locked_size_x, locked_size_y = other:get_locked_size()
-    if locked_size_x or locked_size_y then
+    if (parent.type == "hsplit" and locked_size_x or locked_size_y) then
       self.views = {}
       self:add_view(EmptyView())
     else

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -142,7 +142,8 @@ function Node:remove_view(root, view)
     local parent = self:get_parent_node(root)
     local is_a = (parent.a == self)
     local other = parent[is_a and "b" or "a"]
-    if other:get_locked_size() then
+    local locked_size_x, locked_size_y = other:get_locked_size()
+    if locked_size_x or locked_size_y then
       self.views = {}
       self:add_view(EmptyView())
     else

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -143,8 +143,13 @@ function Node:remove_view(root, view)
     local is_a = (parent.a == self)
     local other = parent[is_a and "b" or "a"]
     local locked_size_x, locked_size_y = other:get_locked_size()
-    if self.is_primary_node
-       or (parent.type == "hsplit" and locked_size_x or locked_size_y) then
+    local locked_size
+    if parent.type == "hsplit" then
+      locked_size = locked_size_x
+    else
+      locked_size = locked_size_y
+    end
+    if self.is_primary_node or locked_size then
       self.views = {}
       self:add_view(EmptyView())
     else

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -143,7 +143,8 @@ function Node:remove_view(root, view)
     local is_a = (parent.a == self)
     local other = parent[is_a and "b" or "a"]
     local locked_size_x, locked_size_y = other:get_locked_size()
-    if (parent.type == "hsplit" and locked_size_x or locked_size_y) then
+    if self.is_primary_node
+       or (parent.type == "hsplit" and locked_size_x or locked_size_y) then
       self.views = {}
       self:add_view(EmptyView())
     else


### PR DESCRIPTION
We only checked if sibling was locked in the `x` direction. This fixes the broken layout found in lite-xl/console#4.