### PR TITLE
Manage unsaved named files

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -88,6 +88,15 @@ command.add(nil, {
     core.root_view:open_doc(core.open_doc())
   end,
 
+  ["core:new-named-doc"] = function()
+    core.command_view:enter(
+      "File name",
+      function(text)
+        core.root_view:open_doc(core.open_doc(text))
+      end
+    )
+  end,
+
   ["core:open-file"] = function()
     local view = core.active_view
     if view.doc and view.doc.abs_filename then

--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -331,6 +331,31 @@ function common.relative_path(ref_dir, dir)
 end
 
 
+function common.absolute_path(path)
+  local abs_path = system.absolute_path(path)
+  if not abs_path then
+    path = common.normalize_path(path)
+    if path:match("^" .. PATHSEP) then
+      return path
+    end
+    local split_path = split_on_slash(path)
+    for i = #split_path, 1, -1 do
+      if path ~= PATHSEP then
+        path = common.dirname(path) or "."
+        abs_path = system.absolute_path(path)
+      else
+        abs_path = path
+      end
+      if abs_path then
+        abs_path = abs_path .. PATHSEP .. table.concat(split_path, PATHSEP, i)
+        break
+      end
+    end
+  end
+  return abs_path
+end
+
+
 function common.mkdirp(path)
   local stat = system.get_file_info(path)
   if stat and stat.type then

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -55,6 +55,7 @@ end
 function Doc:set_filename(filename, abs_filename)
   self.filename = filename
   self.abs_filename = abs_filename
+  self:reset_syntax()
 end
 
 
@@ -91,7 +92,6 @@ function Doc:save(filename, abs_filename)
   fp:close()
   self:set_filename(filename, abs_filename)
   self.new_file = false
-  self:reset_syntax()
   self:clean()
 end
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -442,23 +442,20 @@ function core.init()
   local project_dir = core.recent_projects[1] or "."
   local project_dir_explicit = false
   local files = {}
-  local delayed_error
   for i = 2, #ARGS do
     local arg_filename = strip_trailing_slash(ARGS[i])
     local info = system.get_file_info(arg_filename) or {}
-    if info.type == "file" then
-      local file_abs = system.absolute_path(arg_filename)
-      if file_abs then
-        table.insert(files, file_abs)
-        project_dir = file_abs:match("^(.+)[/\\].+$")
-      end
-    elseif info.type == "dir" then
+    if info.type == "dir" then
       project_dir = arg_filename
       project_dir_explicit = true
     else
       -- on macOS we can get an argument like "-psn_0_52353" that we just ignore.
       if not ARGS[i]:match("^-psn") then
-        delayed_error = string.format("error: invalid file or directory %q", ARGS[i])
+        local file_abs = common.absolute_path(arg_filename)
+        if file_abs then
+          table.insert(files, file_abs)
+          project_dir = file_abs:match("^(.+)[/\\].+$")
+        end
       end
     end
   end
@@ -522,10 +519,6 @@ function core.init()
 
   for _, filename in ipairs(files) do
     core.root_view:open_doc(core.open_doc(filename))
-  end
-
-  if delayed_error then
-    core.error(delayed_error)
   end
 
   if not plugins_success or got_user_error or got_project_error then


### PR DESCRIPTION
With this PR, filenames passed as arguments are always opened, even if the file doesn't exist.

Also added a command to create a new named unsaved file.

This needs testing for edge cases with paths. Mainly on Windows.

Should we verify names passed to the `core:new-named-doc` command?

Also while testing I noticed that the editor crashes when trying to open files in paths like `/aaaa` (to reproduce in master the file must exist; with this PR anything that is not a directory causes the crash).
This is caused by `project_dir = file_abs:match("^(.+)[/\\].+$")` in `core.init` that results in a `nil` `project_dir` that `system.absolute_path(project_dir)` doesn't like.
I'll fix this in the next few days if no one does it before.

This could be picked for 2.0.3 if someone tests this extensively.