### PR TITLE
Soft Line Wrapping

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -549,29 +549,29 @@ local commands = {
 
 
 local translations = {
-  ["previous-char"] = translate.previous_char,
-  ["next-char"] = translate.next_char,
-  ["previous-word-start"] = translate.previous_word_start,
-  ["next-word-end"] = translate.next_word_end,
-  ["previous-block-start"] = translate.previous_block_start,
-  ["next-block-end"] = translate.next_block_end,
-  ["start-of-doc"] = translate.start_of_doc,
-  ["end-of-doc"] = translate.end_of_doc,
-  ["start-of-line"] = translate.start_of_line,
-  ["end-of-line"] = translate.end_of_line,
-  ["start-of-word"] = translate.start_of_word,
-  ["start-of-indentation"] = translate.start_of_indentation,
-  ["end-of-word"] = translate.end_of_word,
-  ["previous-line"] = DocView.translate.previous_line,
-  ["next-line"] = DocView.translate.next_line,
-  ["previous-page"] = DocView.translate.previous_page,
-  ["next-page"] = DocView.translate.next_page,
+  ["previous-char"] = translate,
+  ["next-char"] = translate,
+  ["previous-word-start"] = translate,
+  ["next-word-end"] = translate,
+  ["previous-block-start"] = translate,
+  ["next-block-end"] = translate,
+  ["start-of-doc"] = translate,
+  ["end-of-doc"] = translate,
+  ["start-of-line"] = translate,
+  ["end-of-line"] = translate,
+  ["start-of-word"] = translate,
+  ["start-of-indentation"] = translate,
+  ["end-of-word"] = translate,
+  ["previous-line"] = DocView.translate,
+  ["next-line"] = DocView.translate,
+  ["previous-page"] = DocView.translate,
+  ["next-page"] = DocView.translate,
 }
 
-for name, fn in pairs(translations) do
-  commands["doc:move-to-" .. name] = function() doc():move_to(fn, dv()) end
-  commands["doc:select-to-" .. name] = function() doc():select_to(fn, dv()) end
-  commands["doc:delete-to-" .. name] = function() doc():delete_to(fn, dv()) end
+for name, obj in pairs(translations) do
+  commands["doc:move-to-" .. name] = function() doc():move_to(obj[name:gsub("-", "_")], dv()) end
+  commands["doc:select-to-" .. name] = function() doc():select_to(obj[name:gsub("-", "_")], dv()) end
+  commands["doc:delete-to-" .. name] = function() doc():delete_to(obj[name:gsub("-", "_")], dv()) end
 end
 
 commands["doc:move-to-previous-char"] = function()

--- a/data/core/commandview.lua
+++ b/data/core/commandview.lua
@@ -243,6 +243,7 @@ function CommandView:draw_line_gutter(idx, x, y)
   x = x + style.padding.x
   renderer.draw_text(self:get_font(), self.label, x, y + yoffset, color)
   core.pop_clip_rect()
+  return self:get_line_height()
 end
 
 

--- a/data/core/commandview.lua
+++ b/data/core/commandview.lua
@@ -56,8 +56,8 @@ function CommandView:get_name()
 end
 
 
-function CommandView:get_line_screen_position()
-  local x = CommandView.super.get_line_screen_position(self, 1)
+function CommandView:get_line_screen_position(line, col)
+  local x = CommandView.super.get_line_screen_position(self, 1, col)
   local _, y = self:get_content_offset()
   local lh = self:get_line_height()
   return x, y + (self.size.y - lh) / 2

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -212,11 +212,12 @@ end
 
 
 function DocView:scroll_to_make_visible(line, col)
+  local ox, oy = self:get_content_offset()
   local _, min = self:get_line_screen_position(line - 1)
-  local _, y2 = self:get_line_screen_position(line + 1)
+  local _, y2 = self:get_line_screen_position(line + 2)
   local max = y2 - self.size.y
-  self.scroll.to.y = math.min(self.scroll.to.y, min)
-  self.scroll.to.y = math.max(self.scroll.to.y, max)
+  self.scroll.to.y = math.min(self.scroll.to.y, min - oy)
+  self.scroll.to.y = math.max(self.scroll.to.y, max - oy)
   local gw = self:get_gutter_width()
   local xoffset = self:get_col_x_offset(line, col)
   local xmargin = 3 * self:get_font():get_width(' ')

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -336,7 +336,7 @@ function DocView:draw_caret(x, y)
     renderer.draw_rect(x, y, style.caret_width, lh, style.caret)
 end
 
-function DocView:draw_line_body(idx, x, y)
+function DocView:draw_line_body(line, x, y)
   -- draw highlight if any selection ends on this line
   local draw_highlight = false
   local hcl = config.highlight_current_line

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -121,13 +121,17 @@ function DocView:get_gutter_width()
 end
 
 
-function DocView:get_line_screen_position(idx)
+function DocView:get_line_screen_position(line, col)
   local x, y = self:get_content_offset()
   local lh = self:get_line_height()
   local gw = self:get_gutter_width()
-  return x + gw, y + (idx-1) * lh + style.padding.y
+  y = y + (line-1) * lh + style.padding.y
+  if col then
+    return x + gw + self:get_col_x_offset(line, col), y
+  else
+    return x + gw, y
+  end
 end
-
 
 function DocView:get_line_text_y_offset()
   local lh = self:get_line_height()
@@ -198,8 +202,8 @@ end
 function DocView:scroll_to_line(line, ignore_if_visible, instant)
   local min, max = self:get_visible_line_range()
   if not (ignore_if_visible and line > min and line < max) then
-    local lh = self:get_line_height()
-    self.scroll.to.y = math.max(0, lh * (line - 1) - self.size.y / 2)
+    local x, y = self:get_line_screen_position(line)
+    self.scroll.to.y = math.max(0, y - self.size.y / 2)
     if instant then
       self.scroll.y = self.scroll.to.y
     end
@@ -208,8 +212,9 @@ end
 
 
 function DocView:scroll_to_make_visible(line, col)
-  local min = self:get_line_height() * (line - 1)
-  local max = self:get_line_height() * (line + 2) - self.size.y
+  local _, min = self:get_line_screen_position(line - 1)
+  local _, y2 = self:get_line_screen_position(line + 1)
+  local max = y2 - self.size.y
   self.scroll.to.y = math.min(self.scroll.to.y, min)
   self.scroll.to.y = math.max(self.scroll.to.y, max)
   local gw = self:get_gutter_width()
@@ -314,14 +319,15 @@ function DocView:draw_line_highlight(x, y)
 end
 
 
-function DocView:draw_line_text(idx, x, y)
+function DocView:draw_line_text(line, x, y)
   local default_font = self:get_font()
   local tx, ty = x, y + self:get_line_text_y_offset()
-  for _, type, text in self.doc.highlighter:each_token(idx) do
+  for _, type, text in self.doc.highlighter:each_token(line) do
     local color = style.syntax[type]
     local font = style.syntax_fonts[type] or default_font
     tx = renderer.draw_text(font, text, tx, ty, color)
   end
+  return self:get_line_height()
 end
 
 function DocView:draw_caret(x, y)
@@ -352,14 +358,14 @@ function DocView:draw_line_body(idx, x, y)
   end
 
   -- draw selection if it overlaps this line
+  local lh = self:get_line_height()
   for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do
-    if idx >= line1 and idx <= line2 then
-      local text = self.doc.lines[idx]
-      if line1 ~= idx then col1 = 1 end
-      if line2 ~= idx then col2 = #text + 1 end
-      local x1 = x + self:get_col_x_offset(idx, col1)
-      local x2 = x + self:get_col_x_offset(idx, col2)
-      local lh = self:get_line_height()
+    if line >= line1 and line <= line2 then
+      local text = self.doc.lines[line]
+      if line1 ~= line then col1 = 1 end
+      if line2 ~= line then col2 = #text + 1 end
+      local x1 = x + self:get_col_x_offset(line, col1)
+      local x2 = x + self:get_col_x_offset(line, col2)
       if x1 ~= x2 then
         renderer.draw_rect(x1, y, x2 - x1, lh, style.selection)
       end
@@ -367,20 +373,22 @@ function DocView:draw_line_body(idx, x, y)
   end
 
   -- draw line's text
-  self:draw_line_text(idx, x, y)
+  return self:draw_line_text(line, x, y)
 end
 
 
-function DocView:draw_line_gutter(idx, x, y, width)
+function DocView:draw_line_gutter(line, x, y, width)
   local color = style.line_number
   for _, line1, _, line2 in self.doc:get_selections(true) do
-    if idx >= line1 and idx <= line2 then
+    if line >= line1 and line <= line2 then
       color = style.line_number2
       break
     end
   end
   x = x + style.padding.x
-  common.draw_text(self:get_font(), color, idx, "right", x, y, width,  self:get_line_height())
+  local lh = self:get_line_height()
+  common.draw_text(self:get_font(), color, line, "right", x, y + yoffset, width, lh)
+  return lh
 end
 
 
@@ -394,8 +402,7 @@ function DocView:draw_overlay()
       and system.window_has_focus() then
         if config.disable_blink
         or (core.blink_timer - core.blink_start) % T < T / 2 then
-          local x, y = self:get_line_screen_position(line)
-          self:draw_caret(x + self:get_col_x_offset(line, col), y)
+          self:draw_caret(self:get_line_screen_position(line, col))
         end
       end
     end
@@ -413,8 +420,7 @@ function DocView:draw()
   local x, y = self:get_line_screen_position(minline)
   local gw, gpad = self:get_gutter_width()
   for i = minline, maxline do
-    self:draw_line_gutter(i, self.position.x, y, gpad and gw - gpad or gw)
-    y = y + lh
+    y = y + (self:draw_line_gutter(i, self.position.x, y, gpad and gw - gpad or gw) or lh)
   end
 
   local pos = self.position
@@ -423,8 +429,7 @@ function DocView:draw()
   -- right side it is redundant with the Node's clip.
   core.push_clip_rect(pos.x + gw, pos.y, self.size.x - gw, self.size.y)
   for i = minline, maxline do
-    self:draw_line_body(i, x, y)
-    y = y + lh
+    y = y + (self:draw_line_body(i, x, y) or lh)
   end
   self:draw_overlay()
   core.pop_clip_rect()

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -214,10 +214,9 @@ end
 
 function DocView:scroll_to_make_visible(line, col)
   local ox, oy = self:get_content_offset()
-  local _, min = self:get_line_screen_position(line - 1)
-  local _, max = self:get_line_screen_position(line + 2)
-  self.scroll.to.y = math.max(self.scroll.to.y, min - oy - self.size.y)
-  self.scroll.to.y = math.min(self.scroll.to.y, max - oy)
+  local _, ly = self:get_line_screen_position(line, col)
+  local lh = self:get_line_height()
+  self.scroll.to.y = common.clamp(self.scroll.to.y, ly - oy - self.size.y + lh * 2, ly - oy - lh)
   local gw = self:get_gutter_width()
   local xoffset = self:get_col_x_offset(line, col)
   local xmargin = 3 * self:get_font():get_width(' ')

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -203,7 +203,8 @@ function DocView:scroll_to_line(line, ignore_if_visible, instant)
   local min, max = self:get_visible_line_range()
   if not (ignore_if_visible and line > min and line < max) then
     local x, y = self:get_line_screen_position(line)
-    self.scroll.to.y = math.max(0, y - self.size.y / 2)
+    local ox, oy = self:get_content_offset()
+    self.scroll.to.y = math.max(0, y - oy - self.size.y / 2)
     if instant then
       self.scroll.y = self.scroll.to.y
     end
@@ -214,10 +215,9 @@ end
 function DocView:scroll_to_make_visible(line, col)
   local ox, oy = self:get_content_offset()
   local _, min = self:get_line_screen_position(line - 1)
-  local _, y2 = self:get_line_screen_position(line + 2)
-  local max = y2 - self.size.y
-  self.scroll.to.y = math.min(self.scroll.to.y, min - oy)
-  self.scroll.to.y = math.max(self.scroll.to.y, max - oy)
+  local _, max = self:get_line_screen_position(line + 2)
+  self.scroll.to.y = math.max(self.scroll.to.y, min - oy - self.size.y)
+  self.scroll.to.y = math.min(self.scroll.to.y, max - oy)
   local gw = self:get_gutter_width()
   local xoffset = self:get_col_x_offset(line, col)
   local xmargin = 3 * self:get_font():get_width(' ')

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -6,13 +6,13 @@ local Doc = require "core.doc"
 local style = require "core.style"
 local config = require "core.config"
 local command = require "core.command"
+local keymap = require "core.keymap"
 local translate = require "core.doc.translate"
 
-local LineWrapping = { mode = "letter", width_override = 150 }
+local LineWrapping = { mode = "letter", width_override = nil }
 
--- 
-function LineWrapping:compute_line_breaks(doc, default_font, line, width, mode)
-  width = self.width_override or width
+-- Computes the breaks for a given line, width and mode.
+function LineWrapping.compute_line_breaks(doc, default_font, line, width, mode)
   local xoffset, last_i, i = 0, 1, 1
   local splits = { 1 }
   for _, type, text in doc.highlighter:each_token(line) do
@@ -39,29 +39,47 @@ end
 -- breaks are held in a single table that contains n*2 elements, where n is the amount of line breaks.
 -- each element represents line and column of the break. line_offset will check from the specified line
 -- if the first line has not changed breaks, it will stop there.
-function LineWrapping:reconstruct_breaks(doc, default_font, width, line_offset)
+function LineWrapping.reconstruct_breaks(doc, default_font, width, line_offset)
   -- list of line/columns
-  doc.wrapped_lines = { }
-  for i = line_offset or 1, #doc.lines do
-    for k, col in ipairs(self:compute_line_breaks(doc, default_font, i, width)) do
-      table.insert(doc.wrapped_lines, i)
-      table.insert(doc.wrapped_lines, col)
+  if width ~= math.huge then
+    doc.wrapped_lines = { }
+    doc.wrapped_line_to_idx = { }
+    doc.wrapped_settings = { ["width"] = width, ["font"] = default_font }
+    for i = line_offset or 1, #doc.lines do
+      for k, col in ipairs(LineWrapping.compute_line_breaks(doc, default_font, i, width)) do
+        table.insert(doc.wrapped_lines, i)
+        table.insert(doc.wrapped_lines, col)
+      end
     end
-  end
-  -- list of indices for wrapped_lines, that are based on original line number
-  -- holds the index to the first in the wrapped_lines list
-  doc.wrapped_line_to_idx = { }
-  local last_wrap = nil
-  for i = 1, #doc.wrapped_lines, 2 do
-    if not last_wrap or last_wrap ~= doc.wrapped_lines[i] then
-      table.insert(doc.wrapped_line_to_idx, (i + 1) / 2)
-      last_wrap = doc.wrapped_lines[i]
+    -- list of indices for wrapped_lines, that are based on original line number
+    -- holds the index to the first in the wrapped_lines list
+    local last_wrap = nil
+    for i = 1, #doc.wrapped_lines, 2 do
+      if not last_wrap or last_wrap ~= doc.wrapped_lines[i] then
+        table.insert(doc.wrapped_line_to_idx, (i + 1) / 2)
+        last_wrap = doc.wrapped_lines[i]
+      end
     end
+  else
+    doc.wrapped_lines = nil
+    doc.wrapped_line_to_idx = nil
+    doc.wrapped_settings = nil
   end
 end
 
-function LineWrapping:get_idx_line_col(doc, idx)
-  if not doc.wrapped_lines then 
+function LineWrapping.update_breaks(doc, line)
+  
+end
+
+function LineWrapping.update_docview_breaks(docview)
+  local width = LineWrapping.width_override or (docview.size.x - docview:get_gutter_width())
+  if (not docview.doc.wrapped_settings or docview.doc.wrapped_settings.width == nil or width ~= docview.doc.wrapped_settings.width) then
+    LineWrapping.reconstruct_breaks(docview.doc, docview:get_font(), width)
+  end
+end
+
+local function get_idx_line_col(doc, idx)
+  if not doc.wrapped_settings then 
     if idx > #doc.lines then return #doc.lines, #doc.lines[#doc.lines] + 1 end
     return idx, 1 
   end
@@ -70,8 +88,8 @@ function LineWrapping:get_idx_line_col(doc, idx)
   return doc.wrapped_lines[offset], doc.wrapped_lines[offset + 1]
 end
 
-function LineWrapping:get_idx_line_length(doc, idx)
-  if not doc.wrapped_lines then 
+local function get_idx_line_length(doc, idx)
+  if not doc.wrapped_settings then 
     if idx > #doc.lines then return #doc.lines[#doc.lines] + 1 end
     return #doc.lines[idx]
   end
@@ -84,12 +102,17 @@ function LineWrapping:get_idx_line_length(doc, idx)
   end
 end
 
+local function get_total_wrapped_lines(doc)
+  if not doc.wrapped_settings then return #doc.lines end
+  return #doc.wrapped_lines / 2
+end
+
 -- If line end, gives the end of an index line, rather than the first character of the next line.
-function LineWrapping:get_line_idx_col_count(doc, line, col, line_end)
-  if not doc.wrapped_lines then return common.clamp(line, 1, #doc.lines), col, 1, 1 end
-  if line > #doc.lines then return self:get_line_idx_col_count(doc, #doc.lines, #doc.lines[#doc.lines] + 1) end
+local function get_line_idx_col_count(doc, line, col, line_end)
+  if not doc.wrapped_settings then return common.clamp(line, 1, #doc.lines), col, 1, 1 end
+  if line > #doc.lines then return get_line_idx_col_count(doc, #doc.lines, #doc.lines[#doc.lines] + 1) end
   line = math.max(line, 1)
-  local idx = doc.wrapped_line_to_idx[line]
+  local idx = doc.wrapped_line_to_idx[line] or 1
   local ncol, scol = 1, 1
   if col then
     local i = idx + 1
@@ -104,17 +127,13 @@ function LineWrapping:get_line_idx_col_count(doc, line, col, line_end)
     end
     ncol = (col - scol) + 1
   end
-  local count = (doc.wrapped_line_to_idx[line + 1] or (self:get_total_wrapped_lines(doc) + 1)) - doc.wrapped_line_to_idx[line]
+  local count = (doc.wrapped_line_to_idx[line + 1] or (get_total_wrapped_lines(doc) + 1)) - (doc.wrapped_line_to_idx[line] or get_total_wrapped_lines(doc))
   return idx, ncol, count, scol
 end
 
-function LineWrapping:get_total_wrapped_lines(doc)
-  if not doc.wrapped_lines then return #doc.lines end
-  return #doc.wrapped_lines / 2
-end
 
 local function get_line_col_from_index_and_x(doc, default_font, idx, x)
-  local line, col = LineWrapping:get_idx_line_col(doc, idx)
+  local line, col = get_idx_line_col(doc, idx)
   local xoffset, last_i, i = 0, 1, 1
   for _, type, text in doc.highlighter:each_token(line) do
     local font = style.syntax_fonts[type] or default_font
@@ -137,49 +156,59 @@ end
 local old_doc_insert = Doc.raw_insert
 function Doc:raw_insert(line, col, text, undo_stack, time)
   old_doc_insert(self, line, col, text, undo_stack, time)
-  LineWrapping:reconstruct_breaks(self, core.active_view:get_font(), math.huge)
-  self.break_size = math.huge
+  if self.wrapped_settings then
+    LineWrapping.update_breaks(self, line)
+  end
 end
 
 local old_doc_remove = Doc.raw_remove
 function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
   old_doc_remove(self, line1, col1, line2, col2, undo_stack, time)
-  LineWrapping:reconstruct_breaks(self, core.active_view:get_font(), math.huge)
-  self.break_size = math.huge
+  if self.wrapped_settings then
+    LineWrapping.update_breaks(self, line1)
+  end
 end
 
 local old_doc_update = DocView.update
 function DocView:update()
   old_doc_update(self)
-  if self.size.x > 0 and (self.doc.break_size == nil or self.size.x ~= self.doc.break_size) then
-    LineWrapping:reconstruct_breaks(self.doc, self:get_font(), self.size.x)
-    self.doc.break_size = self.size.x
+  if self.doc.wrapped_settings and self.size.x > 0 then
+    LineWrapping.update_docview_breaks(self)
   end
 end
 
 function DocView:get_scrollable_size()
   if not config.scroll_past_end then
-    return self:get_line_height() * LineWrapping:get_total_wrapped_lines(self.doc) + style.padding.y * 2
+    return self:get_line_height() * get_total_wrapped_lines(self.doc) + style.padding.y * 2
   end
-  return self:get_line_height() * (LineWrapping:get_total_wrapped_lines(self.doc) - 1) + self.size.y
+  return self:get_line_height() * (get_total_wrapped_lines(self.doc) - 1) + self.size.y
+end
+
+
+local old_scroll_to_make_visible = DocView.scroll_to_make_visible
+function DocView:scroll_to_make_visible(line, col)
+  old_scroll_to_make_visible(self, line, col)
+  if self.doc.wrapped_settings then self.scroll.to.x = 0 end
 end
 
 function DocView:get_visible_line_range()
   local x, y, x2, y2 = self:get_content_bounds()
   local lh = self:get_line_height()
-  local minline = LineWrapping:get_idx_line_col(self.doc, math.max(1, math.floor(y / lh)))
-  local maxline = LineWrapping:get_idx_line_col(self.doc, math.min(LineWrapping:get_total_wrapped_lines(self.doc), math.floor(y2 / lh) + 1))
+  local minline = get_idx_line_col(self.doc, math.max(1, math.floor(y / lh)))
+  local maxline = get_idx_line_col(self.doc, math.min(get_total_wrapped_lines(self.doc), math.floor(y2 / lh) + 1))
   return minline, maxline
 end
 
 function DocView:get_x_offset_col(line, x)
-  local idx = LineWrapping:get_line_idx_col_count(self.doc, line)
+  local idx = get_line_idx_col_count(self.doc, line)
   return get_line_col_from_index_and_x(self.doc, self:get_font(), idx, x)
 end
 
 -- If line end is true, returns the end of the previous line, in a multi-line break.
+local old_get_col_x_offset = DocView.get_col_x_offset
 function DocView:get_col_x_offset(line, col, line_end)
-  local idx, ncol, count, scol = LineWrapping:get_line_idx_col_count(self.doc, line, col, line_end)
+  if not self.doc.wrapped_settings then return old_get_col_x_offset(self, line, col) end
+  local idx, ncol, count, scol = get_line_idx_col_count(self.doc, line, col, line_end)
   local xoffset, i = 0, 1
   local default_font = self:get_font()
   for _, type, text in self.doc.highlighter:each_token(line) do
@@ -203,25 +232,31 @@ function DocView:get_col_x_offset(line, col, line_end)
   return xoffset
 end
 
+local old_get_line_screen_position = DocView.get_line_screen_position
 function DocView:get_line_screen_position(line, col)
-  local idx, ncol, count = LineWrapping:get_line_idx_col_count(self.doc, line, col)
+  if not self.doc.wrapped_settings then return old_get_line_screen_position(self, line, col) end
+  local idx, ncol, count = get_line_idx_col_count(self.doc, line, col)
   local x, y = self:get_content_offset()
   local lh = self:get_line_height()
   local gw = self:get_gutter_width()
   return x + gw + (col and self:get_col_x_offset(line, col) or 0), y + (idx-1) * lh + style.padding.y
 end
 
+local old_resolve_screen_position = DocView.resolve_screen_position
 function DocView:resolve_screen_position(x, y)
+  if not self.doc.wrapped_settings then return old_resolve_screen_position(self, x, y) end
   local ox, oy = self:get_line_screen_position(1)
-  local idx = common.clamp(math.floor((y - oy) / self:get_line_height()) + 1, 1, LineWrapping:get_total_wrapped_lines(self.doc))
+  local idx = common.clamp(math.floor((y - oy) / self:get_line_height()) + 1, 1, get_total_wrapped_lines(self.doc))
   return get_line_col_from_index_and_x(self.doc, self:get_font(), idx, x - ox)
 end
 
+local old_draw_line_text = DocView.draw_line_text
 function DocView:draw_line_text(line, x, y)
+  if not self.doc.wrapped_settings then return old_draw_line_text(self, line, x, y) end
   local default_font = self:get_font()
   local tx, ty = x, y + self:get_line_text_y_offset()
   local lh = self:get_line_height()
-  local idx, _, count = LineWrapping:get_line_idx_col_count(self.doc, line)
+  local idx, _, count = get_line_idx_col_count(self.doc, line)
   local total_offset = 1
   for _, type, text in self.doc.highlighter:each_token(line) do
     local color = style.syntax[type]
@@ -229,7 +264,7 @@ function DocView:draw_line_text(line, x, y)
     local token_offset = 1
     -- Split tokens if we're at the end of the document.
     while token_offset <= #text do
-      local next_line, next_line_start_col = LineWrapping:get_idx_line_col(self.doc, idx + 1)
+      local next_line, next_line_start_col = get_idx_line_col(self.doc, idx + 1)
       if next_line ~= line then
         next_line_start_col = #self.doc.lines[line] 
       end
@@ -246,23 +281,24 @@ function DocView:draw_line_text(line, x, y)
   return lh * count
 end
 
+local old_draw_line_body = DocView.draw_line_body
 function DocView:draw_line_body(line, x, y)
-  -- draw selection if it overlaps this line
+  if not self.doc.wrapped_settings then return old_draw_line_body(self, line, x, y) end
   local lh = self:get_line_height()
-  local idx0 = LineWrapping:get_line_idx_col_count(self.doc, line)
+  local idx0 = get_line_idx_col_count(self.doc, line)
   for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do
     if line >= line1 and line <= line2 then
       if line1 ~= line then col1 = 1 end
       if line2 ~= line then col2 = #self.doc.lines[line] + 1 end
       if col1 ~= col2 then
-        local idx1, ncol1 = LineWrapping:get_line_idx_col_count(self.doc, line, col1)
-        local idx2, ncol2 = LineWrapping:get_line_idx_col_count(self.doc, line, col2)
+        local idx1, ncol1 = get_line_idx_col_count(self.doc, line, col1)
+        local idx2, ncol2 = get_line_idx_col_count(self.doc, line, col2)
         for i = idx1, idx2 do
           local x1, x2 = x + (idx1 == i and self:get_col_x_offset(line1, col1) or 0)
           if idx2 == i then
             x2 = x + self:get_col_x_offset(line, col2)
           else
-            x2 = x + self:get_col_x_offset(line, LineWrapping:get_idx_line_length(self.doc, i, line) + 1, true)
+            x2 = x + self:get_col_x_offset(line, get_idx_line_length(self.doc, i, line) + 1, true)
           end
           renderer.draw_rect(x1, y + (i - idx0) * lh, x2 - x1, lh, style.selection)
         end
@@ -278,7 +314,7 @@ function DocView:draw_line_body(line, x, y)
     end
   end
   if draw_highlight then 
-    local _, _, count = LineWrapping:get_line_idx_col_count(self.doc, line)
+    local _, _, count = get_line_idx_col_count(self.doc, line)
     for i=1,count do 
       self:draw_line_highlight(x + self.scroll.x, y + lh * (i - 1))
     end
@@ -290,56 +326,72 @@ end
 local old_draw = DocView.draw
 function DocView:draw()
   old_draw(self)
-  local x, y = self:get_content_offset()
-  local gw = self:get_gutter_width()
-  renderer.draw_rect(x + gw + LineWrapping.width_override, y, 1, core.root_view.size.y, style.selection)
+  if self.doc.wrapped_settings and self.doc.wrapped_settings.width ~= math.huge then
+    local x, y = self:get_content_offset()
+    local gw = self:get_gutter_width()
+    renderer.draw_rect(x + gw + self.doc.wrapped_settings.width, y, 1, core.root_view.size.y, style.selection)
+  end
 end 
 
 local old_draw_line_gutter = DocView.draw_line_gutter
 function DocView:draw_line_gutter(line, x, y, width)
   local lh = self:get_line_height()
-  local _, _, count = LineWrapping:get_line_idx_col_count(self.doc, line)
+  local _, _, count = get_line_idx_col_count(self.doc, line)
   return (old_draw_line_gutter(self, line, x, y, width) or lh) * count
 end
 
 function translate.end_of_line(doc, line, col)
-  local idx, ncol = LineWrapping:get_line_idx_col_count(self.doc, line, col)
-  local nline, ncol2 = LineWrapping:get_idx_line_col(self.doc, idx + 1)
+  local idx, ncol = get_line_idx_col_count(self.doc, line, col)
+  local nline, ncol2 = get_idx_line_col(self.doc, idx + 1)
   if nline ~= line then return line, math.huge end
   return line, ncol2 - 1
 end
 
 function translate.start_of_line(doc, line, col)
-  local idx, ncol = LineWrapping:get_line_idx_col_count(self.doc, line, col)
-  local nline, ncol2 = LineWrapping:get_idx_line_col(self.doc, idx - 1)
+  local idx, ncol = get_line_idx_col_count(self.doc, line, col)
+  local nline, ncol2 = get_idx_line_col(self.doc, idx - 1)
   if nline ~= line then return line, 1 end
   return line, ncol2 + 1
 end
 
 function DocView.translate.previous_line(doc, line, col, dv)
-  local idx, ncol = LineWrapping:get_line_idx_col_count(self.doc, line, col)
-  local nline, ncol2 = LineWrapping:get_idx_line_col(self.doc, idx - 1)
+  local idx, ncol = get_line_idx_col_count(self.doc, line, col)
+  local nline, ncol2 = get_idx_line_col(self.doc, idx - 1)
   if nline ~= line then return line - 1, dv:get_col_x_offset(line, col) end
   return nline, ncol2
 end
 
 function DocView.translate.next_line(doc, line, col, dv)
-  local idx, ncol = LineWrapping:get_line_idx_col_count(self.doc, line, col)
-  local nline, ncol2 = LineWrapping:get_idx_line_col(self.doc, idx + 1)
+  local idx, ncol = get_line_idx_col_count(self.doc, line, col)
+  local nline, ncol2 = get_idx_line_col(self.doc, idx + 1)
   if nline ~= line then return line + 1, dv:get_col_x_offset(line, col) end
   return nline, ncol2
 end
 
 command.add(nil, {
-  ["linewrapping:enable"] = function() 
-    LineWrapping.width_override = nil 
-  end,
-  ["linewrapping:disable"] = function() 
-    LineWrapping.width_override = math.huge 
-    if core.active_view and core.active_view.doc then
-      LineWrapping:reconstruct_breaks(core.active_view.doc)
+  ["line-wrapping:enable"] = function() 
+    if core.active_view and core.active_view.doc then 
+      LineWrapping.update_docview_breaks(core.active_view)
     end
   end,
+  ["line-wrapping:disable"] = function() 
+    if core.active_view and core.active_view.doc then 
+      LineWrapping.reconstruct_breaks(core.active_view.doc, core.active_view:get_font(), math.huge)
+    end
+  end,
+  ["line-wrapping:toggle"] = function() 
+    if core.active_view and core.active_view.doc and core.active_view.doc.wrapped_settings then 
+      command.perform("line-wrapping:disable")
+    else
+      command.perform("line-wrapping:enable")
+    end
+  end
 })
+
+keymap.add {
+  ["f10"] = "line-wrapping:toggle",
+}
+
+
 
 return LineWrapping

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -25,7 +25,7 @@ local LineWrapping = {}
 -- Computes the breaks for a given line, width and mode. Returns a list of columns
 -- at which the line should be broken.
 function LineWrapping.compute_line_breaks(doc, default_font, line, width, mode)
-  local xoffset, last_i, i = 0, 1, 1
+  local xoffset, last_i, i, last_space, last_width = 0, 1, 1, 1, 0
   local splits = { 1 }
   for _, type, text in doc.highlighter:each_token(line) do
     local font = style.syntax_fonts[type] or default_font
@@ -35,8 +35,16 @@ function LineWrapping.compute_line_breaks(doc, default_font, line, width, mode)
         w = font:get_width(char)
         xoffset = xoffset + w
         if xoffset > width then
-          table.insert(splits, i)
-          xoffset = w
+          if mode == "word" then
+            table.insert(splits, last_space + 1)
+            xoffset = xoffset - last_width + w
+          else
+            table.insert(splits, i)
+            xoffset = w
+          end
+        elseif char == ' ' then
+          last_space = i
+          last_width = xoffset
         end
         i = i + #char
       end

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -9,7 +9,7 @@ local command = require "core.command"
 local keymap = require "core.keymap"
 local translate = require "core.doc.translate"
 
-local LineWrapping = { mode = "letter", width_override = nil }
+local LineWrapping = { mode = "letter", width_override = nil, open_files = {} }
 
 -- Computes the breaks for a given line, width and mode.
 function LineWrapping.compute_line_breaks(doc, default_font, line, width, mode)
@@ -39,85 +39,151 @@ end
 -- breaks are held in a single table that contains n*2 elements, where n is the amount of line breaks.
 -- each element represents line and column of the break. line_offset will check from the specified line
 -- if the first line has not changed breaks, it will stop there.
-function LineWrapping.reconstruct_breaks(doc, default_font, width, line_offset)
+function LineWrapping.reconstruct_breaks(docview, default_font, width, line_offset)
   -- list of line/columns
   if width ~= math.huge then
-    doc.wrapped_lines = { }
-    doc.wrapped_line_to_idx = { }
-    doc.wrapped_settings = { ["width"] = width, ["font"] = default_font }
+    local doc = docview.doc
+    docview.wrapped_lines = { }
+    docview.wrapped_line_to_idx = { }
+    docview.wrapped_settings = { ["width"] = width, ["font"] = default_font }
     for i = line_offset or 1, #doc.lines do
       for k, col in ipairs(LineWrapping.compute_line_breaks(doc, default_font, i, width)) do
-        table.insert(doc.wrapped_lines, i)
-        table.insert(doc.wrapped_lines, col)
+        table.insert(docview.wrapped_lines, i)
+        table.insert(docview.wrapped_lines, col)
       end
     end
     -- list of indices for wrapped_lines, that are based on original line number
     -- holds the index to the first in the wrapped_lines list
     local last_wrap = nil
-    for i = 1, #doc.wrapped_lines, 2 do
-      if not last_wrap or last_wrap ~= doc.wrapped_lines[i] then
-        table.insert(doc.wrapped_line_to_idx, (i + 1) / 2)
-        last_wrap = doc.wrapped_lines[i]
+    for i = 1, #docview.wrapped_lines, 2 do
+      if not last_wrap or last_wrap ~= docview.wrapped_lines[i] then
+        table.insert(docview.wrapped_line_to_idx, (i + 1) / 2)
+        last_wrap = docview.wrapped_lines[i]
       end
     end
   else
-    doc.wrapped_lines = nil
-    doc.wrapped_line_to_idx = nil
-    doc.wrapped_settings = nil
+    docview.wrapped_lines = nil
+    docview.wrapped_line_to_idx = nil
+    docview.wrapped_settings = nil
   end
 end
 
-function LineWrapping.update_breaks(doc, line)
-  
+function LineWrapping.update_breaks(docview, line)
+  local idx = docview.wrapped_line_to_idx[line]
+  local offset = (idx - 1) * 2 + 1
+  local breaks = LineWrapping.compute_line_breaks(docview.doc, docview.wrapped_settings.font, line, docview.wrapped_settings.width)
+  local change = 0
+  for i,b in ipairs(breaks) do
+    if docview.wrapped_lines[offset] == line then
+      docview.wrapped_lines[offset + 1] = b
+    else
+      table.insert(docview.wrapped_lines, offset, b)
+      table.insert(docview.wrapped_lines, offset, line)
+      change = change + 1
+    end
+    offset = offset + 2
+  end
+  while docview.wrapped_lines[offset] == line do
+    table.remove(docview.wrapped_lines, offset)
+    table.remove(docview.wrapped_lines, offset)
+    change = change - 1
+  end
+  for i = line + 1, #docview.wrapped_line_to_idx do
+    docview.wrapped_line_to_idx[i] = docview.wrapped_line_to_idx[i] + change
+  end
 end
 
+function LineWrapping.remove_lines(docview, line1, line2)
+  local total_lines = line2 - line1 + 1
+  local offset = (docview.wrapped_line_to_idx[line1] - 1) * 2 + 1
+  for i=line1,line2 do
+    table.remove(docview.wrapped_lines, offset)
+    table.remove(docview.wrapped_lines, offset)
+  end
+  for i = line2 + 1, #docview.wrapped_line_to_idx do
+    docview.wrapped_line_to_idx[i] = docview.wrapped_line_to_idx[i] - total_lines
+  end
+  for i=line1, line2 do
+    table.remove(docview.wrapped_line_to_idx, line1)
+  end
+end
+
+function LineWrapping.add_lines(docview, line, line_count) 
+  local offset = (docview.wrapped_line_to_idx[line] - 1) * 2 + 1
+  for i = line, line + line_count - 1 do
+    table.insert(docview.wrapped_lines, offset, 1)
+    table.insert(docview.wrapped_lines, offset, i)
+    table.insert(docview.wrapped_line_to_idx, line, ((offset - 1) / 2) + 1)
+    offset = offset + 2
+  end
+  for i = line + line_count, #docview.wrapped_line_to_idx do
+    docview.wrapped_line_to_idx[i] = docview.wrapped_line_to_idx[i] + line_count
+  end
+  for i = offset, #docview.wrapped_lines, 2 do
+    docview.wrapped_lines[i] = docview.wrapped_lines[i] + line_count
+  end
+end
+
+
+function LineWrapping.draw_guide(docview)
+  if docview.wrapped_settings.width ~= math.huge then
+    local x, y = docview:get_content_offset()
+    local gw = docview:get_gutter_width()
+    renderer.draw_rect(x + gw + docview.wrapped_settings.width, y, 1, core.root_view.size.y, style.selection)
+  end
+end
+  
 function LineWrapping.update_docview_breaks(docview)
   local width = LineWrapping.width_override or (docview.size.x - docview:get_gutter_width())
-  if (not docview.doc.wrapped_settings or docview.doc.wrapped_settings.width == nil or width ~= docview.doc.wrapped_settings.width) then
-    LineWrapping.reconstruct_breaks(docview.doc, docview:get_font(), width)
+  if (not docview.wrapped_settings or docview.wrapped_settings.width == nil or width ~= docview.wrapped_settings.width) then
+    docview.scroll.to.x = 0
+    LineWrapping.reconstruct_breaks(docview, docview:get_font(), width)
   end
 end
 
-local function get_idx_line_col(doc, idx)
-  if not doc.wrapped_settings then 
+local function get_idx_line_col(docview, idx)
+  local doc = docview.doc
+  if not docview.wrapped_settings then 
     if idx > #doc.lines then return #doc.lines, #doc.lines[#doc.lines] + 1 end
     return idx, 1 
   end
   local offset = (idx - 1) * 2 + 1
-  if offset > #doc.wrapped_lines then return #doc.lines, #doc.lines[#doc.lines] + 1 end
-  return doc.wrapped_lines[offset], doc.wrapped_lines[offset + 1]
+  if offset > #docview.wrapped_lines then return #doc.lines, #doc.lines[#doc.lines] + 1 end
+  return docview.wrapped_lines[offset], docview.wrapped_lines[offset + 1]
 end
 
-local function get_idx_line_length(doc, idx)
-  if not doc.wrapped_settings then 
+local function get_idx_line_length(docview, idx)
+  local doc = docview.doc
+  if not docview.wrapped_settings then 
     if idx > #doc.lines then return #doc.lines[#doc.lines] + 1 end
     return #doc.lines[idx]
   end
   local offset = (idx - 1) * 2 + 1
-  local start = doc.wrapped_lines[offset + 1]
-  if doc.wrapped_lines[offset + 2] and doc.wrapped_lines[offset + 2] == doc.wrapped_lines[offset] then
-    return doc.wrapped_lines[offset + 3] - doc.wrapped_lines[offset + 1]
+  local start = docview.wrapped_lines[offset + 1]
+  if docview.wrapped_lines[offset + 2] and docview.wrapped_lines[offset + 2] == docview.wrapped_lines[offset] then
+    return docview.wrapped_lines[offset + 3] - docview.wrapped_lines[offset + 1]
   else
-    return #doc.lines[doc.wrapped_lines[offset]] - doc.wrapped_lines[offset + 1] + 1
+    return #doc.lines[docview.wrapped_lines[offset]] - docview.wrapped_lines[offset + 1] + 1
   end
 end
 
-local function get_total_wrapped_lines(doc)
-  if not doc.wrapped_settings then return #doc.lines end
-  return #doc.wrapped_lines / 2
+local function get_total_wrapped_lines(docview)
+  if not docview.wrapped_settings then return docview.doc and #docview.doc.lines end
+  return #docview.wrapped_lines / 2
 end
 
 -- If line end, gives the end of an index line, rather than the first character of the next line.
-local function get_line_idx_col_count(doc, line, col, line_end)
-  if not doc.wrapped_settings then return common.clamp(line, 1, #doc.lines), col, 1, 1 end
+local function get_line_idx_col_count(docview, line, col, line_end)
+  local doc = docview.doc
+  if not docview.wrapped_settings then return common.clamp(line, 1, #doc.lines), col, 1, 1 end
   if line > #doc.lines then return get_line_idx_col_count(doc, #doc.lines, #doc.lines[#doc.lines] + 1) end
   line = math.max(line, 1)
-  local idx = doc.wrapped_line_to_idx[line] or 1
+  local idx = docview.wrapped_line_to_idx[line] or 1
   local ncol, scol = 1, 1
   if col then
     local i = idx + 1
-    while line == doc.wrapped_lines[(i - 1) * 2 + 1] and col >= doc.wrapped_lines[(i - 1) * 2 + 2] do
-      local nscol = doc.wrapped_lines[(i - 1) * 2 + 2]
+    while line == docview.wrapped_lines[(i - 1) * 2 + 1] and col >= docview.wrapped_lines[(i - 1) * 2 + 2] do
+      local nscol = docview.wrapped_lines[(i - 1) * 2 + 2]
       if line_end and col == nscol then
         break
       end
@@ -127,15 +193,16 @@ local function get_line_idx_col_count(doc, line, col, line_end)
     end
     ncol = (col - scol) + 1
   end
-  local count = (doc.wrapped_line_to_idx[line + 1] or (get_total_wrapped_lines(doc) + 1)) - (doc.wrapped_line_to_idx[line] or get_total_wrapped_lines(doc))
+  local count = (docview.wrapped_line_to_idx[line + 1] or (get_total_wrapped_lines(docview) + 1)) - (docview.wrapped_line_to_idx[line] or get_total_wrapped_lines(docview))
   return idx, ncol, count, scol
 end
 
 
-local function get_line_col_from_index_and_x(doc, default_font, idx, x)
-  local line, col = get_idx_line_col(doc, idx)
+local function get_line_col_from_index_and_x(docview, default_font, idx, x)
+  local doc = docview.doc
+  local line, col = get_idx_line_col(docview, idx)
   local xoffset, last_i, i = 0, 1, 1
-  for _, type, text in doc.highlighter:each_token(line) do
+  for _, type, text in docview.doc.highlighter:each_token(line) do
     local font = style.syntax_fonts[type] or default_font
     for char in common.utf8_chars(text) do
       if i > col then
@@ -155,60 +222,86 @@ end
 
 local old_doc_insert = Doc.raw_insert
 function Doc:raw_insert(line, col, text, undo_stack, time)
+  local old_lines = #self.lines
   old_doc_insert(self, line, col, text, undo_stack, time)
-  if self.wrapped_settings then
-    LineWrapping.update_breaks(self, line)
+  if LineWrapping.open_files[self] then
+    for i,docview in ipairs(LineWrapping.open_files[self]) do
+      if docview.wrapped_settings then
+        local lines = #self.lines - old_lines
+        if lines > 0 then LineWrapping.add_lines(docview, line, lines) end
+        LineWrapping.update_breaks(docview, line)
+      end
+    end
   end
 end
 
 local old_doc_remove = Doc.raw_remove
 function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
+  local start_line = line1 + 1
+  local end_line = col2 == #self.lines[line2] and line2 or (line2 - 1)
   old_doc_remove(self, line1, col1, line2, col2, undo_stack, time)
-  if self.wrapped_settings then
-    LineWrapping.update_breaks(self, line1)
+  if LineWrapping.open_files[self] then
+    for i,docview in ipairs(LineWrapping.open_files[self]) do
+      if docview.wrapped_settings then
+        if start_line <= end_line then
+          LineWrapping.remove_lines(start_line, end_line)
+        end
+        LineWrapping.update_breaks(docview, line1)
+      end
+    end
   end
 end
 
 local old_doc_update = DocView.update
 function DocView:update()
   old_doc_update(self)
-  if self.doc.wrapped_settings and self.size.x > 0 then
+  if self.wrapped_settings and self.size.x > 0 then
     LineWrapping.update_docview_breaks(self)
   end
 end
 
 function DocView:get_scrollable_size()
   if not config.scroll_past_end then
-    return self:get_line_height() * get_total_wrapped_lines(self.doc) + style.padding.y * 2
+    return self:get_line_height() * get_total_wrapped_lines(self) + style.padding.y * 2
   end
-  return self:get_line_height() * (get_total_wrapped_lines(self.doc) - 1) + self.size.y
+  return self:get_line_height() * (get_total_wrapped_lines(self) - 1) + self.size.y
 end
 
+local old_new = DocView.new
+function DocView:new(doc)
+  old_new(self, doc)
+  if not LineWrapping.open_files[doc] then LineWrapping.open_files[doc] = {} end
+  table.insert(LineWrapping.open_files[doc], self)
+end
 
 local old_scroll_to_make_visible = DocView.scroll_to_make_visible
 function DocView:scroll_to_make_visible(line, col)
   old_scroll_to_make_visible(self, line, col)
-  if self.doc.wrapped_settings then self.scroll.to.x = 0 end
+  if self.wrapped_settings then self.scroll.to.x = 0 end
 end
 
+local old_get_visible_line_range = DocView.get_visible_line_range
 function DocView:get_visible_line_range()
+  if not self.wrapped_settings then return old_get_visible_line_range(self) end
   local x, y, x2, y2 = self:get_content_bounds()
   local lh = self:get_line_height()
-  local minline = get_idx_line_col(self.doc, math.max(1, math.floor(y / lh)))
-  local maxline = get_idx_line_col(self.doc, math.min(get_total_wrapped_lines(self.doc), math.floor(y2 / lh) + 1))
+  local minline = get_idx_line_col(self, math.max(1, math.floor(y / lh)))
+  local maxline = get_idx_line_col(self, math.min(get_total_wrapped_lines(self), math.floor(y2 / lh) + 1))
   return minline, maxline
 end
 
+local old_get_x_offset_col = DocView.get_x_offset_col
 function DocView:get_x_offset_col(line, x)
-  local idx = get_line_idx_col_count(self.doc, line)
-  return get_line_col_from_index_and_x(self.doc, self:get_font(), idx, x)
+  if not self.wrapped_settings then return old_get_x_offset_col(self, line, x) end
+  local idx = get_line_idx_col_count(self, line)
+  return get_line_col_from_index_and_x(self, self:get_font(), idx, x)
 end
 
 -- If line end is true, returns the end of the previous line, in a multi-line break.
 local old_get_col_x_offset = DocView.get_col_x_offset
 function DocView:get_col_x_offset(line, col, line_end)
-  if not self.doc.wrapped_settings then return old_get_col_x_offset(self, line, col) end
-  local idx, ncol, count, scol = get_line_idx_col_count(self.doc, line, col, line_end)
+  if not self.wrapped_settings then return old_get_col_x_offset(self, line, col) end
+  local idx, ncol, count, scol = get_line_idx_col_count(self, line, col, line_end)
   local xoffset, i = 0, 1
   local default_font = self:get_font()
   for _, type, text in self.doc.highlighter:each_token(line) do
@@ -234,8 +327,8 @@ end
 
 local old_get_line_screen_position = DocView.get_line_screen_position
 function DocView:get_line_screen_position(line, col)
-  if not self.doc.wrapped_settings then return old_get_line_screen_position(self, line, col) end
-  local idx, ncol, count = get_line_idx_col_count(self.doc, line, col)
+  if not self.wrapped_settings then return old_get_line_screen_position(self, line, col) end
+  local idx, ncol, count = get_line_idx_col_count(self, line, col)
   local x, y = self:get_content_offset()
   local lh = self:get_line_height()
   local gw = self:get_gutter_width()
@@ -244,19 +337,19 @@ end
 
 local old_resolve_screen_position = DocView.resolve_screen_position
 function DocView:resolve_screen_position(x, y)
-  if not self.doc.wrapped_settings then return old_resolve_screen_position(self, x, y) end
+  if not self.wrapped_settings then return old_resolve_screen_position(self, x, y) end
   local ox, oy = self:get_line_screen_position(1)
-  local idx = common.clamp(math.floor((y - oy) / self:get_line_height()) + 1, 1, get_total_wrapped_lines(self.doc))
-  return get_line_col_from_index_and_x(self.doc, self:get_font(), idx, x - ox)
+  local idx = common.clamp(math.floor((y - oy) / self:get_line_height()) + 1, 1, get_total_wrapped_lines(self))
+  return get_line_col_from_index_and_x(self, self:get_font(), idx, x - ox)
 end
 
 local old_draw_line_text = DocView.draw_line_text
 function DocView:draw_line_text(line, x, y)
-  if not self.doc.wrapped_settings then return old_draw_line_text(self, line, x, y) end
+  if not self.wrapped_settings then return old_draw_line_text(self, line, x, y) end
   local default_font = self:get_font()
   local tx, ty = x, y + self:get_line_text_y_offset()
   local lh = self:get_line_height()
-  local idx, _, count = get_line_idx_col_count(self.doc, line)
+  local idx, _, count = get_line_idx_col_count(self, line)
   local total_offset = 1
   for _, type, text in self.doc.highlighter:each_token(line) do
     local color = style.syntax[type]
@@ -264,7 +357,7 @@ function DocView:draw_line_text(line, x, y)
     local token_offset = 1
     -- Split tokens if we're at the end of the document.
     while token_offset <= #text do
-      local next_line, next_line_start_col = get_idx_line_col(self.doc, idx + 1)
+      local next_line, next_line_start_col = get_idx_line_col(self, idx + 1)
       if next_line ~= line then
         next_line_start_col = #self.doc.lines[line] 
       end
@@ -283,22 +376,22 @@ end
 
 local old_draw_line_body = DocView.draw_line_body
 function DocView:draw_line_body(line, x, y)
-  if not self.doc.wrapped_settings then return old_draw_line_body(self, line, x, y) end
+  if not self.wrapped_settings then return old_draw_line_body(self, line, x, y) end
   local lh = self:get_line_height()
-  local idx0 = get_line_idx_col_count(self.doc, line)
+  local idx0 = get_line_idx_col_count(self, line)
   for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do
     if line >= line1 and line <= line2 then
       if line1 ~= line then col1 = 1 end
       if line2 ~= line then col2 = #self.doc.lines[line] + 1 end
       if col1 ~= col2 then
-        local idx1, ncol1 = get_line_idx_col_count(self.doc, line, col1)
-        local idx2, ncol2 = get_line_idx_col_count(self.doc, line, col2)
+        local idx1, ncol1 = get_line_idx_col_count(self, line, col1)
+        local idx2, ncol2 = get_line_idx_col_count(self, line, col2)
         for i = idx1, idx2 do
           local x1, x2 = x + (idx1 == i and self:get_col_x_offset(line1, col1) or 0)
           if idx2 == i then
             x2 = x + self:get_col_x_offset(line, col2)
           else
-            x2 = x + self:get_col_x_offset(line, get_idx_line_length(self.doc, i, line) + 1, true)
+            x2 = x + self:get_col_x_offset(line, get_idx_line_length(self, i, line) + 1, true)
           end
           renderer.draw_rect(x1, y + (i - idx0) * lh, x2 - x1, lh, style.selection)
         end
@@ -314,7 +407,7 @@ function DocView:draw_line_body(line, x, y)
     end
   end
   if draw_highlight then 
-    local _, _, count = get_line_idx_col_count(self.doc, line)
+    local _, _, count = get_line_idx_col_count(self, line)
     for i=1,count do 
       self:draw_line_highlight(x + self.scroll.x, y + lh * (i - 1))
     end
@@ -326,44 +419,42 @@ end
 local old_draw = DocView.draw
 function DocView:draw()
   old_draw(self)
-  if self.doc.wrapped_settings and self.doc.wrapped_settings.width ~= math.huge then
-    local x, y = self:get_content_offset()
-    local gw = self:get_gutter_width()
-    renderer.draw_rect(x + gw + self.doc.wrapped_settings.width, y, 1, core.root_view.size.y, style.selection)
+  if self.wrapped_settings then
+    LineWrapping.draw_guide(self) 
   end
 end 
 
 local old_draw_line_gutter = DocView.draw_line_gutter
 function DocView:draw_line_gutter(line, x, y, width)
   local lh = self:get_line_height()
-  local _, _, count = get_line_idx_col_count(self.doc, line)
+  local _, _, count = get_line_idx_col_count(self, line)
   return (old_draw_line_gutter(self, line, x, y, width) or lh) * count
 end
 
 function translate.end_of_line(doc, line, col)
-  local idx, ncol = get_line_idx_col_count(self.doc, line, col)
-  local nline, ncol2 = get_idx_line_col(self.doc, idx + 1)
+  local idx, ncol = get_line_idx_col_count(self, line, col)
+  local nline, ncol2 = get_idx_line_col(self, idx + 1)
   if nline ~= line then return line, math.huge end
   return line, ncol2 - 1
 end
 
 function translate.start_of_line(doc, line, col)
-  local idx, ncol = get_line_idx_col_count(self.doc, line, col)
-  local nline, ncol2 = get_idx_line_col(self.doc, idx - 1)
+  local idx, ncol = get_line_idx_col_count(self, line, col)
+  local nline, ncol2 = get_idx_line_col(self, idx - 1)
   if nline ~= line then return line, 1 end
   return line, ncol2 + 1
 end
 
 function DocView.translate.previous_line(doc, line, col, dv)
-  local idx, ncol = get_line_idx_col_count(self.doc, line, col)
-  local nline, ncol2 = get_idx_line_col(self.doc, idx - 1)
+  local idx, ncol = get_line_idx_col_count(self, line, col)
+  local nline, ncol2 = get_idx_line_col(self, idx - 1)
   if nline ~= line then return line - 1, dv:get_col_x_offset(line, col) end
   return nline, ncol2
 end
 
 function DocView.translate.next_line(doc, line, col, dv)
-  local idx, ncol = get_line_idx_col_count(self.doc, line, col)
-  local nline, ncol2 = get_idx_line_col(self.doc, idx + 1)
+  local idx, ncol = get_line_idx_col_count(self, line, col)
+  local nline, ncol2 = get_idx_line_col(self, idx + 1)
   if nline ~= line then return line + 1, dv:get_col_x_offset(line, col) end
   return nline, ncol2
 end
@@ -376,11 +467,11 @@ command.add(nil, {
   end,
   ["line-wrapping:disable"] = function() 
     if core.active_view and core.active_view.doc then 
-      LineWrapping.reconstruct_breaks(core.active_view.doc, core.active_view:get_font(), math.huge)
+      LineWrapping.reconstruct_breaks(core.active_view, core.active_view:get_font(), math.huge)
     end
   end,
   ["line-wrapping:toggle"] = function() 
-    if core.active_view and core.active_view.doc and core.active_view.doc.wrapped_settings then 
+    if core.active_view and core.active_view.doc and core.active_view.wrapped_settings then 
       command.perform("line-wrapping:disable")
     else
       command.perform("line-wrapping:enable")
@@ -391,7 +482,5 @@ command.add(nil, {
 keymap.add {
   ["f10"] = "line-wrapping:toggle",
 }
-
-
 
 return LineWrapping

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -1,0 +1,345 @@
+-- mod-version:2 -- lite-xl 2.0
+local core = require "core"
+local common = require "core.common"
+local DocView = require "core.docview"
+local Doc = require "core.doc"
+local style = require "core.style"
+local config = require "core.config"
+local command = require "core.command"
+local translate = require "core.doc.translate"
+
+local LineWrapping = { mode = "letter", width_override = 150 }
+
+-- 
+function LineWrapping:compute_line_breaks(doc, default_font, line, width, mode)
+  width = self.width_override or width
+  local xoffset, last_i, i = 0, 1, 1
+  local splits = { 1 }
+  for _, type, text in doc.highlighter:each_token(line) do
+    local font = style.syntax_fonts[type] or default_font
+    local w = font:get_width(text)
+    if xoffset + w > width then
+      for char in common.utf8_chars(text) do
+        w = font:get_width(char)
+        xoffset = xoffset + w
+        if xoffset > width then
+          table.insert(splits, i)
+          xoffset = w
+        end
+        i = i + #char
+      end
+    else
+      xoffset = xoffset + w
+      i = i + #text
+    end
+  end
+  return splits
+end
+
+-- breaks are held in a single table that contains n*2 elements, where n is the amount of line breaks.
+-- each element represents line and column of the break. line_offset will check from the specified line
+-- if the first line has not changed breaks, it will stop there.
+function LineWrapping:reconstruct_breaks(doc, default_font, width, line_offset)
+  -- list of line/columns
+  doc.wrapped_lines = { }
+  for i = line_offset or 1, #doc.lines do
+    for k, col in ipairs(self:compute_line_breaks(doc, default_font, i, width)) do
+      table.insert(doc.wrapped_lines, i)
+      table.insert(doc.wrapped_lines, col)
+    end
+  end
+  -- list of indices for wrapped_lines, that are based on original line number
+  -- holds the index to the first in the wrapped_lines list
+  doc.wrapped_line_to_idx = { }
+  local last_wrap = nil
+  for i = 1, #doc.wrapped_lines, 2 do
+    if not last_wrap or last_wrap ~= doc.wrapped_lines[i] then
+      table.insert(doc.wrapped_line_to_idx, (i + 1) / 2)
+      last_wrap = doc.wrapped_lines[i]
+    end
+  end
+end
+
+function LineWrapping:get_idx_line_col(doc, idx)
+  if not doc.wrapped_lines then 
+    if idx > #doc.lines then return #doc.lines, #doc.lines[#doc.lines] + 1 end
+    return idx, 1 
+  end
+  local offset = (idx - 1) * 2 + 1
+  if offset > #doc.wrapped_lines then return #doc.lines, #doc.lines[#doc.lines] + 1 end
+  return doc.wrapped_lines[offset], doc.wrapped_lines[offset + 1]
+end
+
+function LineWrapping:get_idx_line_length(doc, idx)
+  if not doc.wrapped_lines then 
+    if idx > #doc.lines then return #doc.lines[#doc.lines] + 1 end
+    return #doc.lines[idx]
+  end
+  local offset = (idx - 1) * 2 + 1
+  local start = doc.wrapped_lines[offset + 1]
+  if doc.wrapped_lines[offset + 2] and doc.wrapped_lines[offset + 2] == doc.wrapped_lines[offset] then
+    return doc.wrapped_lines[offset + 3] - doc.wrapped_lines[offset + 1]
+  else
+    return #doc.lines[doc.wrapped_lines[offset]] - doc.wrapped_lines[offset + 1] + 1
+  end
+end
+
+-- If line end, gives the end of an index line, rather than the first character of the next line.
+function LineWrapping:get_line_idx_col_count(doc, line, col, line_end)
+  if not doc.wrapped_lines then return common.clamp(line, 1, #doc.lines), col, 1, 1 end
+  if line > #doc.lines then return self:get_line_idx_col_count(doc, #doc.lines, #doc.lines[#doc.lines] + 1) end
+  line = math.max(line, 1)
+  local idx = doc.wrapped_line_to_idx[line]
+  local ncol, scol = 1, 1
+  if col then
+    local i = idx + 1
+    while line == doc.wrapped_lines[(i - 1) * 2 + 1] and col >= doc.wrapped_lines[(i - 1) * 2 + 2] do
+      local nscol = doc.wrapped_lines[(i - 1) * 2 + 2]
+      if line_end and col == nscol then
+        break
+      end
+      scol = nscol
+      i = i + 1
+      idx = idx + 1
+    end
+    ncol = (col - scol) + 1
+  end
+  local count = (doc.wrapped_line_to_idx[line + 1] or (self:get_total_wrapped_lines(doc) + 1)) - doc.wrapped_line_to_idx[line]
+  return idx, ncol, count, scol
+end
+
+function LineWrapping:get_total_wrapped_lines(doc)
+  if not doc.wrapped_lines then return #doc.lines end
+  return #doc.wrapped_lines / 2
+end
+
+local function get_line_col_from_index_and_x(doc, default_font, idx, x)
+  local line, col = LineWrapping:get_idx_line_col(doc, idx)
+  local xoffset, last_i, i = 0, 1, 1
+  for _, type, text in doc.highlighter:each_token(line) do
+    local font = style.syntax_fonts[type] or default_font
+    for char in common.utf8_chars(text) do
+      if i > col then
+        local w = font:get_width(char)
+        if xoffset >= x then
+          return line, ((xoffset - x > w / 2) and last_i or i)
+        end
+        xoffset = xoffset + w
+      end
+      last_i = i
+      i = i + #char
+    end
+  end
+  return line, #doc.lines[line]
+end
+
+
+local old_doc_insert = Doc.raw_insert
+function Doc:raw_insert(line, col, text, undo_stack, time)
+  old_doc_insert(self, line, col, text, undo_stack, time)
+  LineWrapping:reconstruct_breaks(self, core.active_view:get_font(), math.huge)
+  self.break_size = math.huge
+end
+
+local old_doc_remove = Doc.raw_remove
+function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
+  old_doc_remove(self, line1, col1, line2, col2, undo_stack, time)
+  LineWrapping:reconstruct_breaks(self, core.active_view:get_font(), math.huge)
+  self.break_size = math.huge
+end
+
+local old_doc_update = DocView.update
+function DocView:update()
+  old_doc_update(self)
+  if self.size.x > 0 and (self.doc.break_size == nil or self.size.x ~= self.doc.break_size) then
+    LineWrapping:reconstruct_breaks(self.doc, self:get_font(), self.size.x)
+    self.doc.break_size = self.size.x
+  end
+end
+
+function DocView:get_scrollable_size()
+  if not config.scroll_past_end then
+    return self:get_line_height() * LineWrapping:get_total_wrapped_lines(self.doc) + style.padding.y * 2
+  end
+  return self:get_line_height() * (LineWrapping:get_total_wrapped_lines(self.doc) - 1) + self.size.y
+end
+
+function DocView:get_visible_line_range()
+  local x, y, x2, y2 = self:get_content_bounds()
+  local lh = self:get_line_height()
+  local minline = LineWrapping:get_idx_line_col(self.doc, math.max(1, math.floor(y / lh)))
+  local maxline = LineWrapping:get_idx_line_col(self.doc, math.min(LineWrapping:get_total_wrapped_lines(self.doc), math.floor(y2 / lh) + 1))
+  return minline, maxline
+end
+
+function DocView:get_x_offset_col(line, x)
+  local idx = LineWrapping:get_line_idx_col_count(self.doc, line)
+  return get_line_col_from_index_and_x(self.doc, self:get_font(), idx, x)
+end
+
+-- If line end is true, returns the end of the previous line, in a multi-line break.
+function DocView:get_col_x_offset(line, col, line_end)
+  local idx, ncol, count, scol = LineWrapping:get_line_idx_col_count(self.doc, line, col, line_end)
+  local xoffset, i = 0, 1
+  local default_font = self:get_font()
+  for _, type, text in self.doc.highlighter:each_token(line) do
+    if i + #text >= scol then   
+      if i < scol then 
+        text = text:sub(scol - i + 1)
+        i = scol
+      end
+      local font = style.syntax_fonts[type] or default_font
+      for char in common.utf8_chars(text) do
+        if i >= col then
+          return xoffset
+        end
+        xoffset = xoffset + font:get_width(char)
+        i = i + #char
+      end
+    else
+     i = i + #text
+    end
+  end
+  return xoffset
+end
+
+function DocView:get_line_screen_position(line, col)
+  local idx, ncol, count = LineWrapping:get_line_idx_col_count(self.doc, line, col)
+  local x, y = self:get_content_offset()
+  local lh = self:get_line_height()
+  local gw = self:get_gutter_width()
+  return x + gw + (col and self:get_col_x_offset(line, col) or 0), y + (idx-1) * lh + style.padding.y
+end
+
+function DocView:resolve_screen_position(x, y)
+  local ox, oy = self:get_line_screen_position(1)
+  local idx = common.clamp(math.floor((y - oy) / self:get_line_height()) + 1, 1, LineWrapping:get_total_wrapped_lines(self.doc))
+  return get_line_col_from_index_and_x(self.doc, self:get_font(), idx, x - ox)
+end
+
+function DocView:draw_line_text(line, x, y)
+  local default_font = self:get_font()
+  local tx, ty = x, y + self:get_line_text_y_offset()
+  local lh = self:get_line_height()
+  local idx, _, count = LineWrapping:get_line_idx_col_count(self.doc, line)
+  local total_offset = 1
+  for _, type, text in self.doc.highlighter:each_token(line) do
+    local color = style.syntax[type]
+    local font = style.syntax_fonts[type] or default_font
+    local token_offset = 1
+    -- Split tokens if we're at the end of the document.
+    while token_offset <= #text do
+      local next_line, next_line_start_col = LineWrapping:get_idx_line_col(self.doc, idx + 1)
+      if next_line ~= line then
+        next_line_start_col = #self.doc.lines[line] 
+      end
+      local max_length = next_line_start_col - total_offset
+      local rendered_text = text:sub(token_offset, token_offset + max_length - 1)
+      tx = renderer.draw_text(font, rendered_text, tx, ty, color)
+      total_offset = total_offset + #rendered_text
+      if total_offset ~= next_line_start_col or max_length == 0 then break end
+      token_offset = token_offset + #rendered_text
+      idx = idx + 1
+      tx, ty = x, ty + lh
+    end
+  end
+  return lh * count
+end
+
+function DocView:draw_line_body(line, x, y)
+  -- draw selection if it overlaps this line
+  local lh = self:get_line_height()
+  local idx0 = LineWrapping:get_line_idx_col_count(self.doc, line)
+  for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do
+    if line >= line1 and line <= line2 then
+      if line1 ~= line then col1 = 1 end
+      if line2 ~= line then col2 = #self.doc.lines[line] + 1 end
+      if col1 ~= col2 then
+        local idx1, ncol1 = LineWrapping:get_line_idx_col_count(self.doc, line, col1)
+        local idx2, ncol2 = LineWrapping:get_line_idx_col_count(self.doc, line, col2)
+        for i = idx1, idx2 do
+          local x1, x2 = x + (idx1 == i and self:get_col_x_offset(line1, col1) or 0)
+          if idx2 == i then
+            x2 = x + self:get_col_x_offset(line, col2)
+          else
+            x2 = x + self:get_col_x_offset(line, LineWrapping:get_idx_line_length(self.doc, i, line) + 1, true)
+          end
+          renderer.draw_rect(x1, y + (i - idx0) * lh, x2 - x1, lh, style.selection)
+        end
+      end
+    end
+  end
+  local draw_highlight = nil
+  for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do
+    -- draw line highlight if caret is on this line
+    if draw_highlight ~= false and config.highlight_current_line
+    and line1 == line and core.active_view == self then
+      draw_highlight = (line1 == line2 and col1 == col2)
+    end
+  end
+  if draw_highlight then 
+    local _, _, count = LineWrapping:get_line_idx_col_count(self.doc, line)
+    for i=1,count do 
+      self:draw_line_highlight(x + self.scroll.x, y + lh * (i - 1))
+    end
+  end
+  -- draw line's text
+  return self:draw_line_text(line, x, y)
+end
+
+local old_draw = DocView.draw
+function DocView:draw()
+  old_draw(self)
+  local x, y = self:get_content_offset()
+  local gw = self:get_gutter_width()
+  renderer.draw_rect(x + gw + LineWrapping.width_override, y, 1, core.root_view.size.y, style.selection)
+end 
+
+local old_draw_line_gutter = DocView.draw_line_gutter
+function DocView:draw_line_gutter(line, x, y, width)
+  local lh = self:get_line_height()
+  local _, _, count = LineWrapping:get_line_idx_col_count(self.doc, line)
+  return (old_draw_line_gutter(self, line, x, y, width) or lh) * count
+end
+
+function translate.end_of_line(doc, line, col)
+  local idx, ncol = LineWrapping:get_line_idx_col_count(self.doc, line, col)
+  local nline, ncol2 = LineWrapping:get_idx_line_col(self.doc, idx + 1)
+  if nline ~= line then return line, math.huge end
+  return line, ncol2 - 1
+end
+
+function translate.start_of_line(doc, line, col)
+  local idx, ncol = LineWrapping:get_line_idx_col_count(self.doc, line, col)
+  local nline, ncol2 = LineWrapping:get_idx_line_col(self.doc, idx - 1)
+  if nline ~= line then return line, 1 end
+  return line, ncol2 + 1
+end
+
+function DocView.translate.previous_line(doc, line, col, dv)
+  local idx, ncol = LineWrapping:get_line_idx_col_count(self.doc, line, col)
+  local nline, ncol2 = LineWrapping:get_idx_line_col(self.doc, idx - 1)
+  if nline ~= line then return line - 1, dv:get_col_x_offset(line, col) end
+  return nline, ncol2
+end
+
+function DocView.translate.next_line(doc, line, col, dv)
+  local idx, ncol = LineWrapping:get_line_idx_col_count(self.doc, line, col)
+  local nline, ncol2 = LineWrapping:get_idx_line_col(self.doc, idx + 1)
+  if nline ~= line then return line + 1, dv:get_col_x_offset(line, col) end
+  return nline, ncol2
+end
+
+command.add(nil, {
+  ["linewrapping:enable"] = function() 
+    LineWrapping.width_override = nil 
+  end,
+  ["linewrapping:disable"] = function() 
+    LineWrapping.width_override = math.huge 
+    if core.active_view and core.active_view.doc then
+      LineWrapping:reconstruct_breaks(core.active_view.doc)
+    end
+  end,
+})
+
+return LineWrapping

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -102,6 +102,7 @@ end
 
 -- Updates the breaks for the various lines; with no extra new lines added.
 function LineWrapping.update_breaks(docview, line)
+  if line < 1 or line > #docview.doc.lines then return end
   local idx = docview.wrapped_line_to_idx[line]
   local offset = (idx - 1) * 2 + 1
   local breaks, begin_width = LineWrapping.compute_line_breaks(docview.doc, docview.wrapped_settings.font, line, docview.wrapped_settings.width, config.plugins.linewrapping.mode)

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -277,6 +277,7 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
         local lines = #self.lines - old_lines
         if lines > 0 then LineWrapping.add_lines(docview, line, lines) end
         LineWrapping.update_breaks(docview, line)
+        LineWrapping.update_breaks(docview, line+1)
       end
     end
   end
@@ -291,6 +292,7 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
         if line1 ~= line2 then
           LineWrapping.remove_lines(docview, line1, line2 - 1)
         end
+        LineWrapping.update_breaks(docview, line1 - 1)
         LineWrapping.update_breaks(docview, line1)
       end
     end


### PR DESCRIPTION
An ongoing PR where implementing soft line wrapping.

I've managed to implement it as a plugin; I think that's probably the best place to put it, as it's not really core to the editor; but it is a very common ask. (#326, #36, numerous times on discord, etc..)

The only changes I've made to the core (beyond the plugin), are making things a bit clearer in the `DocView` by renaming `idx` to `line` where appropriate, and ensuring that the various `draw_line` functions return the height of the line they're drawing (as with this plugin, a variable line height is possible). This will have to be paired with plugin changes, as several plugins override these functions, so this should be paired with a mod-version bump, and upgrading these plugins to support that kind of change if we want to merge this.

Currently the plugin is semi-functional, but is incredibly verbose and needlessly repetitive, and highly inefficient. I'll be refining it over the coming days to get it up to snuff; hopefully cutting down the size and complexity significantly and having it incrementally compute the linebreaks, rather than recomputing the entire document on every keystroke.

Example here:

https://user-images.githubusercontent.com/1034518/138949582-9160c538-a526-4ea4-a8be-dff8e69d9f3d.mp4

: 