### PR TITLE
Add predefined colors to style.lua: good, warn, error, modified

### DIFF
--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -27,20 +27,22 @@ style.icon_font = renderer.font.load(DATADIR .. "/fonts/icons.ttf", 16 * SCALE, 
 style.icon_big_font = style.icon_font:copy(23 * SCALE)
 style.code_font = renderer.font.load(DATADIR .. "/fonts/JetBrainsMono-Regular.ttf", 15 * SCALE)
 
-style.background = { common.color "#2e2e32" }
-style.background2 = { common.color "#252529" }
-style.background3 = { common.color "#252529" }
+style.background = { common.color "#2e2e32" }  -- Docview
+style.background2 = { common.color "#252529" } -- Treeview
+style.background3 = { common.color "#252529" } -- Command view
 style.text = { common.color "#97979c" }
 style.caret = { common.color "#93DDFA" }
 style.accent = { common.color "#e1e1e6" }
+-- style.dim - text color for nonactive tabs, tabs divider, prefix in log and
+-- search result, hotkeys for context menu and command view
 style.dim = { common.color "#525257" }
-style.divider = { common.color "#202024" }
+style.divider = { common.color "#202024" } -- Line between nodes
 style.selection = { common.color "#48484f" }
 style.line_number = { common.color "#525259" }
-style.line_number2 = { common.color "#83838f" }
+style.line_number2 = { common.color "#83838f" } -- With cursor
 style.line_highlight = { common.color "#343438" }
 style.scrollbar = { common.color "#414146" }
-style.scrollbar2 = { common.color "#4b4b52" }
+style.scrollbar2 = { common.color "#4b4b52" } -- Hovered
 style.nagbar = { common.color "#FF0000" }
 style.nagbar_text = { common.color "#FFFFFF" }
 style.nagbar_dim = { common.color "rgba(0, 0, 0, 0.45)" }
@@ -55,12 +57,12 @@ style.syntax = {}
 style.syntax["normal"] = { common.color "#e1e1e6" }
 style.syntax["symbol"] = { common.color "#e1e1e6" }
 style.syntax["comment"] = { common.color "#676b6f" }
-style.syntax["keyword"] = { common.color "#E58AC9" }
-style.syntax["keyword2"] = { common.color "#F77483" }
+style.syntax["keyword"] = { common.color "#E58AC9" }  -- local function end if case
+style.syntax["keyword2"] = { common.color "#F77483" } -- self int float
 style.syntax["number"] = { common.color "#FFA94D" }
-style.syntax["literal"] = { common.color "#FFA94D" }
+style.syntax["literal"] = { common.color "#FFA94D" }  -- true false nil
 style.syntax["string"] = { common.color "#f7c95c" }
-style.syntax["operator"] = { common.color "#93DDFA" }
+style.syntax["operator"] = { common.color "#93DDFA" } -- = + - / < >
 style.syntax["function"] = { common.color "#93DDFA" }
 
 -- This can be used to override fonts per syntax group.

--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -47,7 +47,9 @@ style.nagbar_dim = { common.color "rgba(0, 0, 0, 0.45)" }
 style.drag_overlay = { common.color "rgba(255,255,255,0.1)" }
 style.drag_overlay_tab = { common.color "#93DDFA" }
 style.good = { common.color "#72b886" }
-style.bad = { common.color "#FFA94D" }
+style.warn = { common.color "#FFA94D" }
+style.error = { common.color "#FF3333" }
+style.modified = { common.color "#1c7c9c" }
 
 style.syntax = {}
 style.syntax["normal"] = { common.color "#e1e1e6" }

--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -46,6 +46,8 @@ style.nagbar_text = { common.color "#FFFFFF" }
 style.nagbar_dim = { common.color "rgba(0, 0, 0, 0.45)" }
 style.drag_overlay = { common.color "rgba(255,255,255,0.1)" }
 style.drag_overlay_tab = { common.color "#93DDFA" }
+style.good = { common.color "#72b886" }
+style.bad = { common.color "#FFA94D" }
 
 style.syntax = {}
 style.syntax["normal"] = { common.color "#e1e1e6" }


### PR DESCRIPTION
Various plugins like git, linters and others need colors to express "good" and "bad" things. I suggest adding a couple of this pair of colors so that plugin authors can use them, and so that theme authors can change everything accordingly at once.
It will also help for  https://github.com/lite-xl/lite-xl/pull/743

I don't like the color names very much. M.b. ok/error? Offer yours.