### PR TITLE
Add Support for `none` Antialiasing

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -6,16 +6,18 @@ static int f_font_load(lua_State *L) {
   const char *filename  = luaL_checkstring(L, 1);
   float size = luaL_checknumber(L, 2);
   unsigned int font_hinting = FONT_HINTING_SLIGHT, font_style = 0;
-  bool subpixel = true;
+  ERenFontAntialiasing font_antialiasing = FONT_ANTIALIASING_SUBPIXEL;
   if (lua_gettop(L) > 2 && lua_istable(L, 3)) {
     lua_getfield(L, 3, "antialiasing");
     if (lua_isstring(L, -1)) {
       const char *antialiasing = lua_tostring(L, -1);
       if (antialiasing) {
-        if (strcmp(antialiasing, "grayscale") == 0) {
-          subpixel = false;
+        if (strcmp(antialiasing, "none") == 0) {
+          font_antialiasing = FONT_ANTIALIASING_NONE;
+        } else if (strcmp(antialiasing, "grayscale") == 0) {
+          font_antialiasing = FONT_ANTIALIASING_GRAYSCALE;
         } else if (strcmp(antialiasing, "subpixel") == 0) {
-          subpixel = true;
+          font_antialiasing = FONT_ANTIALIASING_SUBPIXEL;
         } else {
           return luaL_error(L, "error in renderer.font.load, unknown antialiasing option: \"%s\"", antialiasing);
         }
@@ -48,7 +50,7 @@ static int f_font_load(lua_State *L) {
     lua_pop(L, 5);
   }
   RenFont** font = lua_newuserdata(L, sizeof(RenFont*));
-  *font = ren_font_load(filename, size, subpixel, font_hinting, font_style);
+  *font = ren_font_load(filename, size, font_antialiasing, font_hinting, font_style);
   if (!*font)
     return luaL_error(L, "failed to load font");
   luaL_setmetatable(L, API_TYPE_FONT);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -8,11 +8,12 @@
 #define FONT_FALLBACK_MAX 4
 typedef struct RenFont RenFont;
 typedef enum { FONT_HINTING_NONE, FONT_HINTING_SLIGHT, FONT_HINTING_FULL } ERenFontHinting;
+typedef enum { FONT_ANTIALIASING_NONE, FONT_ANTIALIASING_GRAYSCALE, FONT_ANTIALIASING_SUBPIXEL } ERenFontAntialiasing;
 typedef enum { FONT_STYLE_BOLD = 1, FONT_STYLE_ITALIC = 2, FONT_STYLE_UNDERLINE = 4 } ERenFontStyle;
 typedef struct { uint8_t b, g, r, a; } RenColor;
 typedef struct { int x, y, width, height; } RenRect;
 
-RenFont* ren_font_load(const char *filename, float size, bool subpixel, unsigned char hinting, unsigned char style);
+RenFont* ren_font_load(const char *filename, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, unsigned char style);
 RenFont* ren_font_copy(RenFont* font, float size);
 void ren_font_free(RenFont *font);
 int ren_font_group_get_tab_size(RenFont **font);


### PR DESCRIPTION
Made anti-aliasing choices explicit and enabled monochrome rendering; changed subpixel true/false to `none`, `grayscale` and `subpxiel`, as requested by a user on discord.