### PR TITLE
Restore `TitleView` only when needed

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -6,6 +6,7 @@ local LogView = require "core.logview"
 
 
 local fullscreen = false
+local restore_title_view = false
 
 local function suggest_directory(text)
   text = common.home_expand(text)
@@ -28,9 +29,12 @@ command.add(nil, {
 
   ["core:toggle-fullscreen"] = function()
     fullscreen = not fullscreen
+    if fullscreen then
+      restore_title_view = core.title_view.visible
+    end
     system.set_window_mode(fullscreen and "fullscreen" or "normal")
-    core.show_title_bar(not fullscreen)
-    core.title_view:configure_hit_test(not fullscreen)
+    core.show_title_bar(not fullscreen and restore_title_view)
+    core.title_view:configure_hit_test(not fullscreen and restore_title_view)
   end,
 
   ["core:reload-module"] = function()


### PR DESCRIPTION
Before, every time the user came back from fullscreen, the `TitleView` was shown regardless of its previous status.

Edit: also :smiling_imp: