### PR TITLE
Sanitize selections after redo

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -301,7 +301,8 @@ local function pop_undo(self, undo_stack, redo_stack, modified)
     local line1, col1, line2, col2 = table.unpack(cmd)
     self:raw_remove(line1, col1, line2, col2, redo_stack, cmd.time)
   elseif cmd.type == "selection" then
-    self.selections = { unpack(cmd) }
+    self.selections = { table.unpack(cmd) }
+    self:sanitize_selection()
   end
 
   modified = modified or (cmd.type ~= "selection")


### PR DESCRIPTION
In some cases the restored selection was out of bounds.
This can be cherry-picked for `2.0.3`.