### PR TITLE
Takes kivutar's changes into account, cleaning things up slightly.

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -1,6 +1,6 @@
 #include "api.h"
-#include "renderer.h"
-#include "rencache.h"
+#include "../renderer.h"
+#include "../rencache.h"
 
 static int f_font_load(lua_State *L) {
   const char *filename  = luaL_checkstring(L, 1);

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -6,8 +6,8 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include "api.h"
-#include "dirmonitor.h"
-#include "rencache.h"
+#include "../dirmonitor.h"
+#include "../rencache.h"
 #ifdef _WIN32
   #include <direct.h>
   #include <windows.h>

--- a/src/bundle_open.m
+++ b/src/bundle_open.m
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#include "lua.h"
+#include <lua.h>
 
 #ifdef MACOS_USE_BUNDLE
 void set_macos_bundle_resources(lua_State *L)

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -1,6 +1,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <stdalign.h>
 
 #include <lauxlib.h>


### PR DESCRIPTION
Reworks #567 with no controversial changes. Basically, properly sets relative paths, so that it isn't necessary to specify `-Isrc` in compile_commands (kivutar was saying that this didn't happen by default for him, upon using `ccls`), and added in `#include <stdbool.h>` in places where we use booleans, but don't include this header currently. Theoretically, that is better practice.

But in the end, `sdl2-config` and `pkg-config` should be used to generate the include paths for freetype, so I didn't make those changes, as specified in #567 .