### PR TITLE
Make selection behavior more in line with other editors

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -362,6 +362,10 @@ function DocView:draw_line_body(idx, x, y)
       if line2 ~= idx then col2 = #text + 1 end
       local x1 = x + self:get_col_x_offset(idx, col1)
       local x2 = x + self:get_col_x_offset(idx, col2)
+      if line2 ~= idx and line1 ~= line2 then
+        -- draw selection on the whole line
+        x2 = x + self.scroll.x + self.size.x
+      end
       local lh = self:get_line_height()
       if x1 ~= x2 then
         renderer.draw_rect(x1, y, x2 - x1, lh, style.selection)

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -354,6 +354,18 @@ function DocView:draw_caret(x, y)
 end
 
 function DocView:draw_line_body(idx, x, y)
+  -- draw highlight if any selection ends on this line
+  local draw_highlight = false
+  for lidx, line1, col1, line2, col2 in self.doc:get_selections(false) do
+    if line1 == idx then
+      draw_highlight = true
+      break
+    end
+  end
+  if draw_highlight and config.highlight_current_line and core.active_view == self then
+    self:draw_line_highlight(x + self.scroll.x, y)
+  end
+
   -- draw selection if it overlaps this line
   for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do
     if idx >= line1 and idx <= line2 then
@@ -372,15 +384,6 @@ function DocView:draw_line_body(idx, x, y)
       end
     end
   end
-  local draw_highlight = nil
-  for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do
-    -- draw line highlight if caret is on this line
-    if draw_highlight ~= false and config.highlight_current_line
-    and line1 == idx and core.active_view == self then
-      draw_highlight = (line1 == line2 and col1 == col2)
-    end
-  end
-  if draw_highlight then self:draw_line_highlight(x + self.scroll.x, y) end
 
   -- draw line's text
   self:draw_line_text(idx, x, y)


### PR DESCRIPTION
Before:
![Before](https://user-images.githubusercontent.com/2798487/140766132-b7336441-59fb-4e8f-bbf5-141950a9e189.png)

After:
![After](https://user-images.githubusercontent.com/2798487/140766175-052ce3ca-abef-47a6-ab9d-cdec849f6740.png)

Also, now lines with selections are highlighted if they contain a caret.