### PR TITLE
add Libraries label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -33,3 +33,6 @@
 
 "Category: C Core":
   - src/**/*
+
+"Category: Libraries":
+  - lib/**/*


### PR DESCRIPTION
since `/lib` is only designed to house vendored libraries I figured it would be worthwhile to include it in the labeler 