### PR TITLE
Use plain search by default in `search.find`

### DIFF
--- a/data/core/doc/search.lua
+++ b/data/core/doc/search.lua
@@ -43,6 +43,7 @@ end
 
 function search.find(doc, line, col, text, opt)
   doc, line, col, text, opt = init_args(doc, line, col, text, opt)
+  local plain = not opt.pattern
   local pattern = text
   local search_func = string.find
   if opt.regex then
@@ -60,9 +61,9 @@ function search.find(doc, line, col, text, opt)
     end
     local s, e
     if opt.reverse then
-      s, e = rfind(search_func, line_text, pattern, col - 1)
+      s, e = rfind(search_func, line_text, pattern, col - 1, plain)
     else
-      s, e = search_func(line_text, pattern, col)
+      s, e = search_func(line_text, pattern, col, plain)
     end
     if s then
       return line, s, line, e + 1


### PR DESCRIPTION
With 3a1274fd08dfc3d6a9c3a0e659e3bb856ed791c0 I introduced a regression by not specifying to `string.find` that we want a plain search.
This caused `find-replace:find` to use a pattern search instead of a plain one.