### PR TITLE
Removed docs for *_subpixel functions which no longer exist

### DIFF
--- a/docs/api/renderer.lua
+++ b/docs/api/renderer.lua
@@ -62,26 +62,11 @@ function renderer.font:set_tab_size(chars) end
 function renderer.font:get_width(text) end
 
 ---
----Get the width in subpixels of the given text when
----rendered with this font.
----
----@param text string
----
----@return number
-function renderer.font:get_width_subpixel(text) end
-
----
 ---Get the height in pixels that occupies a single character
 ---when rendered with this font.
 ---
 ---@return number
 function renderer.font:get_height() end
-
----
----Gets the font subpixel scale.
----
----@return number
-function renderer.font:subpixel_scale() end
 
 ---
 ---Get the current size of the font.


### PR DESCRIPTION
Removed docs for get_width_subpixel and subpixel_scale which no longer exist.