### PR TITLE
Copy/cut whole line if selection empty

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -47,17 +47,26 @@ end
 
 local function cut_or_copy(delete)
   local full_text = ""
+  local text = ""
   for idx, line1, col1, line2, col2 in doc():get_selections() do
     if line1 ~= line2 or col1 ~= col2 then
-      local text = doc():get_text(line1, col1, line2, col2)
+      text = doc():get_text(line1, col1, line2, col2)
+      full_text = full_text == "" and text or (full_text .. "\n" .. text)
       if delete then
         doc():delete_to_cursor(idx, 0)
       end
-      full_text = full_text == "" and text or (full_text .. "\n" .. text)
-      doc().cursor_clipboard[idx] = text
     else
-      doc().cursor_clipboard[idx] = ""
+      text = "\n" .. doc().lines[line1]:gsub("\n", "")
+      full_text = full_text == "" and text or (full_text ..  text)
+      if delete then
+        if line1 < #doc().lines then
+          doc():remove(line1, 1, line1 + 1, 1)
+        else
+          doc():remove(line1 - 1, math.huge, line1, math.huge)
+        end
+      end
     end
+    doc().cursor_clipboard[idx] = text
   end
   doc().cursor_clipboard["full"] = full_text
   system.set_clipboard(full_text)
@@ -85,6 +94,13 @@ local function set_cursor(x, y, snap_type)
 end
 
 local selection_commands = {
+  ["doc:select-none"] = function()
+    local line, col = doc():get_selection()
+    doc():set_selection(line, col)
+  end
+}
+
+local commands = {
   ["doc:cut"] = function()
     cut_or_copy(true)
   end,
@@ -93,13 +109,6 @@ local selection_commands = {
     cut_or_copy(false)
   end,
 
-  ["doc:select-none"] = function()
-    local line, col = doc():get_selection()
-    doc():set_selection(line, col)
-  end
-}
-
-local commands = {
   ["doc:undo"] = function()
     doc():undo()
   end,
@@ -393,27 +402,27 @@ local commands = {
     os.remove(filename)
     core.log("Removed \"%s\"", filename)
   end,
-    
-  ["doc:select-to-cursor"] = function(x, y, clicks) 
+
+  ["doc:select-to-cursor"] = function(x, y, clicks)
     local line1, col1 = select(3, doc():get_selection())
     local line2, col2 = dv():resolve_screen_position(x, y)
     dv().mouse_selecting = { line1, col1, nil }
     doc():set_selection(line2, col2, line1, col1)
   end,
-  
+
   ["doc:set-cursor"] = function(x, y)
-    set_cursor(x, y, "set") 
+    set_cursor(x, y, "set")
   end,
-  
-  ["doc:set-cursor-word"] = function(x, y) 
-    set_cursor(x, y, "word") 
-  end,  
-  
-  ["doc:set-cursor-line"] = function(x, y, clicks) 
-    set_cursor(x, y, "lines") 
+
+  ["doc:set-cursor-word"] = function(x, y)
+    set_cursor(x, y, "word")
   end,
-  
-  ["doc:split-cursor"] = function(x, y, clicks) 
+
+  ["doc:set-cursor-line"] = function(x, y, clicks)
+    set_cursor(x, y, "lines")
+  end,
+
+  ["doc:split-cursor"] = function(x, y, clicks)
     local line, col = dv():resolve_screen_position(x, y)
     doc():add_selection(line, col, line, col)
   end,

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -135,7 +135,7 @@ local commands = {
         whole_line = core.cursor_clipboard_whole_line[idx] == true
       else
         value = clipboard
-        whole_line = clipboard:find("\n") ~= nil
+        whole_line = false
       end
       if whole_line then
         doc():insert(line1, 1, value:gsub("\r", ""))

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -135,7 +135,7 @@ local commands = {
         whole_line = core.cursor_clipboard_whole_line[idx] == true
       else
         value = clipboard
-        whole_line = false
+        whole_line = clipboard:find("\n") ~= nil
       end
       if whole_line then
         doc():insert(line1, 1, value:gsub("\r", ""))

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -33,8 +33,6 @@ end
 function Doc:reset()
   self.lines = { "\n" }
   self.selections = { 1, 1, 1, 1 }
-  self.cursor_clipboard = {}
-  self.cursor_clipboard_whole_line = {}
   self.undo_stack = { idx = 1 }
   self.redo_stack = { idx = 1 }
   self.clean_change_id = 1
@@ -199,7 +197,7 @@ function Doc:add_selection(line1, col1, line2, col2, swap)
 end
 
 function Doc:set_selection(line1, col1, line2, col2, swap)
-  self.selections, self.cursor_clipboard = {}, {}
+  self.selections = {}
   self:set_selections(1, line1, col1, line2, col2, swap)
 end
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -34,6 +34,7 @@ function Doc:reset()
   self.lines = { "\n" }
   self.selections = { 1, 1, 1, 1 }
   self.cursor_clipboard = {}
+  self.cursor_clipboard_whole_line = {}
   self.undo_stack = { idx = 1 }
   self.redo_stack = { idx = 1 }
   self.clean_change_id = 1
@@ -356,7 +357,7 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
 
   -- splice lines into line array
   common.splice(self.lines, line, 1, lines)
-  
+
   -- keep cursors where they should be
   for idx, cline1, ccol1, cline2, ccol2 in self:get_selections(true, true) do
     if cline1 < line then break end
@@ -388,7 +389,7 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
 
   -- splice line into line array
   common.splice(self.lines, line1, line2 - line1 + 1, { before .. after })
-  
+
   -- move all cursors back if they share a line with the removed text
   for idx, cline1, ccol1, cline2, ccol2 in self:get_selections(true, true) do
     if cline1 < line2 then break end
@@ -458,7 +459,7 @@ end
 function Doc:replace(fn)
   local has_selection, n = false, 0
   for idx, line1, col1, line2, col2 in self:get_selections(true) do
-    if line1 ~= line2 or col1 ~= col2 then 
+    if line1 ~= line2 or col1 ~= col2 then
       n = n + self:replace_cursor(idx, line1, col1, line2, col2, fn)
       has_selection = true
     end

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -207,12 +207,10 @@ function Doc:merge_cursors(idx)
       if self.selections[i] == self.selections[j] and
         self.selections[i+1] == self.selections[j+1] then
           common.splice(self.selections, i, 4)
-          common.splice(self.cursor_clipboard, i, 1)
           break
       end
     end
   end
-  if #self.selections <= 4 then self.cursor_clipboard = {} end
 end
 
 local function selection_iterator(invariant, idx)

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -648,6 +648,8 @@ function core.init()
   core.clip_rect_stack = {{ 0,0,0,0 }}
   core.log_items = {}
   core.docs = {}
+  core.cursor_clipboard = {}
+  core.cursor_clipboard_whole_line = {}
   core.window_mode = "normal"
   core.threads = setmetatable({}, { __mode = "k" })
   core.blink_start = system.get_time()


### PR DESCRIPTION
I already tried(https://github.com/rxi/lite/pull/209) to add this to the original project. But you know how things are going with the adoption of new features.

The current implementation differs from that due to the fact that this project supports multiple cursors. The difference is in insertion - if inserted in the middle of the line, then it will be inserted in the middle of the line :)
The old implementation was inserting a line next to it, without breaking the one where the courses are. 

If the cursor is at the end of the line, then the insert will work fine. And in my case, I almost always put the cursor at the end of a line if I want to insert a whole line. 
Although the difference does not seem big to me. The most important thing is that this functionality is generally added.

I am **absolutely sure that this functionality should be out of the box,** and not a plugin. I've tried many text editors, even simple console ones (nano, dte, micro, etc), and this feature is everywhere.