### PR TITLE
Fixed negative pens.

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -236,7 +236,7 @@ float ren_draw_text(RenFont *font, const char *text, float x, int y, RenColor co
     unsigned int codepoint, r, g, b;
     text = utf8_to_codepoint(text, &codepoint);
     int bitmap_index = font->subpixel ? (int)(fmod(pen_x, 1.0) * SUBPIXEL_BITMAPS_CACHED) : 0;
-    GlyphSet* set = font_get_glyphset(font, codepoint, bitmap_index);
+    GlyphSet* set = font_get_glyphset(font, codepoint, bitmap_index + (bitmap_index < 0 ? SUBPIXEL_BITMAPS_CACHED : 0));
     GlyphMetric* metric = &set->metrics[codepoint % 256];
     int start_x = floor(pen_x) + metric->bitmap_left, end_x = metric->x1 - metric->x0 + pen_x;
     int glyph_end = metric->x1, glyph_start = metric->x0;


### PR DESCRIPTION
Wraps bitmaps back around so that they're functional.