### PR TITLE
Add CFBundleIdentifier to Info.plist.in

### DIFF
--- a/resources/macos/Info.plist.in
+++ b/resources/macos/Info.plist.in
@@ -8,6 +8,8 @@
 	<string>lite-xl</string>
 	<key>CFBundleIconFile</key>
 	<string>icon.icns</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.lite-xl</string>
 	<key>CFBundleName</key>
 	<string>Lite XL</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
The CFBundleIdentifier key is necessary to associate lite-xl to all files with a certain extension.

When trying to associate lite-xl to e.g. all .yaml files with the `Get Info` -> `Change All...` buttons I get the following error

    An unexpected error occurred (error code -10813).
    The operation could not be completed.

To fix it add the aforementioned key to the `Info.plist` file, save it and touch the application tell OS X about the change

```bash
touch /Applications/Lite\ XL.app
```

After that you can associate the file type to lite-xl.

I used `com.lite-xl` as value, but you can say if you wish another one.