### PR TITLE
Use Python syntax highlighting for Ren'Py scripts.

### DIFF
--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -2,7 +2,7 @@
 local syntax = require "core.syntax"
 
 syntax.add {
-  files = { "%.py$", "%.pyw$" },
+  files = { "%.py$", "%.pyw$", "%.rpy$" },
   headers = "^#!.*[ /]python",
   comment = "#",
   patterns = {


### PR DESCRIPTION
Ren'Py is a very popular Python visual novel engine, which has it's own "coding language" (even GitHub shows it as a separate language) and it's own file extension.
Generally Python syntax highlighting works for the Ren'Py language.

This should be added so Ren'Py developers don't have to add this by themselves.