### PR TITLE
Used basenames for ignore_files rather than full paths.

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -100,7 +100,7 @@ local function get_project_file_info(root, file)
   if info then
     info.filename = strip_leading_path(file)
     return (info.size < config.file_size_limit * 1e6 and
-      not common.match_pattern(info.filename, config.ignore_files)
+      not common.match_pattern(common.basename(info.filename), config.ignore_files)
       and info)
   end
 end


### PR DESCRIPTION
Reverts to the old behaviour of ignore_files.