### PR TITLE
ignore files enhancement to match paths

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -141,6 +141,9 @@ command.add(nil, {
   end,
 
   ["core:open-project-module"] = function()
+    if not system.get_file_info(".lite_project.lua") then
+      core.try(core.write_init_project_module, ".lite_project.lua")
+    end
     local doc = core.open_doc(".lite_project.lua")
     core.root_view:open_doc(doc)
     doc:save()

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -123,6 +123,7 @@ local function compare_file(a, b)
 end
 
 
+-- inspect config.ignore_files patterns and prepare ready to use entries.
 local function compile_ignore_files()
   local ipatterns = config.ignore_files
   local compiled = {}
@@ -132,8 +133,8 @@ local function compile_ignore_files()
     local match_dir = pattern:match("(.+)/$")
     compiled[i] = {
       use_path = pattern:match("/[^/]"), -- contains a slash but not at the end
-      match_dir = match_dir,
-      pattern = match_dir or pattern
+      match_dir = match_dir, -- to be used as a boolen value
+      pattern = match_dir or pattern -- get the actual pattern
     }
   end
   return compiled
@@ -610,11 +611,13 @@ local function project_scan_add_file(dir, filepath)
   local ignore = compile_ignore_files()
   local fileinfo = get_project_file_info(dir.name, PATHSEP .. filepath, ignore)
   if fileinfo then
+    -- on Windows and MacOS we can get events from directories we are not following:
+    -- check if each parent directories pass the ignore_files rules.
     repeat
       filepath = common.dirname(filepath)
       local parent_info = filepath and get_project_file_info(dir.name, PATHSEP .. filepath, ignore)
       if filepath and not parent_info then
-        return
+        return -- parent directory does match ignore_files rules: stop there
       end
     until not parent_info
     project_scan_add_entry(dir, fileinfo)

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -123,34 +123,32 @@ local function compare_file(a, b)
 end
 
 
+local function compile_ignore_files()
+  local ipatterns = config.ignore_files
+  local compiled = {}
+  -- config.ignore_files could be a simple string...
+  if type(ipatterns) ~= "table" then ipatterns = {ipatterns} end
+  for i, pattern in ipairs(ipatterns) do
+    local match_dir = pattern:match("(.+)/$")
+    compiled[i] = {
+      use_path = pattern:match("/[^/]"), -- contains a slash but not at the end
+      match_dir = match_dir,
+      pattern = match_dir or pattern
+    }
+  end
+  return compiled
+end
 
 
-
-
-local function fileinfo_pass_filter(info)
+local function fileinfo_pass_filter(info, ignore_compiled)
   if info.size >= config.file_size_limit * 1e6 then return false end
   local basename = common.basename(info.filename)
   -- replace '\' with '/' for Windows where PATHSEP = '\'
   local fullname = "/" .. info.filename:gsub("\\", "/")
-  local ipatterns = config.ignore_files
-  -- config.ignore_files could be a simple string...
-  if type(ipatterns) ~= "table" then ipatterns = {ipatterns} end
-  for _, pattern in ipairs(ipatterns) do
-    local is_path_like = pattern:match("/[^/]") -- contains a slash but not at the end
-    local dir_pass = true
-    if pattern:match("(.+)/$") then
-      dir_pass = (info.type == "dir")
-      -- the final '/' should not participate to the match.
-      pattern = pattern:match("(.+)/$")
-    end
-    if is_path_like then
-      if fullname:match(pattern) and dir_pass then
-        return false
-      end
-    else
-      if basename:match(pattern) and dir_pass then
-        return false
-      end
+  for _, compiled in ipairs(ignore_compiled) do
+    local pass_dir = (not compiled.match_dir or info.type == "dir")
+    if (compiled.use_path and fullname or basename):match(compiled.pattern) and pass_dir then
+      return false
     end
   end
   return true
@@ -159,11 +157,11 @@ end
 
 -- compute a file's info entry completed with "filename" to be used
 -- in project scan or falsy if it shouldn't appear in the list.
-local function get_project_file_info(root, file)
+local function get_project_file_info(root, file, ignore_compiled)
   local info = system.get_file_info(root .. file)
   if info then
     info.filename = strip_leading_path(file)
-    return fileinfo_pass_filter(info) and info
+    return fileinfo_pass_filter(info, ignore_compiled) and info
   end
 end
 
@@ -185,15 +183,16 @@ end
 -- When recursing "root" will always be the same, only "path" will change.
 -- Returns a list of file "items". In eash item the "filename" will be the
 -- complete file path relative to "root" *without* the trailing '/'.
-local function get_directory_files(dir, root, path, t, entries_count, recurse_pred, begin_hook)
+local function get_directory_files(dir, root, path, t, ignore_compiled, entries_count, recurse_pred, begin_hook)
   if begin_hook then begin_hook() end
+  ignore_compiled = ignore_compiled or compile_ignore_files()
   local t0 = system.get_time()
   local all = system.list_dir(root .. path) or {}
   local t_elapsed = system.get_time() - t0
   local dirs, files = {}, {}
 
   for _, file in ipairs(all) do
-    local info = get_project_file_info(root, path .. PATHSEP .. file)
+    local info = get_project_file_info(root, path .. PATHSEP .. file, ignore_compiled)
     if info then
       table.insert(info.type == "dir" and dirs or files, info)
       entries_count = entries_count + 1
@@ -205,7 +204,7 @@ local function get_directory_files(dir, root, path, t, entries_count, recurse_pr
   for _, f in ipairs(dirs) do
     table.insert(t, f)
     if recurse_pred(dir, f.filename, entries_count, t_elapsed) then
-      local _, complete, n = get_directory_files(dir, root, PATHSEP .. f.filename, t, entries_count, recurse_pred, begin_hook)
+      local _, complete, n = get_directory_files(dir, root, PATHSEP .. f.filename, t, ignore_compiled, entries_count, recurse_pred, begin_hook)
       recurse_complete = recurse_complete and complete
       entries_count = n
     else
@@ -338,7 +337,7 @@ local function project_subdir_bounds(dir, filename)
 end
 
 local function rescan_project_subdir(dir, filename_rooted)
-  local new_files = get_directory_files(dir, dir.name, filename_rooted, {}, 0, core.project_subdir_is_shown, coroutine.yield)
+  local new_files = get_directory_files(dir, dir.name, filename_rooted, {}, nil, 0, core.project_subdir_is_shown, coroutine.yield)
   local index, n = 0, #dir.files
   if filename_rooted ~= "" then
     local filename = strip_leading_path(filename_rooted)
@@ -395,7 +394,7 @@ local function scan_project_folder(index)
   if not dir.force_rescan then
     dir.watch_id = system.watch_dir(dir.name)
   end
-  local t, complete, entries_count = get_directory_files(dir, dir.name, "", {}, 0, timed_max_files_pred)
+  local t, complete, entries_count = get_directory_files(dir, dir.name, "", {}, nil, 0, timed_max_files_pred)
   -- If dir.files_limit is set to TRUE it means that:
   -- * we will not read recursively all the project files and we don't index them
   -- * we read only the files for the subdirectories that are opened/expanded in the
@@ -495,7 +494,7 @@ function core.update_project_subdir(dir, filename, expanded)
   assert(dir.files_limit, "function should be called only when directory is in files limit mode")
   local index, n, file = project_subdir_bounds(dir, filename)
   if index then
-    local new_files = expanded and get_directory_files(dir, dir.name, PATHSEP .. filename, {}, 0, core.project_subdir_is_shown) or {}
+    local new_files = expanded and get_directory_files(dir, dir.name, PATHSEP .. filename, {}, nil, 0, core.project_subdir_is_shown) or {}
     -- ASSUMPTION: core.update_project_subdir is called only when dir.files_limit is true
     -- NOTE: we may add new directories below but we do not need to call
     -- system.watch_dir_add because the current function is called only
@@ -608,9 +607,11 @@ end
 
 
 local function project_scan_add_file(dir, filepath)
-  local fileinfo = get_project_file_info(dir.name, PATHSEP .. filepath)
-  if not fileinfo or not fileinfo_pass_filter(fileinfo) then return end
-  project_scan_add_entry(dir, fileinfo)
+  local fileinfo = get_project_file_info(dir.name, PATHSEP .. filepath, compile_ignore_files())
+  if fileinfo then
+    if not fileinfo_pass_filter(fileinfo) then return end
+    project_scan_add_entry(dir, fileinfo)
+  end
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -607,9 +607,16 @@ end
 
 
 local function project_scan_add_file(dir, filepath)
-  local fileinfo = get_project_file_info(dir.name, PATHSEP .. filepath, compile_ignore_files())
+  local ignore = compile_ignore_files()
+  local fileinfo = get_project_file_info(dir.name, PATHSEP .. filepath, ignore)
   if fileinfo then
-    if not fileinfo_pass_filter(fileinfo) then return end
+    repeat
+      filepath = common.dirname(filepath)
+      local parent_info = filepath and get_project_file_info(dir.name, PATHSEP .. filepath, ignore)
+      if filepath and not parent_info then
+        return
+      end
+    until not parent_info
     project_scan_add_entry(dir, fileinfo)
   end
 end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -123,10 +123,37 @@ local function compare_file(a, b)
 end
 
 
+
+
+
+
 local function fileinfo_pass_filter(info)
+  if info.size >= config.file_size_limit * 1e6 then return false end
   local basename = common.basename(info.filename)
-  return (info.size < config.file_size_limit * 1e6 and
-      not common.match_pattern(basename, config.ignore_files))
+  -- replace '\' with '/' for Windows where PATHSEP = '\'
+  local fullname = "/" .. info.filename:gsub("\\", "/")
+  local ipatterns = config.ignore_files
+  -- config.ignore_files could be a simple string...
+  if type(ipatterns) ~= "table" then ipatterns = {ipatterns} end
+  for _, pattern in ipairs(ipatterns) do
+    local is_path_like = pattern:match("/[^/]") -- contains a slash but not at the end
+    local dir_pass = true
+    if pattern:match("(.+)/$") then
+      dir_pass = (info.type == "dir")
+      -- the final '/' should not participate to the match.
+      pattern = pattern:match("(.+)/$")
+    end
+    if is_path_like then
+      if fullname:match(pattern) and dir_pass then
+        return false
+      end
+    else
+      if basename:match(pattern) and dir_pass then
+        return false
+      end
+    end
+  end
+  return true
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -700,6 +700,46 @@ local style = require "core.style"
 end
 
 
+function core.write_init_project_module(init_filename)
+  local init_file = io.open(init_filename, "w")
+  if not init_file then error("cannot create file: \"" .. init_filename .. "\"") end
+  init_file:write([[
+-- Put project's module settings here.
+-- This module will be loaded when opening a project, after the user module
+-- configuration.
+-- It will be automatically reloaded when saved.
+
+local config = require "core.config"
+
+-- you can add some patterns to ignore files within the project
+-- config.ignore_files = {"^%.", <some-patterns>}
+
+-- Patterns are normally applied to the file's or directory's name, without
+-- its path. See below about how to include the path.
+--
+-- Here some examples:
+--
+-- "^%." match any file of directory whose basename begins with a dot.
+--
+-- When there is an '/' at the end the pattern will only match directories. The final
+-- '/' is removed from the pattern to match the file's or directory's name.
+--
+-- "^%.git$/" match any directory named ".git" anywhere in the project.
+--
+-- If a "/" appears anywhere in the pattern (except at the end) then the pattern
+-- will be applied to the full path of the file or directory. An initial "/" will
+-- be prepended to the file's or directory's path to indicate the project's root.
+--
+-- "^/node_modules$/" match a directory named "node_modules" at the project's root.
+-- "^/build/" match any top level directory whose name _begins_ with "build"
+-- "^/subprojects/.+/" match any directory inside a top-level folder named "subprojects".
+
+-- You may activate some plugins on a pre-project base to override the user's settings.
+-- config.plugins.trimwitespace = true
+]])
+  init_file:close()
+end
+
 
 function core.load_user_directory()
   return core.try(function()


### PR DESCRIPTION
I propose this enhancement of the config.ignore_files pattern taking inspiration from .gitignore.

The rules I propose are:

- the pattern is applied to the basename
- if a "/" appear in the pattern except at the end the pattern is applied to the full path of the file or directory.
- for the full path a "/" is added at the beginning to mean the project's root
- a pattern ending with "/" will match only directories. The final "/" is removed to match the file's or directory's name.

Here some examples:

"^%." match any file of directory whose basename begins with a dot.
"^%.git$/" match any directory named ".git" anywhere in the project.
"^/node_modules$/" match a directory named "node_modules" at the project's root.
"^/build/" match any top level directory whose name _begins_ with "build"
"^/subprojects/.+/" match any directory inside a top-level folder named "subprojects".

The resulting patterns are quite odds because we are essentially marrying Lua patterns with some ad-hoc rules about the "/" but this works in practice as long as the rules are correctly understood.

If used with the automatic reload of the project's module as implemented in the master-2.0 branch it is very practical and nice to have as you can interactively add the ignore_files pattern you need.

Eventually it should be merged in the master branch if there is agreement about this feature.