### PR TITLE
Prepopulate highlighter

### DIFF
--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -40,6 +40,13 @@ end
 
 function Highlighter:reset()
   self.lines = {}
+  self:soft_reset()
+end
+
+function Highlighter:soft_reset()
+  for i=1,#self.lines do
+    self.lines[i] = false
+  end
   self.first_invalid_line = 1
   self.max_wanted_line = 0
 end

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -47,7 +47,7 @@ function Doc:reset_syntax()
   local syn = syntax.get(self.filename or "", header)
   if self.syntax ~= syn then
     self.syntax = syn
-    self.highlighter:reset()
+    self.highlighter:soft_reset()
   end
 end
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -62,12 +62,15 @@ function Doc:load(filename)
   local fp = assert( io.open(filename, "rb") )
   self:reset()
   self.lines = {}
+  local i = 1
   for line in fp:lines() do
     if line:byte(-1) == 13 then
       line = line:sub(1, -2)
       self.crlf = true
     end
     table.insert(self.lines, line .. "\n")
+    self.highlighter.lines[i] = false
+    i = i + 1
   end
   if #self.lines == 0 then
     table.insert(self.lines, "\n")


### PR DESCRIPTION
Before this change, calls to `insert_notify` and `remove_notify` about lines that the `highlighter` hadn't yet encountered were throwing an error.

To test this problem, open a file with a decent number of lines (1000+) and _quickly_ press ctrl+a ctrl+c ctrl+v ctrl+v.