### PR TITLE
Consume unmatched character correctly

### DIFF
--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -237,8 +237,13 @@ function tokenizer.tokenize(incoming_syntax, text, state)
 
     -- consume character if we didn't match
     if not matched then
-      push_token(res, "normal", text:sub(i, i))
-      i = i + 1
+      local n = 0
+      -- reach the next character
+      while text:byte(i + n + 1) and common.is_utf8_cont(text, i + n + 1) do
+        n = n + 1
+      end
+      push_token(res, "normal", text:sub(i, i + n))
+      i = i + n + 1
     end
   end
 


### PR DESCRIPTION
If the tokenizer doesn't match a character, we must consume the whole UTF-8 character, not just a single byte.

This might make 8a516d35ce4aeecc9f7b2879028a89f9d8816d11 a bit useless.

To reproduce the problem this PR fixes, with some highlighters (like the ones for `lua` and `c`), writing accented letters could produce garbled text if it didn't match any pattern.

Before:
![2021-12-11_03-47](https://user-images.githubusercontent.com/2798487/145661245-844438b9-312a-4eac-9282-4dc0f7a9c8db.png)
After:
![2021-12-11_03-47_1](https://user-images.githubusercontent.com/2798487/145661250-b395ef41-86f9-43c2-b1ec-a2f67a99b152.png)