### PR TITLE
Add fallbacks to all common dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@ build*/
 .build*/
 lhelper/
 submodules/
-subprojects/lua/
-subprojects/reproc/
+subprojects/*/
 /appimage*
 .ccls-cache
 .lite-debug.log

--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,7 @@ endif
 cc = meson.get_compiler('c')
 
 lite_includes = []
-lite_cargs = []
+lite_cargs = ['-DSDL_MAIN_HANDLED']
 # On macos we need to use the SDL renderer to support retina displays
 if get_option('renderer') or host_machine.system() == 'darwin'
     lite_cargs += '-DLITE_USE_SDL_RENDERER'
@@ -47,12 +47,28 @@ if not get_option('source-only')
     libm = cc.find_library('m', required : false)
     libdl = cc.find_library('dl', required : false)
     threads_dep = dependency('threads')
+
     lua_dep = dependency('lua5.2', fallback: ['lua', 'lua_dep'],
         default_options: ['shared=false', 'use_readline=false', 'app=false']
     )
-    pcre2_dep = dependency('libpcre2-8')
-    freetype_dep = dependency('freetype2')
-    sdl_dep = dependency('sdl2')
+
+    pcre2_fallback = []
+    # PCRE2 10.23 does not build on MinGW
+    if host_machine.system() != 'windows'
+        pcre2_fallback += ['pcre2', 'libpcre2_8']
+    endif
+    pcre2_dep = dependency('libpcre2-8', fallback: pcre2_fallback,
+        default_options: ['default_library=static']
+    )
+
+    freetype_dep = dependency('freetype2', fallback: ['freetype2', 'freetype_dep'],
+        default_options: ['default_library=static']
+    )
+
+    sdl_dep = dependency('sdl2', fallback: ['sdl2', 'sdl2_dep'],
+        default_options: ['default_library=static']
+    )
+
     lite_deps = [lua_dep, sdl_dep, freetype_dep, pcre2_dep, libm, libdl, threads_dep]
 endif
 #===============================================================================

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -63,10 +63,10 @@ main() {
   elif [[ "$OSTYPE" == "msys" ]]; then
     if [[ $lhelper == true ]]; then
       pacman --noconfirm -S \
-        ${MINGW_PACKAGE_PREFIX}-{gcc,meson,ninja,ntldd,pkg-config} unzip
+        ${MINGW_PACKAGE_PREFIX}-{gcc,meson,ninja,ntldd,pkg-config,mesa} unzip
     else
       pacman --noconfirm -S \
-        ${MINGW_PACKAGE_PREFIX}-{gcc,meson,ninja,ntldd,pkg-config,freetype,pcre2,SDL2} unzip
+        ${MINGW_PACKAGE_PREFIX}-{gcc,meson,ninja,ntldd,pkg-config,mesa,freetype,pcre2,SDL2} unzip
     fi
   fi
 }

--- a/scripts/lhelper.sh
+++ b/scripts/lhelper.sh
@@ -60,9 +60,9 @@ main() {
   # Not using $(lhelper activate lite-xl) to support CI
   source "$(lhelper env-source lite-xl)"
 
-  lhelper install freetype2
-  lhelper install sdl2 2.0.14-wait-event-timeout-1
-  lhelper install pcre2
+  if [[ "$OSTYPE" == "msys" ]]; then
+    lhelper install pcre2
+  fi
 
   # Help MSYS2 to find the SDL2 include and lib directories to avoid errors
   # during build and linking when using lhelper.

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1,4 +1,5 @@
 #include <SDL.h>
+#include <string.h>
 #include <stdbool.h>
 #include <ctype.h>
 #include <dirent.h>

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = freetype-2.11.1
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.11.1.tar.gz
+source_filename = freetype-2.11.1.tar.gz
+source_hash = f8db94d307e9c54961b39a1cc799a67d46681480696ed72ecf78d4473770f09b
+
+[provide]
+freetype2 = freetype_dep
+

--- a/subprojects/pcre2.wrap
+++ b/subprojects/pcre2.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = pcre2-10.23
+source_url = https://sourceforge.net/projects/pcre/files/pcre2/10.23/pcre2-10.23.zip
+source_filename = pcre2-10.23.zip
+source_hash = 6301a525a8a7e63a5fac0c2fbfa0374d3eb133e511d886771e097e427707094a
+patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.23-1/get_patch
+patch_filename = pcre2-10.23-1-wrap.zip
+patch_hash = ad6b4f042a911d06805fbbeeb9ffed0a988b282561164d0624a3ce02e93d4e24
+

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = SDL2-2.0.12
+source_url = https://www.libsdl.org/release/SDL2-2.0.12.tar.gz
+source_filename = SDL2-2.0.12.tar.gz
+source_hash = 349268f695c02efbc9b9148a70b85e58cefbbf704abd3e91be654db7f1e2c863
+patch_filename = sdl2_2.0.12-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.0.12-3/get_patch
+patch_hash = a5fb7c34694e6765da5c86a76119559df8d6891d9ce1d9fc800158c5161ff52b
+
+[provide]
+sdl2 = sdl2_dep
+


### PR DESCRIPTION
Work in progress move to having fallbacks for every dependency we can.

the PCRE2 link had to be updated from the ftp.pcre.org since that shut down (see https://github.com/mesonbuild/wrapdb/pull/224)

At the moment Sourceforge seems to be having some trouble so I'm marking this as a draft until they restore service or until I implement an alternative

Freetype is still linked dynamically for some reason, have to figure that out