### PR TITLE
Add command and shortcut for Unicode input

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -125,6 +125,7 @@ local commands = {
       -- It is possible both HEX and DEC, tonumber will converts
       doc():text_input(common.codepoint_to_utf8(tonumber(text)))
     end)
+    core.command_view:set_text("0x")
   end,
 
   ["doc:newline"] = function()
@@ -400,27 +401,27 @@ local commands = {
     os.remove(filename)
     core.log("Removed \"%s\"", filename)
   end,
-    
-  ["doc:select-to-cursor"] = function(x, y, clicks) 
+
+  ["doc:select-to-cursor"] = function(x, y, clicks)
     local line1, col1 = select(3, doc():get_selection())
     local line2, col2 = dv():resolve_screen_position(x, y)
     dv().mouse_selecting = { line1, col1, nil }
     doc():set_selection(line2, col2, line1, col1)
   end,
-  
+
   ["doc:set-cursor"] = function(x, y)
-    set_cursor(x, y, "set") 
+    set_cursor(x, y, "set")
   end,
-  
-  ["doc:set-cursor-word"] = function(x, y) 
-    set_cursor(x, y, "word") 
-  end,  
-  
-  ["doc:set-cursor-line"] = function(x, y, clicks) 
-    set_cursor(x, y, "lines") 
+
+  ["doc:set-cursor-word"] = function(x, y)
+    set_cursor(x, y, "word")
   end,
-  
-  ["doc:split-cursor"] = function(x, y, clicks) 
+
+  ["doc:set-cursor-line"] = function(x, y, clicks)
+    set_cursor(x, y, "lines")
+  end,
+
+  ["doc:split-cursor"] = function(x, y, clicks)
     local line, col = dv():resolve_screen_position(x, y)
     doc():add_selection(line, col, line, col)
   end,

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -123,7 +123,12 @@ local commands = {
   ["doc:type-unicode"] = function()
     core.command_view:enter("Unicode code point", function(text)
       -- It is possible both HEX and DEC, tonumber will converts
-      doc():text_input(common.codepoint_to_utf8(tonumber(text)))
+      local number = tonumber(text)
+      if number ~= nil then
+        doc():text_input(common.codepoint_to_utf8(number))
+      else
+        core.error("Wrong Unicode codepoint")
+      end
     end)
     core.command_view:set_text("0x")
   end,

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -120,6 +120,13 @@ local commands = {
     end
   end,
 
+  ["doc:type-unicode"] = function()
+    core.command_view:enter("Unicode code point", function(text)
+      -- It is possible both HEX and DEC, tonumber will converts
+      doc():text_input(common.codepoint_to_utf8(tonumber(text)))
+    end)
+  end,
+
   ["doc:newline"] = function()
     for idx, line, col in doc():get_selections(false, true) do
       local indent = doc().lines[line]:match("^[\t ]*")

--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -11,6 +11,24 @@ function common.utf8_chars(text)
   return text:gmatch("[\0-\x7f\xc2-\xf4][\x80-\xbf]*")
 end
 
+-- Source https://stackoverflow.com/a/26071044
+function common.codepoint_to_utf8(decimal)
+  local bytemarkers = { {0x7FF,192}, {0xFFFF,224}, {0x1FFFFF,240} }
+  if decimal<128 then return string.char(decimal) end
+  local charbytes = {}
+  for bytes,vals in ipairs(bytemarkers) do
+    if decimal<=vals[1] then
+      for b=bytes+1,2,-1 do
+        local mod = decimal%64
+        decimal = (decimal-mod)/64
+        charbytes[b] = string.char(128+mod)
+      end
+      charbytes[1] = string.char(vals[2]+decimal)
+      break
+    end
+  end
+  return table.concat(charbytes)
+end
 
 function common.clamp(n, lo, hi)
   return math.max(math.min(n, hi), lo)
@@ -349,7 +367,7 @@ function common.relative_path(ref_dir, dir)
   if drive and ref_drive and drive ~= ref_drive then
     -- Windows, different drives, system.absolute_path fails for C:\..\D:\
     return dir
-  end    
+  end
   local ref_ls = split_on_slash(ref_dir)
   local dir_ls = split_on_slash(dir)
   local i = 1

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -218,6 +218,7 @@ keymap.add_direct {
   ["ctrl+down"] = "doc:move-lines-down",
   ["ctrl+shift+d"] = "doc:duplicate-lines",
   ["ctrl+shift+k"] = "doc:delete-lines",
+  ["ctrl+shift+u"] = "doc:type-unicode",
 
   ["left"] = { "doc:move-to-previous-char", "dialog:previous-entry" },
   ["right"] = { "doc:move-to-next-char", "dialog:next-entry"},


### PR DESCRIPTION
This is a very [popular](https://en.wikipedia.org/wiki/Unicode_input#In_X11_(Linux_and_other_Unix_variants_including_Chrome_OS)) shortcut. It might have helped me when I was making an [icons plugin](https://github.com/lite-xl/lite-plugins/pull/104).
It also adds a converting function for common use.