### PR TITLE
Allow for color overrides in the tree view

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -43,7 +43,6 @@ function TreeView:new()
   self.cache = {}
   self.last = {}
   self.tooltip = { x = 0, y = 0, begin = 0, alpha = 0 }
-  self.color_overrides = {}
 end
 
 
@@ -296,13 +295,9 @@ function TreeView:draw_tooltip()
 end
 
 
-function TreeView:set_color_override(abs_filename, color)
-  self.color_overrides[abs_filename] = color
-end
-
-
-function TreeView:clear_all_color_overrides()
-  self.color_overrides = {}
+function TreeView:color_for_item(abs_filename)
+  -- other plugins can override this to customize the color of each icon
+  return nil
 end
 
 
@@ -330,7 +325,7 @@ function TreeView:draw()
     end
 
     -- allow for color overrides
-    local icon_color = self.color_overrides[item.abs_filename] or color
+    local icon_color = self:color_for_item(item.abs_filename) or color
     
     -- icons
     x = x + item.depth * style.padding.x + style.padding.x

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -43,6 +43,7 @@ function TreeView:new()
   self.cache = {}
   self.last = {}
   self.tooltip = { x = 0, y = 0, begin = 0, alpha = 0 }
+  self.color_overrides = {}
 end
 
 
@@ -295,6 +296,16 @@ function TreeView:draw_tooltip()
 end
 
 
+function TreeView:set_color_override(abs_filename, color)
+  self.color_overrides[abs_filename] = color
+end
+
+
+function TreeView:clear_all_color_overrides()
+  self.color_overrides = {}
+end
+
+
 function TreeView:draw()
   self:draw_background(style.background2)
 
@@ -318,6 +329,9 @@ function TreeView:draw()
       color = style.accent
     end
 
+    -- allow for color overrides
+    local icon_color = self.color_overrides[item.abs_filename] or color
+    
     -- icons
     x = x + item.depth * style.padding.x + style.padding.x
     if item.type == "dir" then
@@ -325,11 +339,11 @@ function TreeView:draw()
       local icon2 = item.expanded and "D" or "d"
       common.draw_text(style.icon_font, color, icon1, nil, x, y, 0, h)
       x = x + style.padding.x
-      common.draw_text(style.icon_font, color, icon2, nil, x, y, 0, h)
+      common.draw_text(style.icon_font, icon_color, icon2, nil, x, y, 0, h)
       x = x + icon_width
     else
       x = x + style.padding.x
-      common.draw_text(style.icon_font, color, "f", nil, x, y, 0, h)
+      common.draw_text(style.icon_font, icon_color, "f", nil, x, y, 0, h)
       x = x + icon_width
     end
 


### PR DESCRIPTION
This PR adds two new functions on TreeView:

- `set_color_override(abs_filename, color)` assigns a color to a specific file based on its absolute path.
- `clear_all_color_overrides()` clears all color overrides.

Other plugins can use this feature to highlight particular files, for example to indicate whether they have pending changes.

This change is small, light weight, has minimal performance impact, and does not change the default behavior or presentation of the tree view.

See this PR which shows the motivating use case: https://github.com/lite-xl/lite-plugins/pull/93

<img width="390" alt="image" src="https://user-images.githubusercontent.com/169599/142755662-775cb7e2-504a-404a-964c-764c410c46a3.png">
