### PR TITLE
Fixed issue with ignored files. Reverted to only surface-level scans on Linux.

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -173,7 +173,7 @@ local function show_max_files_warning(dir)
     "Too many files in project directory: stopped reading at "..
     config.max_project_files.." files. For more information see "..
     "usage.md at github.com/franko/lite-xl."
-  core.log(message)
+  core.error(message)
 end
 
 
@@ -330,9 +330,7 @@ function core.open_folder_project(dir_path_abs)
     if not core.load_project_module() then
       command.perform("core:open-log")
     end
-    for i = 1, #core.project_directories do
-      scan_project_folder(i)
-    end
+    scan_project_folder(1)
     core.on_enter_project(dir_path_abs)
   end
 end
@@ -351,6 +349,7 @@ function core.add_project_directory(path)
     shown_subdir = {},
   }
   table.insert(core.project_directories, dir)
+  scan_project_folder(#core.project_directories)
   core.redraw = true
 end
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -58,7 +58,7 @@ function core.set_project_dir(new_dir, change_project_fn)
     if change_project_fn then change_project_fn() end
     core.project_dir = common.normalize_volume(new_dir)
     core.project_directories = {}
-    core.add_project_directory(new_dir)
+    core.add_project_directory(new_dir, true)
     return true
   end
   return false
@@ -336,7 +336,7 @@ function core.open_folder_project(dir_path_abs)
 end
 
 
-function core.add_project_directory(path)
+function core.add_project_directory(path, noscan)
   -- top directories has a file-like "item" but the item.filename
   -- will be simply the name of the directory, without its path.
   -- The field item.topdir will identify it as a top level directory.
@@ -349,7 +349,9 @@ function core.add_project_directory(path)
     shown_subdir = {},
   }
   table.insert(core.project_directories, dir)
-  scan_project_folder(#core.project_directories)
+  if not noscan then
+    scan_project_folder(#core.project_directories)
+  end
   core.redraw = true
 end
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -321,9 +321,6 @@ local function scan_project_folder(index)
   else
     core.dir_rescan_add_job(dir, ".")
   end
-  if dir.name == core.project_dir then
-    core.project_files = dir.files
-  end
 end
 
 function core.open_folder_project(dir_path_abs)
@@ -702,10 +699,11 @@ function core.init()
     core.log("Opening project %q from directory %s", pname, pdir)
   end
   local got_project_error = not core.load_project_module()
+  local plugins_success, plugins_refuse_list = core.load_plugins()
+  
   for i = 1, #core.project_directories do
     scan_project_folder(i)
   end
-  local plugins_success, plugins_refuse_list = core.load_plugins()
 
   -- We assume we have just a single project directory here. Now that StatusView
   -- is there show max files warning if needed.

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -139,7 +139,7 @@ function StatusView:get_items()
     style.icon_font, "g",
     style.font, style.dim, self.separator2,
     #core.docs, style.text, " / ",
-    #core.project_files, " files"
+    core.project_files_number(), " files"
   }
 end
 

--- a/src/main.c
+++ b/src/main.c
@@ -108,12 +108,13 @@ int main(int argc, char **argv) {
   SDL_DisplayMode dm;
   SDL_GetCurrentDisplayMode(0, &dm);
 
+  dirmonitor_init();
+
   window = SDL_CreateWindow(
     "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, dm.w * 0.8, dm.h * 0.8,
     SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_HIDDEN);
   init_window_icon();
   ren_init(window);
-  dirmonitor_init();
 
   lua_State *L;
 init_lua:

--- a/src/main.c
+++ b/src/main.c
@@ -108,8 +108,6 @@ int main(int argc, char **argv) {
   SDL_DisplayMode dm;
   SDL_GetCurrentDisplayMode(0, &dm);
 
-  dirmonitor_init();
-
   window = SDL_CreateWindow(
     "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, dm.w * 0.8, dm.h * 0.8,
     SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_HIDDEN);
@@ -118,6 +116,7 @@ int main(int argc, char **argv) {
 
   lua_State *L;
 init_lua:
+  dirmonitor_init();
   L = luaL_newstate();
   luaL_openlibs(L);
   api_load_libs(L);
@@ -187,6 +186,7 @@ init_lua:
   if (lua_toboolean(L, -1)) {
     lua_close(L);
     rencache_invalidate();
+    dirmonitor_deinit();
     goto init_lua;
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -113,10 +113,10 @@ int main(int argc, char **argv) {
     SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_HIDDEN);
   init_window_icon();
   ren_init(window);
+  dirmonitor_init();
 
   lua_State *L;
 init_lua:
-  dirmonitor_init();
   L = luaL_newstate();
   luaL_openlibs(L);
   api_load_libs(L);
@@ -186,7 +186,6 @@ init_lua:
   if (lua_toboolean(L, -1)) {
     lua_close(L);
     rencache_invalidate();
-    dirmonitor_deinit();
     goto init_lua;
   }
 


### PR DESCRIPTION
Recursive scan of a directory that has large ignored folders will fail. Also moved around where dirmonitor was initialized and deinitialized. Should at least allow for the thing to work on all linux projects.