### PR TITLE
Support portable user config(Fix #762) 

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -12,8 +12,9 @@ else
   local prefix = EXEDIR:match("^(.+)[/\\]bin$")
   DATADIR = prefix and (prefix .. '/share/lite-xl') or (EXEDIR .. '/data')
 end
-USERDIR = (os.getenv("XDG_CONFIG_HOME") and os.getenv("XDG_CONFIG_HOME") .. "/lite-xl")
-  or (HOME and (HOME .. '/.config/lite-xl') or (EXEDIR .. '/user'))
+USERDIR = (system.get_file_info(EXEDIR .. '/user') and (EXEDIR .. '/user'))
+       or ((os.getenv("XDG_CONFIG_HOME") and os.getenv("XDG_CONFIG_HOME") .. "/lite-xl"))
+       or (HOME and (HOME .. '/.config/lite-xl'))
 
 package.path = DATADIR .. '/?.lua;' .. package.path
 package.path = DATADIR .. '/?/init.lua;' .. package.path


### PR DESCRIPTION
I am assuming that `user` was used in the past for backward compatibility with lite. But I think everyone who wanted to have already migrated and now this thing hangs useless with us.
I do not think that this pr can cause any problems for anyone.