### PR TITLE
Show cursor at the start of the next line when selecting full lines

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -359,7 +359,7 @@ local commands = {
   ["doc:select-lines"] = function(dv)
     for idx, line1, _, line2 in dv.doc:get_selections(true) do
       append_line_if_last_line(line2)
-      dv.doc:set_selections(idx, line1, 1, line2 + 1, 1)
+      dv.doc:set_selections(idx, line2 + 1, 1, line1, 1)
     end
   end,
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -317,7 +317,7 @@ function DocView:mouse_selection(doc, snap_type, line1, col1, line2, col2)
     line1, col1 = translate.start_of_word(doc, line1, col1)
     line2, col2 = translate.end_of_word(doc, line2, col2)
   elseif snap_type == "lines" then
-    col1, col2 = 1, math.huge
+    col1, col2, line2 = 1, 1, line2 + 1
   end
   if swap then
     return line2, col2, line1, col1


### PR DESCRIPTION
This was the previous behavior that regressed with the keymap clicks.