### PR TITLE
Better "Remove changed files/dirs from `TreeView` cache"

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1158,7 +1158,7 @@ end
 
 
 -- no-op but can be overrided by plugins
-function core.on_dirmonitor_modify(dir, filepath)
+function core.on_dirmonitor_modify()
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1158,8 +1158,8 @@ end
 
 
 -- no-op but can be overrided by plugins
-function core.on_dirmonitor_modify() end
-function core.on_dirmonitor_delete() end
+function core.on_dirmonitor_modify(dir, filepath) end
+function core.on_dirmonitor_delete(dir, filepath) end
 
 
 function core.on_dir_change(watch_id, action, filepath)

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1158,8 +1158,8 @@ end
 
 
 -- no-op but can be overrided by plugins
-function core.on_dirmonitor_modify()
-end
+function core.on_dirmonitor_modify() end
+function core.on_dirmonitor_delete() end
 
 
 function core.on_dir_change(watch_id, action, filepath)
@@ -1168,6 +1168,7 @@ function core.on_dir_change(watch_id, action, filepath)
   core.dir_rescan_add_job(dir, filepath)
   if action == "delete" then
     project_scan_remove_file(dir, filepath)
+    core.on_dirmonitor_delete(dir, filepath)
   elseif action == "create" then
     project_scan_add_file(dir, filepath)
     core.on_dirmonitor_modify(dir, filepath);

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -45,14 +45,6 @@ function TreeView:new()
 
   self.item_icon_width = 0
   self.item_text_spacing = 0
-
-  local on_dirmonitor_modify = core.on_dirmonitor_modify
-  function core.on_dirmonitor_modify(dir, filepath)
-    if self.cache[dir.name] then
-      self.cache[dir.name][filepath] = nil
-    end
-    on_dirmonitor_modify(dir, filepath)
-  end
 end
 
 

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -45,6 +45,19 @@ function TreeView:new()
 
   self.item_icon_width = 0
   self.item_text_spacing = 0
+  self:add_core_hooks()
+end
+
+
+function TreeView:add_core_hooks()
+  -- When a file or directory is deleted we delete the corresponding cache entry
+  -- because if the entry is recreated we may use wrong information from cache.
+  local on_delete = core.on_dirmonitor_delete
+  core.on_dirmonitor_delete = function(dir, filepath)
+    local cache = self.cache[dir.name]
+    if cache then cache[filepath] = nil end
+    on_delete(dir, filepath)
+  end
 end
 
 


### PR DESCRIPTION
This is an improved version of #697, as suggested by franko.

The problem of the older version was that it removed cached entries even in cases when it doesn't make sense to, for example when the content of a file changes.