### PR TITLE
Add option to disable scrolling past the end

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -5,6 +5,7 @@ config.fps = 60
 config.max_log_items = 80
 config.message_timeout = 5
 config.mouse_wheel_scroll = 50 * SCALE
+config.scroll_past_end = true
 config.file_size_limit = 10
 config.ignore_files = "^%."
 config.symbol_pattern = "[%a_][%w_]*"

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -98,6 +98,9 @@ end
 
 
 function DocView:get_scrollable_size()
+  if not config.scroll_past_end then
+    return self:get_line_height() * (#self.doc.lines) + style.padding.y * 2
+  end
   return self:get_line_height() * (#self.doc.lines - 1) + self.size.y
 end
 


### PR DESCRIPTION
As proposed in #560, this adds the config option `scroll_past_end`, enabled by default.