### PR TITLE
Add install instructions for prebuilt binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ affects only the place where the application is actually installed.
 
 Head over to [releases](https://github.com/lite-xl/lite-xl/releases) and download the version for your operating system.
 
-### Ubuntu
+### Linux
 
 Unzip the file and `cd` into the `lite-xl` directory:
 
@@ -90,7 +90,13 @@ tar -xzf <file>
 cd lite-xl
 ```
 
-Copy files over into appropriate directories:
+To run lite-xl without installing:
+```sh
+cd bin
+./lite-xl
+```
+
+To install lite-xl copy files over into appropriate directories:
 
 ```sh
 mkdir -p $HOME/.local/bin && cp bin/lite-xl $HOME/.local/bin
@@ -118,11 +124,9 @@ rm -f $HOME/.local/bin/lite-xl
 rm -rf $HOME/.local/share/icons/hicolor/scalable/apps/lite-xl.svg \
           $HOME/.local/share/applications/org.lite_xl.lite_xl.desktop \
           $HOME/.local/share/metainfo/org.lite_xl.lite_xl.appdata.xml \
-          $HOME/.local/share/lite-xl \
-          $HOME/.local/share/doc/lite-xl
+          $HOME/.local/share/lite-xl
 ```
 
-You may need to `Alt + F2` and enter 'r' to see changes.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,53 @@ DESTDIR="$(pwd)/Lite XL.app" meson install --skip-subprojects -C build
 Please note that the package is relocatable to any prefix and the option prefix
 affects only the place where the application is actually installed.
 
+## Installing Prebuilt
+
+Head over to [releases](https://github.com/lite-xl/lite-xl/releases) and download the version for your operating system.
+
+### Ubuntu
+
+Unzip the file and `cd` into the `lite-xl` directory:
+
+```sh
+tar -xzf <file>
+cd lite-xl
+```
+
+Copy files over into appropriate directories:
+
+```sh
+mkdir -p $HOME/.local/bin && cp bin/lite-xl $HOME/.local/bin
+cp -r share $HOME/.local
+```
+
+If `$HOME/.local/bin` is not in PATH:
+
+```sh
+echo -e 'export PATH=$PATH:$HOME/.local/bin' >> $HOME/.bashrc
+```
+
+To get the icon to show up in app launcher:
+
+```sh
+xdg-desktop-menu forceupdate
+```
+
+You may need to logout and login again to see icon in app launcher.
+
+To uninstall just run:
+
+```sh
+rm -f $HOME/.local/bin/lite-xl
+rm -rf $HOME/.local/share/icons/hicolor/scalable/apps/lite-xl.svg \
+          $HOME/.local/share/applications/org.lite_xl.lite_xl.desktop \
+          $HOME/.local/share/metainfo/org.lite_xl.lite_xl.appdata.xml \
+          $HOME/.local/share/lite-xl \
+          $HOME/.local/share/doc/lite-xl
+```
+
+You may need to `Alt + F2` and enter 'r' to see changes.
+
 ## Contributing
 
 Any additional functionality that can be added through a plugin should be done


### PR DESCRIPTION
Intructions for people that decide not to build themselves. When I was trying to install the application, I found the docs to be lacking any instructions for installing prebuilt binaries. I spent hours trying to get the application icons to work :sob: so I don't want anyone else to waste their time like I did. Thanks to @frogtile for the inspiration. #522  
Tested on Ubuntu-vm 20.04.3 to make sure it works.