### PR TITLE
Don't insert `nil` in highlighter lines table

### DIFF
--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -52,7 +52,7 @@ end
 function Highlighter:insert_notify(line, n)
   self:invalidate(line)
   for i = 1, n do
-    table.insert(self.lines, line, nil)
+    table.insert(self.lines, line, false)
   end
 end
 


### PR DESCRIPTION
When `highlighter:insert_notify` was called, a hole in the array was created.
If another call to `highlighter:insert_notify` happened before the hole was filled, a `Position out of bounds` error could have been raised.

Fixes #653.