### PR TITLE
fixed borderless settings behaviour after exit from FullScreenMode

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -3,6 +3,7 @@ local common = require "core.common"
 local command = require "core.command"
 local keymap = require "core.keymap"
 local LogView = require "core.logview"
+local config = require "core.config"
 
 
 local fullscreen = false
@@ -30,6 +31,10 @@ command.add(nil, {
     system.set_window_mode(fullscreen and "fullscreen" or "normal")
     core.show_title_bar(not fullscreen)
     core.title_view:configure_hit_test(not fullscreen)
+    
+    system.set_window_bordered(not config.borderless)
+    core.show_title_bar(config.borderless)
+    core.title_view:configure_hit_test(config.borderless)
   end,
 
   ["core:reload-module"] = function()


### PR DESCRIPTION
For every platform, when borderless mode is disable after exit from FullScreen Mode (activated Alt+Enter combination) restored window is activated borderless titlebar together with OS TitleBar.

How it was look:
![Снимок экрана 2021-11-10 в 00 15 02](https://user-images.githubusercontent.com/10284309/141006411-e6fbe781-6336-4632-9264-5228d4f7f7e7.png)

