### PR TITLE
Added in keycodes, and scancodes, restoring older functionality by default.

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -28,7 +28,7 @@ config.draw_whitespace = false
 config.borderless = false
 config.tab_close_button = true
 config.max_clicks = 3
-config.combination_codes = "keycodes"
+config.combination_codes = "guess"
 
 -- Disable plugin loading setting to false the config entry
 -- of the same name.

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -28,6 +28,7 @@ config.draw_whitespace = false
 config.borderless = false
 config.tab_close_button = true
 config.max_clicks = 3
+config.combination_codes = "keycodes"
 
 -- Disable plugin loading setting to false the config entry
 -- of the same name.

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1180,7 +1180,7 @@ function core.on_event(type, ...)
   if type == "textinput" then
     core.root_view:on_text_input(...)
   elseif type == "keypressed" then
-    did_keymap = keymap.on_key_pressed(...)
+    did_keymap = keymap.on_key_pressed(config.combination_codes, ...)
   elseif type == "keyreleased" then
     keymap.on_key_released(...)
   elseif type == "mousemoved" then

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -90,7 +90,8 @@ function keymap.get_binding(cmd)
 end
 
 
-function keymap.on_key_pressed(k, ...)
+function keymap.on_key_pressed(keycode, scancode, ...)
+  local k = config.combination_codes == "scancodes" and scancode or keycode
   local mk = modkey_map[k]
   if mk then
     keymap.modkeys[mk] = true
@@ -112,20 +113,29 @@ function keymap.on_key_pressed(k, ...)
   return false
 end
 
-function keymap.on_mouse_wheel(delta, ...)
-  return not (keymap.on_key_pressed("wheel" .. (delta > 0 and "up" or "down"), delta, ...)
-    or keymap.on_key_pressed("wheel", delta, ...))
+
+local function mouse_press(k, ...)
+  return keymap.on_key_pressed(k, k, ...)
 end
+
+
+function keymap.on_mouse_wheel(delta, ...)
+  return not (mouse_press("wheel" .. (delta > 0 and "up" or "down"), delta, ...)
+    or mouse_press("wheel", delta, ...))
+end
+
 
 function keymap.on_mouse_pressed(button, x, y, clicks)
   local click_number = (((clicks - 1) % config.max_clicks) + 1)
-  return not (keymap.on_key_pressed(click_number  .. button:sub(1,1) .. "click", x, y, clicks) or
-    keymap.on_key_pressed(button:sub(1,1) .. "click", x, y, clicks) or
-    keymap.on_key_pressed(click_number .. "click", x, y, clicks) or
-    keymap.on_key_pressed("click", x, y, clicks))
+  return not (mouse_press(click_number  .. button:sub(1,1) .. "click", x, y, clicks) or
+    mouse_press(button:sub(1,1) .. "click", x, y, clicks) or
+    mouse_press(click_number .. "click", x, y, clicks) or
+    mouse_press("click", x, y, clicks))
 end
 
-function keymap.on_key_released(k)
+
+function keymap.on_key_released(keycode, scancode)
+  local k = config.combination_codes == "scancodes" and scancode or keycode
   local mk = modkey_map[k]
   if mk then
     keymap.modkeys[mk] = false

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -90,8 +90,8 @@ function keymap.get_binding(cmd)
 end
 
 
-function keymap.on_key_pressed(keycode, scancode, ...)
-  local k = config.combination_codes == "scancodes" and scancode or keycode
+function keymap.on_key_pressed(combination_codes, keycode, scancode, ...)
+  local k = combination_codes == "scancodes" and scancode or keycode
   local mk = modkey_map[k]
   if mk then
     keymap.modkeys[mk] = true
@@ -110,12 +110,15 @@ function keymap.on_key_pressed(keycode, scancode, ...)
       return performed
     end
   end
+  if config.combination_codes == "guess" and string.byte(keycode) >= 128 then 
+    return keymap.on_key_pressed("scancodes", keycode, scancode, ...) 
+  end
   return false
 end
 
 
 local function mouse_press(k, ...)
-  return keymap.on_key_pressed(k, k, ...)
+  return keymap.on_key_pressed(config.combination_codes, k, k, ...)
 end
 
 

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -97,23 +97,25 @@ static SDL_HitTestResult SDLCALL hit_test(SDL_Window *window, const SDL_Point *p
 
 static const char *numpad[] = { "end", "down", "pagedown", "left", "", "right", "home", "up", "pageup", "ins", "delete" };
 
-static const char *get_key_name(const SDL_Event *e, char *buf) {
-  SDL_Scancode scancode = e->key.keysym.scancode;
+static void get_key_name(const SDL_Event *e, char* keycode, char *scancode) {
+  SDL_Scancode code = e->key.keysym.scancode;
   /* Is the scancode from the keypad and the number-lock off?
   ** We assume that SDL_SCANCODE_KP_1 up to SDL_SCANCODE_KP_9 and SDL_SCANCODE_KP_0
   ** and SDL_SCANCODE_KP_PERIOD are declared in SDL2 in that order. */
-  if (scancode >= SDL_SCANCODE_KP_1 && scancode <= SDL_SCANCODE_KP_1 + 10 &&
+  if (code >= SDL_SCANCODE_KP_1 && code <= SDL_SCANCODE_KP_1 + 10 &&
     !(e->key.keysym.mod & KMOD_NUM)) {
-    return numpad[scancode - SDL_SCANCODE_KP_1];
+    strcpy(keycode, numpad[code - SDL_SCANCODE_KP_1]);
+    strcpy(scancode, numpad[code - SDL_SCANCODE_KP_1]);
   } else {
-    strcpy(buf, SDL_GetScancodeName(e->key.keysym.scancode));
-    str_tolower(buf);
-    return buf;
+    strcpy(keycode, SDL_GetKeyName(e->key.keysym.sym));
+    str_tolower(keycode);
+    strcpy(scancode, SDL_GetScancodeName(e->key.keysym.scancode));
+    str_tolower(scancode);
   }
 }
 
 static int f_poll_event(lua_State *L) {
-  char buf[16];
+  char keycode[16], scancode[16];
   int mx, my, wx, wy;
   SDL_Event e;
 
@@ -181,8 +183,10 @@ top:
       }
 #endif
       lua_pushstring(L, "keypressed");
-      lua_pushstring(L, get_key_name(&e, buf));
-      return 2;
+      get_key_name(&e, keycode, scancode);
+      lua_pushstring(L, keycode);
+      lua_pushstring(L, scancode);
+      return 3;
 
     case SDL_KEYUP:
 #ifdef __APPLE__
@@ -195,8 +199,10 @@ top:
       }
 #endif
       lua_pushstring(L, "keyreleased");
-      lua_pushstring(L, get_key_name(&e, buf));
-      return 2;
+      get_key_name(&e, keycode, scancode);
+      lua_pushstring(L, keycode);
+      lua_pushstring(L, scancode);
+      return 3;
 
     case SDL_TEXTINPUT:
       lua_pushstring(L, "textinput");


### PR DESCRIPTION
 Added in the scancode after the keycode when passed to keypress functions. Added in a config option to toggle between using scancodes or keycodes for key combinations.

I am not sure which default is correct, but according to #735 , it should be the default to use keycodes for keyboard shortcuts. Anyone using a not QWERTY layout, please feel free to chime in to voice your opinion about which default should rule.

~~I am 99% sure that we want to use keycodes for normal keypresses in the docview, which I think the previous PR would've also broken. (Presumably, you want to type in the layout your keyboard is in?).~~ (never mind, because this is from `textinput`, would've been fine)

Should close #735 .