### PR TITLE
Remove bash dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,6 @@ jobs:
         sh scripts/lhelper.sh --debug
     - name: Build
       run: |
-        sh --version
         sh scripts/build.sh --debug --forcefallback
     - name: Package
       if: ${{ matrix.config.cc == 'gcc' }}
@@ -99,7 +98,6 @@ jobs:
     - name: System Information
       run: |
         system_profiler SPSoftwareDataType
-        sh --version
         gcc -v
         xcodebuild -version
     - name: Set Environment Variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
         sudo apt-get install -qq ninja-build
         pip3 install meson
     - name: Package
-      shell: bash
-      run: bash scripts/package.sh --version ${GITHUB_REF##*/} --debug --source
+      shell: sh
+      run: sh scripts/package.sh --version ${GITHUB_REF##*/} --debug --source
     - uses: actions/upload-artifact@v2
       with:
         name: Source Code Tarball
@@ -64,22 +64,22 @@ jobs:
       run: sudo apt-get update
     - name: Install Dependencies
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/install-dependencies.sh --debug
+      run: sh scripts/install-dependencies.sh --debug
     - name: Install Release Dependencies
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: |
-        bash scripts/install-dependencies.sh --debug --lhelper
-        bash scripts/lhelper.sh --debug
+        sh scripts/install-dependencies.sh --debug --lhelper
+        sh scripts/lhelper.sh --debug
     - name: Build
       run: |
-        bash --version
-        bash scripts/build.sh --debug --forcefallback
+        sh --version
+        sh scripts/build.sh --debug --forcefallback
     - name: Package
       if: ${{ matrix.config.cc == 'gcc' }}
-      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary
+      run: sh scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary
     - name: AppImage
       if: ${{ matrix.config.cc == 'gcc' && startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/appimage.sh --nobuild --version ${INSTALL_REF}
+      run: sh scripts/appimage.sh --nobuild --version ${INSTALL_REF}
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       if: ${{ matrix.config.cc == 'gcc' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
     - name: System Information
       run: |
         system_profiler SPSoftwareDataType
-        bash --version
+        sh --version
         gcc -v
         xcodebuild -version
     - name: Set Environment Variables
@@ -114,16 +114,16 @@ jobs:
         python-version: 3.9
     - name: Install Dependencies
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/install-dependencies.sh --debug
+      run: sh scripts/install-dependencies.sh --debug
     - name: Install Release Dependencies
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: |
-        bash scripts/install-dependencies.sh --debug --lhelper
-        bash scripts/lhelper.sh --debug
+        sh scripts/install-dependencies.sh --debug --lhelper
+        sh scripts/lhelper.sh --debug
     - name: Build
       run: |
-        bash --version
-        bash scripts/build.sh --bundle --debug --forcefallback
+        sh --version
+        sh scripts/build.sh --bundle --debug --forcefallback
     - name: Error Logs
       if: failure()
       run: |
@@ -132,9 +132,9 @@ jobs:
         tar czvf ${INSTALL_NAME}.tar.gz ${INSTALL_NAME}
 #   - name: Package
 #     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-#     run:  bash scripts/package.sh --version ${INSTALL_REF} --debug --addons
+#     run:  sh scripts/package.sh --version ${INSTALL_REF} --debug --addons
     - name: Create DMG Image
-      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --dmg
+      run: sh scripts/package.sh --version ${INSTALL_REF} --debug --addons --dmg
     - name: Upload DMG Image
       uses: actions/upload-artifact@v2
       with:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you compile Lite XL yourself, it is recommended to use the script
 `build-packages.sh`:
 
 ```sh
-bash build-packages.sh -h
+sh build-packages.sh -h
 ```
 
 The script will run Meson and create a tar compressed archive with the application or,

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 if [ ! -e "src/api/api.h" ]; then

--- a/scripts/appdmg.sh
+++ b/scripts/appdmg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -ex
 
 if [ ! -e "src/api/api.h" ]; then
@@ -27,4 +27,4 @@ cat > lite-xl-dmg.json << EOF
   ]
 }
 EOF
-~/node_modules/appdmg/bin/appdmg.js lite-xl-dmg.json "$(pwd)/$1.dmg"
+appdmg lite-xl-dmg.json "$(pwd)/$1.dmg"

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/bin/sh
 set -ex
 
 if [ ! -e "src/api/api.h" ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,7 @@ if [ ! -e "src/api/api.h" ]; then
   echo "Please run this script from the root directory of Lite XL."; exit 1
 fi
 
-source scripts/common.sh
+. scripts/common.sh
 
 show_help() {
   echo

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 if [ ! -e "src/api/api.h" ]; then

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/scripts/innosetup/innosetup.sh
+++ b/scripts/innosetup/innosetup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 if [ ! -e "src/api/api.h" ]; then

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -ex
 
 if [ ! -e "src/api/api.h" ]; then
@@ -53,9 +53,9 @@ main() {
     pip3 install meson
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     if [[ $lhelper == true ]]; then
-      brew install bash md5sha1sum ninja
+      brew install md5sha1sum ninja
     else
-      brew install bash ninja sdl2
+      brew install ninja sdl2
     fi
     pip3 install meson
     cd ~; npm install appdmg; cd -

--- a/scripts/lhelper.sh
+++ b/scripts/lhelper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 show_help() {

--- a/scripts/lhelper.sh
+++ b/scripts/lhelper.sh
@@ -48,7 +48,7 @@ main() {
     # FIXME: This should be set in ~/.bash_profile if not using CI
     # export PATH="${HOME}/.local/bin:${PATH}"
     mkdir -p "${lhelper_prefix}/bin"
-    pushd lhelper; bash install "${lhelper_prefix}"; popd
+    pushd lhelper; sh install "${lhelper_prefix}"; popd
 
     if [[ "$OSTYPE" == "darwin"* ]]; then
       CC=clang CXX=clang++ lhelper create lite-xl -n

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 if [ ! -e "src/api/api.h" ]; then

--- a/scripts/repackage.sh
+++ b/scripts/repackage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # strip-components is normally set to 1 to strip the initial "data" from the
 # directory path.
@@ -41,7 +41,7 @@ while [ ! -z ${1+x} ]; do
   esac
 done
 
-wget="wget --retry-connrefused --waitretry=1 --read-timeout=20 --no-check-certificate" 
+wget="wget --retry-connrefused --waitretry=1 --read-timeout=20 --no-check-certificate"
 
 workdir=".repackage"
 rm -fr "$workdir" && mkdir "$workdir" && pushd "$workdir"

--- a/scripts/run-local
+++ b/scripts/run-local
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -o errexit
 


### PR DESCRIPTION
Bash is not the default shell on some system, but sh is almost always there.
On OSX, I was able to build and package without it.
However, I need to check on Windows and Linux if this PR breaks something.