### PR TITLE
Suppress the drawing of the command view scrollbar

### DIFF
--- a/data/core/commandview.lua
+++ b/data/core/commandview.lua
@@ -288,5 +288,8 @@ function CommandView:draw()
   end
 end
 
+-- Suppress the drawing of the scrollbar
+function CommandView:draw_scrollbar()
+end
 
 return CommandView


### PR DESCRIPTION
Fixes that:
![image](https://user-images.githubusercontent.com/25588359/146687081-dcf1027c-994b-4147-8e77-1027b2fbec79.png)
