### PR TITLE
Add names to language plugins

### DIFF
--- a/data/plugins/language_c.lua
+++ b/data/plugins/language_c.lua
@@ -2,6 +2,7 @@
 local syntax = require "core.syntax"
 
 syntax.add {
+  name = "C",
   files = { "%.c$", "%.h$", "%.inl$" },
   comment = "//",
   patterns = {

--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -4,6 +4,7 @@ pcall(require, "plugins.language_c")
 local syntax = require "core.syntax"
 
 syntax.add {
+  name = "C++",
   files = {
     "%.h$", "%.inl$", "%.cpp$", "%.cc$", "%.C$", "%.cxx$",
     "%.c++$", "%.hh$", "%.H$", "%.hxx$", "%.hpp$", "%.h++$"

--- a/data/plugins/language_css.lua
+++ b/data/plugins/language_css.lua
@@ -2,6 +2,7 @@
 local syntax = require "core.syntax"
 
 syntax.add {
+  name = "CSS",
   files = { "%.css$" },
   patterns = {
     { pattern = "\\.",                type = "normal"   },

--- a/data/plugins/language_html.lua
+++ b/data/plugins/language_html.lua
@@ -2,6 +2,7 @@
 local syntax = require "core.syntax"
 
 syntax.add {
+  name = "HTML",
   files = { "%.html?$" },
   patterns = {
     { 

--- a/data/plugins/language_js.lua
+++ b/data/plugins/language_js.lua
@@ -2,6 +2,7 @@
 local syntax = require "core.syntax"
 
 syntax.add {
+  name = "JavaScript",
   files = { "%.js$", "%.json$", "%.cson$" },
   comment = "//",
   patterns = {

--- a/data/plugins/language_lua.lua
+++ b/data/plugins/language_lua.lua
@@ -2,6 +2,7 @@
 local syntax = require "core.syntax"
 
 syntax.add {
+  name = "Lua",
   files = "%.lua$",
   headers = "^#!.*[ /]lua",
   comment = "--",

--- a/data/plugins/language_md.lua
+++ b/data/plugins/language_md.lua
@@ -4,6 +4,7 @@ local syntax = require "core.syntax"
 
 
 syntax.add {
+  name = "Markdown",
   files = { "%.md$", "%.markdown$" },
   patterns = {
     { pattern = "\\.",                      type = "normal"   },

--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -2,6 +2,7 @@
 local syntax = require "core.syntax"
 
 syntax.add {
+  name = "Python",
   files = { "%.py$", "%.pyw$" },
   headers = "^#!.*[ /]python",
   comment = "#",

--- a/data/plugins/language_xml.lua
+++ b/data/plugins/language_xml.lua
@@ -2,6 +2,7 @@
 local syntax = require "core.syntax"
 
 syntax.add {
+  name = "XML",
   files = { "%.xml$" },
   headers = "<%?xml",
   patterns = {


### PR DESCRIPTION
I noticed that we have `language_cpp.lua` both here and in lite-plugins; is this intended?