### PR TITLE
Made plugin load order deterministic.

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -675,16 +675,18 @@ function core.load_plugins()
     userdir = {dir = USERDIR, plugins = {}},
     datadir = {dir = DATADIR, plugins = {}},
   }
-  local files = {}
+  local files, ordered = {}, {}
   for _, root_dir in ipairs {DATADIR, USERDIR} do
     local plugin_dir = root_dir .. "/plugins"
     for _, filename in ipairs(system.list_dir(plugin_dir) or {}) do
+      if not files[filename] then table.insert(ordered, filename) end
       files[filename] = plugin_dir -- user plugins will always replace system plugins
     end
   end
+  table.sort(ordered)
 
-  for filename, plugin_dir in pairs(files) do
-    local basename = filename:match("(.-)%.lua$") or filename
+  for i, filename in ipairs(ordered) do
+    local plugin_dir, basename = files[filename], filename:match("(.-)%.lua$") or filename
     local is_lua_file, version_match = check_plugin_version(plugin_dir .. '/' .. filename)
     if is_lua_file then
       if not version_match then

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -685,7 +685,7 @@ function core.load_plugins()
   end
   table.sort(ordered)
 
-  for i, filename in ipairs(ordered) do
+  for _, filename in ipairs(ordered) do
     local plugin_dir, basename = files[filename], filename:match("(.-)%.lua$") or filename
     local is_lua_file, version_match = check_plugin_version(plugin_dir .. '/' .. filename)
     if is_lua_file then


### PR DESCRIPTION
Sometimes you'll get errors depending on the order in which plugins load.

Very simple change that adds in a sort to enforce a deterministic load order that just makes everything a lot easier to debug. Plus, this'll let us if we really need to name plugins with numeric prefixes in order to influence sort order manually.