### PR TITLE
Migrate to Lua 5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ build*/
 .build*/
 lhelper/
 submodules/
-subprojects/lua/
+subprojects/lua*/
 subprojects/reproc/
 /appimage*
 .ccls-cache

--- a/data/core/bit.lua
+++ b/data/core/bit.lua
@@ -1,0 +1,30 @@
+local bit = {}
+
+local LUA_NBITS = 32
+local ALLONES = (~(((~0) << (LUA_NBITS - 1)) << 1))
+
+local function trim(x)
+	return (x & ALLONES)
+end
+
+local function mask(n)
+	return (~((ALLONES << 1) << ((n) - 1)))
+end
+
+function bit.extract(n, field, width)
+	local r = trim(field)
+	local f = width
+	r = (r >> f) & mask(width)
+	return r
+end
+
+function bit.replace(n, v, field, width)
+	local r = trim(v);
+	local v = trim(field);
+	local f = width
+	local m = mask(width);
+	r = (r & ~(m << f)) | ((v & m) << f);
+	return r
+end
+
+return bit

--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -55,7 +55,7 @@ end
 local function find(label, search_fn)
   last_view, last_sel = core.active_view,
     { core.active_view.doc:get_selection() }
-  local text = last_view.doc:get_text(unpack(last_sel))
+  local text = last_view.doc:get_text(table.unpack(last_sel))
   found_expression = false
 
   core.command_view:set_text(text, true)

--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -42,7 +42,7 @@ end
 
 
 function common.distance(x1, y1, x2, y2)
-    return math.sqrt(math.pow(x2-x1, 2)+math.pow(y2-y1, 2))
+    return math.sqrt(((x2-x1) ^ 2)+((y2-y1) ^ 2))
 end
 
 

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -124,7 +124,7 @@ function StatusView:get_items()
       col > config.line_limit and style.accent or style.text, "col: ", col,
       style.text,
       self.separator,
-      string.format("%d%%", line / #dv.doc.lines * 100),
+      string.format("%.f%%", line / #dv.doc.lines * 100),
     }, {
       style.text, indent_label, indent_size,
       style.dim, self.separator2, style.text,

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -1,5 +1,6 @@
 local syntax = require "core.syntax"
 local common = require "core.common"
+local bit32 = require "core.bit"
 
 local tokenizer = {}
 

--- a/data/plugins/projectsearch.lua
+++ b/data/plugins/projectsearch.lua
@@ -176,7 +176,7 @@ function ResultsView:draw()
   local text
   if self.searching then
     if files_number then
-      text = string.format("Searching %d%% (%d of %d files, %d matches) for %q...",
+      text = string.format("Searching %.f%% (%d of %d files, %d matches) for %q...",
         per * 100, self.last_file_idx, files_number,
         #self.results, self.query)
     else

--- a/meson.build
+++ b/meson.build
@@ -47,9 +47,12 @@ if not get_option('source-only')
     libm = cc.find_library('m', required : false)
     libdl = cc.find_library('dl', required : false)
     threads_dep = dependency('threads')
-    lua_dep = dependency('lua5.2', fallback: ['lua', 'lua_dep'],
-        default_options: ['shared=false', 'use_readline=false', 'app=false']
-    )
+    lua_dep = dependency('lua5.4', required : false)
+    if not lua_dep.found()
+        lua_dep = dependency('lua', fallback: ['lua', 'lua_dep'],
+            default_options: ['line_editing=false', 'default_library=static']
+        )
+    endif
     pcre2_dep = dependency('libpcre2-8')
     freetype_dep = dependency('freetype2')
     sdl_dep = dependency('sdl2')

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -128,12 +128,12 @@ static int process_start(lua_State* L) {
   #if LUA_VERSION_NUM > 501
     lua_len(L, 1);
   #else
-    lua_pushnumber(L, (int)lua_objlen(L, 1));
+    lua_pushinteger(L, (int)lua_objlen(L, 1));
   #endif
   size_t cmd_len = luaL_checknumber(L, -1); lua_pop(L, 1);
   size_t arg_len = lua_gettop(L);
   for (size_t i = 1; i <= cmd_len; ++i) {
-    lua_pushnumber(L, i);
+    lua_pushinteger(L, i);
     lua_rawget(L, 1);
     cmd[i-1] = luaL_checkstring(L, -1);
   }
@@ -343,7 +343,7 @@ static int f_write(lua_State* L) {
       return luaL_error(L, "error writing to process: %s", strerror(errno));
     }
   #endif
-  lua_pushnumber(L, length);
+  lua_pushinteger(L, length);
   return 1;
 }
 
@@ -375,7 +375,7 @@ static int f_tostring(lua_State* L) {
 
 static int f_pid(lua_State* L) {
   process_t* self = (process_t*) luaL_checkudata(L, 1, API_TYPE_PROCESS);
-  lua_pushnumber(L, self->pid);
+  lua_pushinteger(L, self->pid);
   return 1;
 }
 
@@ -383,7 +383,7 @@ static int f_returncode(lua_State *L) {
   process_t* self = (process_t*) luaL_checkudata(L, 1, API_TYPE_PROCESS);
   if (self->running)
     return 0;
-  lua_pushnumber(L, self->returncode);
+  lua_pushinteger(L, self->returncode);
   return 1;
 }
 
@@ -404,7 +404,7 @@ static int f_wait(lua_State* L) {
   int timeout = luaL_optnumber(L, 2, 0);
   if (poll_process(self, timeout))
     return 0;
-  lua_pushnumber(L, self->returncode);
+  lua_pushinteger(L, self->returncode);
   return 1;
 }
 

--- a/src/api/regex.c
+++ b/src/api/regex.c
@@ -104,17 +104,17 @@ int luaopen_regex(lua_State *L) {
   lua_setfield(L, -2, "__name");
   lua_pushvalue(L, -1);
   lua_setfield(L, LUA_REGISTRYINDEX, "regex");
-  lua_pushnumber(L, PCRE2_ANCHORED);
+  lua_pushinteger(L, PCRE2_ANCHORED);
   lua_setfield(L, -2, "ANCHORED");
-  lua_pushnumber(L, PCRE2_ANCHORED) ;
+  lua_pushinteger(L, PCRE2_ANCHORED) ;
   lua_setfield(L, -2, "ENDANCHORED");
-  lua_pushnumber(L, PCRE2_NOTBOL);
+  lua_pushinteger(L, PCRE2_NOTBOL);
   lua_setfield(L, -2, "NOTBOL");
-  lua_pushnumber(L, PCRE2_NOTEOL);
+  lua_pushinteger(L, PCRE2_NOTEOL);
   lua_setfield(L, -2, "NOTEOL");
-  lua_pushnumber(L, PCRE2_NOTEMPTY);
+  lua_pushinteger(L, PCRE2_NOTEMPTY);
   lua_setfield(L, -2, "NOTEMPTY");
-  lua_pushnumber(L, PCRE2_NOTEMPTY_ATSTART);
+  lua_pushinteger(L, PCRE2_NOTEMPTY_ATSTART);
   lua_setfield(L, -2, "NOTEMPTY_ATSTART");
   return 1;
 }

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -145,8 +145,8 @@ top:
         ren_resize_window();
         lua_pushstring(L, "resized");
         /* The size below will be in points. */
-        lua_pushnumber(L, e.window.data1);
-        lua_pushnumber(L, e.window.data2);
+        lua_pushinteger(L, e.window.data1);
+        lua_pushinteger(L, e.window.data2);
         return 3;
       } else if (e.window.event == SDL_WINDOWEVENT_EXPOSED) {
         rencache_invalidate();
@@ -179,8 +179,8 @@ top:
       SDL_GetWindowPosition(window, &wx, &wy);
       lua_pushstring(L, "filedropped");
       lua_pushstring(L, e.drop.file);
-      lua_pushnumber(L, mx - wx);
-      lua_pushnumber(L, my - wy);
+      lua_pushinteger(L, mx - wx);
+      lua_pushinteger(L, my - wy);
       SDL_free(e.drop.file);
       return 4;
 
@@ -220,17 +220,17 @@ top:
       if (e.button.button == 1) { SDL_CaptureMouse(1); }
       lua_pushstring(L, "mousepressed");
       lua_pushstring(L, button_name(e.button.button));
-      lua_pushnumber(L, e.button.x);
-      lua_pushnumber(L, e.button.y);
-      lua_pushnumber(L, e.button.clicks);
+      lua_pushinteger(L, e.button.x);
+      lua_pushinteger(L, e.button.y);
+      lua_pushinteger(L, e.button.clicks);
       return 5;
 
     case SDL_MOUSEBUTTONUP:
       if (e.button.button == 1) { SDL_CaptureMouse(0); }
       lua_pushstring(L, "mousereleased");
       lua_pushstring(L, button_name(e.button.button));
-      lua_pushnumber(L, e.button.x);
-      lua_pushnumber(L, e.button.y);
+      lua_pushinteger(L, e.button.x);
+      lua_pushinteger(L, e.button.y);
       return 4;
 
     case SDL_MOUSEMOTION:
@@ -243,20 +243,20 @@ top:
         e.motion.yrel += event_plus.motion.yrel;
       }
       lua_pushstring(L, "mousemoved");
-      lua_pushnumber(L, e.motion.x);
-      lua_pushnumber(L, e.motion.y);
-      lua_pushnumber(L, e.motion.xrel);
-      lua_pushnumber(L, e.motion.yrel);
+      lua_pushinteger(L, e.motion.x);
+      lua_pushinteger(L, e.motion.y);
+      lua_pushinteger(L, e.motion.xrel);
+      lua_pushinteger(L, e.motion.yrel);
       return 5;
 
     case SDL_MOUSEWHEEL:
       lua_pushstring(L, "mousewheel");
-      lua_pushnumber(L, e.wheel.y);
+      lua_pushinteger(L, e.wheel.y);
       return 2;
 
     case SDL_USEREVENT:
       lua_pushstring(L, "dirchange");
-      lua_pushnumber(L, e.user.code >> 16);
+      lua_pushinteger(L, e.user.code >> 16);
       switch (e.user.code & 0xffff) {
         case DMON_ACTION_DELETE:
           lua_pushstring(L, "delete");
@@ -371,10 +371,10 @@ static int f_get_window_size(lua_State *L) {
   int x, y, w, h;
   SDL_GetWindowSize(window, &w, &h);
   SDL_GetWindowPosition(window, &x, &y);
-  lua_pushnumber(L, w);
-  lua_pushnumber(L, h);
-  lua_pushnumber(L, x);
-  lua_pushnumber(L, y);
+  lua_pushinteger(L, w);
+  lua_pushinteger(L, h);
+  lua_pushinteger(L, x);
+  lua_pushinteger(L, y);
   return 4;
 }
 
@@ -544,10 +544,10 @@ static int f_get_file_info(lua_State *L) {
   }
 
   lua_newtable(L);
-  lua_pushnumber(L, s.st_mtime);
+  lua_pushinteger(L, s.st_mtime);
   lua_setfield(L, -2, "modified");
 
-  lua_pushnumber(L, s.st_size);
+  lua_pushinteger(L, s.st_size);
   lua_setfield(L, -2, "size");
 
   if (S_ISREG(s.st_mode)) {
@@ -639,7 +639,7 @@ static int f_set_clipboard(lua_State *L) {
 
 static int f_get_time(lua_State *L) {
   double n = SDL_GetPerformanceCounter() / (double) SDL_GetPerformanceFrequency();
-  lua_pushnumber(L, n);
+  lua_pushinteger(L, n);
   return 1;
 }
 
@@ -693,7 +693,7 @@ static int f_fuzzy_match(lua_State *L) {
     strTarget += increment;
   }
   if (ptnTarget >= ptn && *ptnTarget) { return 0; }
-  lua_pushnumber(L, score - (int)strLen * 10);
+  lua_pushinteger(L, score - (int)strLen * 10);
   return 1;
 }
 
@@ -718,13 +718,13 @@ static void* api_require(const char* symbol) {
     P(error),  P(gc), P(getallocf),  P(getfield),
     P(gethook), P(gethookcount), P(gethookmask), P(getinfo), P(getlocal),
     P(getmetatable), P(getstack), P(gettable), P(gettop), P(getupvalue),
-    P(insert), P(isnumber), P(isstring), P(isuserdata),
-    P(load), P(newstate), P(newthread), P(newuserdata), P(next),
+    P(isnumber), P(isstring), P(isuserdata),
+    P(load), P(newstate), P(newthread), P(next),
     P(pushboolean), P(pushcclosure), P(pushfstring), P(pushinteger),
     P(pushlightuserdata), P(pushlstring), P(pushnil), P(pushnumber),
     P(pushstring), P(pushthread),  P(pushvalue),
     P(pushvfstring), P(rawequal), P(rawget), P(rawgeti),
-    P(rawset), P(rawseti),  P(remove), P(replace), P(resume),
+    P(rawset), P(rawseti), P(resume),
     P(setallocf), P(setfield), P(sethook), P(setlocal),
     P(setmetatable), P(settable), P(settop), P(setupvalue),
     P(status), P(tocfunction), P(tointegerx), P(tolstring), P(toboolean),
@@ -737,12 +737,12 @@ static void* api_require(const char* symbol) {
     U(newstate), U(setfuncs), U(buffinit), U(addlstring), U(addstring),
     U(addvalue), U(pushresult),
     #if LUA_VERSION_NUM >= 502
-    P(absindex), P(arith), P(callk), P(compare), P(getctx), P(getglobal), P(getuservalue),
-    P(len), P(pcallk), P(pushunsigned), P(rawgetp), P(rawlen), P(rawsetp), P(setglobal),
-    P(iscfunction), P(setuservalue), P(tounsignedx), P(yieldk),
-    U(checkversion_), U(tolstring),  U(checkunsigned), U(len), U(getsubtable), U(prepbuffsize),
+    P(absindex), P(arith), P(callk), P(compare), P(getglobal),
+    P(len), P(pcallk), P(rawgetp), P(rawlen), P(rawsetp), P(setglobal),
+    P(iscfunction), P(yieldk),
+    U(checkversion_), U(tolstring), U(len), U(getsubtable), U(prepbuffsize),
     U(pushresultsize), U(buffinitsize), U(checklstring), U(checkoption), U(gsub), U(loadbufferx),
-    U(loadfilex), U(optinteger), U(optlstring), U(optunsigned), U(requiref), U(traceback)
+    U(loadfilex), U(optinteger), U(optlstring), U(requiref), U(traceback)
     #else
     P(objlen)
     #endif
@@ -797,7 +797,7 @@ static int f_watch_dir(lua_State *L) {
   uint32_t dmon_flags = (recursive ? DMON_WATCHFLAGS_RECURSIVE : 0);
   dmon_watch_id watch_id = dmon_watch(path, dirmonitor_watch_callback, dmon_flags, NULL);
   if (watch_id.id == 0) { luaL_error(L, "directory monitoring watch failed"); }
-  lua_pushnumber(L, watch_id.id);
+  lua_pushinteger(L, watch_id.id);
   return 1;
 }
 

--- a/subprojects/lua.wrap
+++ b/subprojects/lua.wrap
@@ -1,4 +1,12 @@
-[wrap-git]
-directory = lua
-url = https://github.com/franko/lua
-revision = v5.2.4-7
+[wrap-file]
+directory = lua-5.4.3
+source_url = https://www.lua.org/ftp/lua-5.4.3.tar.gz
+source_filename = lua-5.4.3.tar.gz
+source_hash = f8612276169e3bfcbcfb8f226195bfc6e466fe13042f1076cbde92b7ec96bbfb
+patch_filename = lua_5.4.3-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/lua_5.4.3-1/get_patch
+patch_hash = 66794455e18d373041c8ffa9c23d1629b813c7a716f8905425d347937f5c8dc8
+
+[provide]
+lua-5.4 = lua_dep
+


### PR DESCRIPTION
- floor every calculation that results in floating point numbers
- replace bit32 usage with pure lua replacement
- replace math.pow with ^2
- update meson.build to check for lua5.4 and lua (Lua does not have an official pkgconf and the names distros differs between distros, `luaMAJOR.MINOR` and `lua` being the most common ones)
- remove references to lua functions that are no longer available
- replace lua.wrap pointing to [franko/lua](https://github.com/franko/lua) to the [lua.wrap maintained by WrapDB](https://github.com/mesonbuild/wrapdb/blob/master/subprojects/lua.wrap)