### PR TITLE
Refactor how to get the indentation of a `Doc`

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -16,14 +16,6 @@ local function doc()
 end
 
 
-local function get_indent_string()
-  if config.tab_type == "hard" then
-    return "\t"
-  end
-  return string.rep(" ", config.indent_size)
-end
-
-
 local function doc_multiline_selections(sort)
   local iter, state, idx, line1, col1, line2, col2 = doc():get_selections(sort)
   return function()
@@ -157,11 +149,12 @@ local commands = {
   end,
 
   ["doc:backspace"] = function()
+    local _, indent_size = doc():get_indent_info()
     for idx, line1, col1, line2, col2 in doc():get_selections() do
       if line1 == line2 and col1 == col2 then
         local text = doc():get_text(line1, 1, line1, col1)
-        if #text >= config.indent_size and text:find("^ *$") then
-          doc():delete_to_cursor(idx, 0, -config.indent_size)
+        if #text >= indent_size and text:find("^ *$") then
+          doc():delete_to_cursor(idx, 0, -indent_size)
           return
         end
       end
@@ -271,7 +264,7 @@ local commands = {
   ["doc:toggle-line-comments"] = function()
     local comment = doc().syntax.comment
     if not comment then return end
-    local indentation = get_indent_string()
+    local indentation = doc():get_indent_string()
     local comment_text = comment .. " "
     for idx, line1, _, line2 in doc_multiline_selections(true) do
       local uncomment = true

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -115,6 +115,14 @@ function Doc:clean()
 end
 
 
+function Doc:get_indent_info()
+  if not self.indent_info then return config.tab_type, config.indent_size, false end
+  return self.indent_info.type or config.tab_type,
+         self.indent_info.size or config.indent_size,
+         self.indent_info.confirmed
+end
+
+
 function Doc:get_change_id()
   return self.undo_stack.idx
 end

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -494,19 +494,21 @@ end
 function Doc:select_to(...) return self:select_to_cursor(nil, ...) end
 
 
-local function get_indent_string()
-  if config.tab_type == "hard" then
+function Doc:get_indent_string()
+  local indent_type, indent_size = self:get_indent_info()
+  if indent_type == "hard" then
     return "\t"
   end
-  return string.rep(" ", config.indent_size)
+  return string.rep(" ", indent_size)
 end
 
 -- returns the size of the original indent, and the indent
 -- in your config format, rounded either up or down
-local function get_line_indent(line, rnd_up)
+function Doc:get_line_indent(line, rnd_up)
   local _, e = line:find("^[ \t]+")
-  local soft_tab = string.rep(" ", config.indent_size)
-  if config.tab_type == "hard" then
+  local indent_type, indent_size = self:get_indent_info()
+  local soft_tab = string.rep(" ", indent_size)
+  if indent_type == "hard" then
     local indent = e and line:sub(1, e):gsub(soft_tab, "\t") or ""
     return e, indent:gsub(" +", rnd_up and "\t" or "")
   else
@@ -528,14 +530,14 @@ end
 -- * if you are unindenting, the cursor will jump to the start of the line,
 --   and remove the appropriate amount of spaces (or a tab).
 function Doc:indent_text(unindent, line1, col1, line2, col2)
-  local text = get_indent_string()
+  local text = self:get_indent_string()
   local _, se = self.lines[line1]:find("^[ \t]+")
   local in_beginning_whitespace = col1 == 1 or (se and col1 <= se + 1)
   local has_selection = line1 ~= line2 or col1 ~= col2
   if unindent or has_selection or in_beginning_whitespace then
     local l1d, l2d = #self.lines[line1], #self.lines[line2]
     for line = line1, line2 do
-      local e, rnded = get_line_indent(self.lines[line], unindent)
+      local e, rnded = self:get_line_indent(self.lines[line], unindent)
       self:remove(line, 1, line, (e or 0) + 1)
       self:insert(line, 1,
         unindent and rnded:sub(1, #rnded - #text) or rnded .. text)

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -395,8 +395,8 @@ end
 
 function DocView:draw()
   self:draw_background(style.background)
-
-  self:get_font():set_tab_size(config.indent_size)
+  local _, indent_size = self.doc:get_indent_info()
+  self:get_font():set_tab_size(indent_size)
 
   local minline, maxline = self:get_visible_line_range()
   local lh = self:get_line_height()

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -108,9 +108,9 @@ function StatusView:get_items()
     local dv = core.active_view
     local line, col = dv.doc:get_selection()
     local dirty = dv.doc:is_dirty()
-    local indent = dv.doc.indent_info
-    local indent_label = (indent and indent.type == "hard") and "tabs: " or "spaces: "
-    local indent_size = indent and tostring(indent.size) .. (indent.confirmed and "" or "*") or "unknown"
+    local indent_type, indent_size, indent_confirmed = dv.doc:get_indent_info()
+    local indent_label = (indent_type == "hard") and "tabs: " or "spaces: "
+    local indent_size_str = tostring(indent_size) .. (indent_confirmed and "" or "*") or "unknown"
 
     return {
       dirty and style.accent or style.text, style.icon_font, "f",

--- a/data/plugins/detectindent.lua
+++ b/data/plugins/detectindent.lua
@@ -121,40 +121,17 @@ end
 local clean = Doc.clean
 function Doc:clean(...)
   clean(self, ...)
-  if not cache[self].confirmed then
+  local _, _, confirmed = self:get_indent_info()
+  if not confirmed then
     update_cache(self)
   end
 end
 
 
-local function with_indent_override(doc, fn, ...)
-  local c = cache[doc]
-  if not c then
-    return fn(...)
-  end
-  local type, size = config.tab_type, config.indent_size
-  config.tab_type, config.indent_size = c.type, c.size or config.indent_size
-  local r1, r2, r3 = fn(...)
-  config.tab_type, config.indent_size = type, size
-  return r1, r2, r3
-end
-
-
-local perform = command.perform
-function command.perform(...)
-  return with_indent_override(core.active_view.doc, perform, ...)
-end
-
-
-local draw = DocView.draw
-function DocView:draw(...)
-  return with_indent_override(self.doc, draw, self, ...)
-end
-
-
 local function set_indent_type(doc, type)
+  local _, indent_size = doc:get_indent_info()
   cache[doc] = {type = type,
-                size = cache[doc].value or config.indent_size,
+                size = indent_size,
                 confirmed = true}
   doc.indent_info = cache[doc]
 end
@@ -180,7 +157,8 @@ end
 
 
 local function set_indent_size(doc, size)
-  cache[doc] = {type = cache[doc].type or config.tab_type,
+  local indent_type = doc:get_indent_info()
+  cache[doc] = {type = indent_type,
                 size = size,
                 confirmed = true}
   doc.indent_info = cache[doc]


### PR DESCRIPTION
Before, info on the indent type of a `Doc` was split between `Doc.indent_info` and `config.tab_type` and `config.indent_size` (that `detectindent` overrode with `with_indent_override`). This caused some instances where the information was conflicting.

With this PR, `Doc`s can be queried with `Doc:get_indent_info` to obtain what they are actually using.