### PR TITLE
Use `header` to get syntax only when provided

### DIFF
--- a/data/core/syntax.lua
+++ b/data/core/syntax.lua
@@ -22,7 +22,7 @@ end
 
 function syntax.get(filename, header)
   return find(filename, "files")
-      or find(header, "headers")
+      or (header and find(header, "headers"))
       or plain_text_syntax
 end
 


### PR DESCRIPTION
Fixes #630.

When `syntax.get` is called with only one parameter and the first `find` fails, it tried to use `nil` to check `headers`, making `common.match_pattern` throw an error.