### PR TITLE
Initial implementation of the `SDL_TEXTEDITING` event

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -438,6 +438,18 @@ function Doc:text_input(text, idx)
   end
 end
 
+
+function Doc:text_editing(text, start, length, idx)
+  for sidx, line1, col1, line2, col2 in self:get_selections(true, idx or true) do
+    if line1 ~= line2 or col1 ~= col2 then
+      self:delete_to_cursor(sidx)
+    end
+    self:insert(line1, col1, text)
+    self:set_selections(sidx, line1, col1 + #text, line1, col1)
+  end
+end
+
+
 function Doc:replace_cursor(idx, line1, col1, line2, col2, fn)
   local old_text = self:get_text(line1, col1, line2, col2)
   local new_text, n = fn(old_text)

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -4,6 +4,7 @@ local config = require "core.config"
 local style = require "core.style"
 local keymap = require "core.keymap"
 local translate = require "core.doc.translate"
+local textediting = require "core.textediting"
 local View = require "core.view"
 
 
@@ -283,6 +284,14 @@ end
 
 function DocView:on_text_editing(text, start, length)
   self.doc:text_editing(text, start, length)
+
+  local line1, col1, line2, col2 = self.doc:get_selection(true)
+  local x, y = self:get_line_screen_position(line1)
+  local x1 = self:get_col_x_offset(line1, col1)
+  local x2 = self:get_col_x_offset(line2, col2)
+  local h = self:get_line_height()
+  
+  textediting.set_ime_location(x + x1, y, x2 - x1, h)
 end
 
 function DocView:update()

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -281,6 +281,9 @@ function DocView:on_text_input(text)
   self.doc:text_input(text)
 end
 
+function DocView:on_text_editing(text, start, length)
+  self.doc:text_editing(text, start, length)
+end
 
 function DocView:update()
   -- scroll to make caret visible and reset blink timer if it moved

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -387,18 +387,30 @@ function DocView:draw_line_gutter(idx, x, y, width)
 end
 
 
+function DocView:draw_ime_decoration(line1, col1, line2, col2)
+  local x, y = self:get_line_screen_position(line1)
+  local x1 = self:get_col_x_offset(line1, col1)
+  local x2 = self:get_col_x_offset(line2, col2)
+  local lh = self:get_line_height()
+  renderer.draw_rect(x + math.min(x1, x2), y + lh, math.abs(x1 - x2), math.max(1, SCALE), style.text)
+end
+
+
 function DocView:draw_overlay()
   if core.active_view == self then
     local minline, maxline = self:get_visible_line_range()
     -- draw caret if it overlaps this line
     local T = config.blink_period
-    for _, line, col in self.doc:get_selections() do
-      if line >= minline and line <= maxline
+    for _, line1, col1, line2, col2 in self.doc:get_selections() do
+      if line1 >= minline and line1 <= maxline
       and system.window_has_focus() then
+        if textediting.editing then
+          self:draw_ime_decoration(line1, col1, line2, col2)
+        end
         if config.disable_blink
         or (core.blink_timer - core.blink_start) % T < T / 2 then
-          local x, y = self:get_line_screen_position(line)
-          self:draw_caret(x + self:get_col_x_offset(line, col), y)
+          local x, y = self:get_line_screen_position(line1)
+          self:draw_caret(x + self:get_col_x_offset(line1, col1), y)
         end
       end
     end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -5,6 +5,7 @@ local config = require "core.config"
 local style = require "core.style"
 local command
 local keymap
+local textediting
 local RootView
 local StatusView
 local TitleView
@@ -594,6 +595,7 @@ end
 function core.init()
   command = require "core.command"
   keymap = require "core.keymap"
+  textediting = require "core.textediting"
   RootView = require "core.rootview"
   StatusView = require "core.statusview"
   TitleView = require "core.titleview"
@@ -933,6 +935,8 @@ end
 
 function core.set_active_view(view)
   assert(view, "Tried to set active view to nil")
+  -- Reset the IME even if the focus didn't change
+  textediting.stop()
   if view ~= core.active_view then
     if core.active_view and core.active_view.force_focus then
       core.next_active_view = view
@@ -1182,7 +1186,7 @@ function core.on_event(type, ...)
   if type == "textinput" then
     core.root_view:on_text_input(...)
   elseif type == "textediting" then
-    core.root_view:on_text_editing(...)
+    textediting.on_text_editing(...)
   elseif type == "keypressed" then
     did_keymap = keymap.on_key_pressed(...)
   elseif type == "keyreleased" then

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1181,6 +1181,8 @@ function core.on_event(type, ...)
   local did_keymap = false
   if type == "textinput" then
     core.root_view:on_text_input(...)
+  elseif type == "textediting" then
+    core.root_view:on_text_editing(...)
   elseif type == "keypressed" then
     did_keymap = keymap.on_key_pressed(...)
   elseif type == "keyreleased" then

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -1,5 +1,6 @@
 local command = require "core.command"
 local config = require "core.config"
+local textediting = require "core.textediting"
 local keymap = {}
 
 keymap.modkeys = {}
@@ -91,6 +92,10 @@ end
 
 
 function keymap.on_key_pressed(k, ...)
+  -- In Windows during IME composition, input is still sent to us
+  -- so we just ignore it
+  if textediting.editing then return false end
+
   local mk = modkey_map[k]
   if mk then
     keymap.modkeys[mk] = true

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -280,6 +280,9 @@ function RootView:on_text_input(...)
   core.active_view:on_text_input(...)
 end
 
+function RootView:on_text_editing(...)
+  core.active_view:on_text_editing(...)
+end
 
 function RootView:on_focus_lost(...)
   -- We force a redraw so documents can redraw without the cursor.

--- a/data/core/textediting.lua
+++ b/data/core/textediting.lua
@@ -1,0 +1,61 @@
+local core = require "core"
+
+local textediting = { }
+
+function textediting.reset()
+  textediting.editing = false
+  textediting.buffer = { "" }
+  textediting.starts = { [0] = 1 }
+  textediting.last_start = 0
+end
+
+-- SDL manages IME composition with chunks of 32 bytes.
+-- 
+-- For each chunk `start` is the total number of characters (not bytes)
+-- of the preceding chunks, and `length` is the number of characters of the
+-- current chunk.
+-- 
+-- Every time the composition changes, SDL sends all the chunks again,
+-- in order, one at a time.
+function textediting.ingest(text, start, length)
+  if #text == 0 then
+    -- finished textediting
+    textediting.reset()
+    return "", 0, 0
+  end
+
+  if start < textediting.last_start then
+    -- restarted textediting
+    textediting.reset()
+  end
+
+  textediting.editing = true
+
+  if not textediting.starts[start] then
+    -- new segment
+    textediting.starts[start] = #textediting.buffer + 1
+  end
+  textediting.buffer[textediting.starts[start]] = text
+
+  textediting.last_start = start
+  return table.concat(textediting.buffer), 0, start + length
+end
+
+function textediting.on_text_editing(...)
+  core.root_view:on_text_editing(textediting.ingest(...))
+end
+
+function textediting.stop()
+  if textediting.editing then
+    textediting.reset()
+    -- https://github.com/libsdl-org/SDL/issues/4847
+    -- TODO: when SDL supports it, call SDL_ResetTextInput to reset the IME
+    -- with something like
+    -- system.stop_ime()
+    -- For now just remove the ingested content
+    textediting.on_text_editing("", 0, 0)
+  end
+end
+
+textediting.reset()
+return textediting

--- a/data/core/textediting.lua
+++ b/data/core/textediting.lua
@@ -41,8 +41,10 @@ function textediting.ingest(text, start, length)
   return table.concat(textediting.buffer), 0, start + length
 end
 
-function textediting.on_text_editing(...)
-  core.root_view:on_text_editing(textediting.ingest(...))
+function textediting.on_text_editing(text, ...)
+  if textediting.editing or #text > 0 then
+    core.root_view:on_text_editing(textediting.ingest(text, ...))
+  end
 end
 
 function textediting.stop()

--- a/data/core/textediting.lua
+++ b/data/core/textediting.lua
@@ -57,5 +57,9 @@ function textediting.stop()
   end
 end
 
+function textediting.set_ime_location(x, y, w, h)
+  system.set_text_input_rect(x, y, w, h)
+end
+
 textediting.reset()
 return textediting

--- a/data/core/textediting.lua
+++ b/data/core/textediting.lua
@@ -42,6 +42,10 @@ function textediting.ingest(text, start, length)
 end
 
 function textediting.on_text_editing(text, ...)
+  -- In Windows SDL only sends the first TEXTEDITING "chunk" and drops the rest.
+  -- So we just consider every TEXTEDITING as the first and only one.
+  if PLATFORM == "Windows" then textediting.reset() end
+
   if textediting.editing or #text > 0 then
     core.root_view:on_text_editing(textediting.ingest(text, ...))
   end

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -102,6 +102,10 @@ function View:on_text_input(text)
   -- no-op
 end
 
+function View:on_text_editing(text, start, length)
+  -- no-op
+end
+
 function View:on_mouse_wheel(y)
 
 end

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -216,6 +216,13 @@ top:
       lua_pushstring(L, e.text.text);
       return 2;
 
+    case SDL_TEXTEDITING:
+      lua_pushstring(L, "textediting");
+      lua_pushstring(L, e.edit.text);
+      lua_pushnumber(L, e.edit.start);
+      lua_pushnumber(L, e.edit.length);
+      return 4;
+
     case SDL_MOUSEBUTTONDOWN:
       if (e.button.button == 1) { SDL_CaptureMouse(1); }
       lua_pushstring(L, "mousepressed");

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -419,6 +419,16 @@ static int f_get_window_mode(lua_State *L) {
   return 1;
 }
 
+static int f_set_text_input_rect(lua_State *L) {
+  SDL_Rect rect;
+  rect.x = luaL_checknumber(L, 1);
+  rect.y = luaL_checknumber(L, 2);
+  rect.w = luaL_checknumber(L, 3);
+  rect.h = luaL_checknumber(L, 4);
+  SDL_SetTextInputRect(&rect);
+  return 0;
+}
+
 
 static int f_show_fatal_error(lua_State *L) {
   const char *title = luaL_checkstring(L, 1);
@@ -895,6 +905,7 @@ static const luaL_Reg lib[] = {
   { "set_window_hit_test", f_set_window_hit_test },
   { "get_window_size",     f_get_window_size     },
   { "set_window_size",     f_set_window_size     },
+  { "set_text_input_rect", f_set_text_input_rect },
   { "window_has_focus",    f_window_has_focus    },
   { "show_fatal_error",    f_show_fatal_error    },
   { "rmdir",               f_rmdir               },

--- a/src/main.c
+++ b/src/main.c
@@ -104,6 +104,9 @@ int main(int argc, char **argv) {
 #if SDL_VERSION_ATLEAST(2, 0, 5)
   SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
 #endif
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+  SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
+#endif
 
   SDL_DisplayMode dm;
   SDL_GetCurrentDisplayMode(0, &dm);


### PR DESCRIPTION
This creates a visual feedback for IME compositions.

https://user-images.githubusercontent.com/2798487/147286915-5d3f0e82-e058-41d4-8746-cafffa028834.mp4

In the video, on the first line I use ctrl+shift+u that allows me to input unicode in hex.
On the second line I use ctrl+. that allows me to input via unicode names(?).

For now we ignore both the `start` and `length` variables, as `start` seems to always be `0`, but I probably just haven't encountered a case that was using it, and `length` is in characters, but we need bytes.

This supports multiple cursors, but let me know if you find problems.