### PR TITLE
[Fix] Pointer Bug in ToolBar plugin

### DIFF
--- a/data/plugins/toolbarview.lua
+++ b/data/plugins/toolbarview.lua
@@ -84,11 +84,12 @@ end
 
 function ToolbarView:on_mouse_pressed(button, x, y, clicks)
   local caught = ToolbarView.super.on_mouse_pressed(self, button, x, y, clicks)
-  if caught then return end
+  if caught then return false end
   core.set_active_view(core.last_active_view)
   if self.hovered_item then
     command.perform(self.hovered_item.command)
   end
+  return true
 end
 
 

--- a/data/plugins/toolbarview.lua
+++ b/data/plugins/toolbarview.lua
@@ -84,7 +84,7 @@ end
 
 function ToolbarView:on_mouse_pressed(button, x, y, clicks)
   local caught = ToolbarView.super.on_mouse_pressed(self, button, x, y, clicks)
-  if caught then return false end
+  if caught then return caught end
   core.set_active_view(core.last_active_view)
   if self.hovered_item then
     command.perform(self.hovered_item.command)


### PR DESCRIPTION
Fixes an issue where the pointer moves down when "open user module" button is spammed