### PR TITLE
WIP: static CI builds + caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,13 +49,18 @@ jobs:
       CC: ${{ matrix.config.cc }}
       CXX: ${{ matrix.config.cxx }}
     steps:
+    - uses: actions/checkout@v2
     - name: Set Environment Variables
-      if: ${{ matrix.config.cc == 'gcc' }}
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
         echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-linux-$(uname -m)" >> "$GITHUB_ENV"
-    - uses: actions/checkout@v2
+    - name: Restore Cache
+      uses: actions/cache@v2
+      id:   cache
+      with:
+        key: lite-xl-${{ runner.os }}-${{ matrix.config.cc }}-${{ hashFiles('resources/lhelper-lockfile') }}
+        path: ~/.local/var
     - name: Python Setup
       uses: actions/setup-python@v2
       with:
@@ -63,17 +68,23 @@ jobs:
     - name: Update Packages
       run: sudo apt-get update
     - name: Install Dependencies
-      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/install-dependencies.sh --debug
-    - name: Install Release Dependencies
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      run: |
-        bash scripts/install-dependencies.sh --debug --lhelper
-        bash scripts/lhelper.sh --debug
+      run: bash scripts/install-dependencies.sh --debug --lhelper
+    - name: Install lhelper
+      run: bash scripts/lhelper.sh --install --debug
+    - name: Install Build Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: bash scripts/lhelper.sh --setup --debug
     - name: Build
       run: |
         bash --version
+        source "$(lhelper env-source lite-xl)"
         bash scripts/build.sh --debug --forcefallback
+    - name: Error Logs
+      if: failure()
+      run: |
+        mkdir ${INSTALL_NAME}
+        cp ~/.local/var/lhenv/lite-xl/logs/* ${INSTALL_NAME}
+        tar czvf ${INSTALL_NAME}.tar.gz ${INSTALL_NAME}
     - name: Package
       if: ${{ matrix.config.cc == 'gcc' }}
       run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary
@@ -88,6 +99,12 @@ jobs:
         path: |
           ${{ env.INSTALL_NAME }}.tar.gz
           LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
+    - name: Upload Error Logs
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: Error Logs
+        path: ${{ env.INSTALL_NAME }}.tar.gz
 
   build_macos:
     name: macOS (x86_64)
@@ -96,6 +113,7 @@ jobs:
       CC: clang
       CXX: clang++
     steps:
+    - uses: actions/checkout@v2
     - name: System Information
       run: |
         system_profiler SPSoftwareDataType
@@ -107,28 +125,33 @@ jobs:
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
         echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-macos-$(uname -m)" >> "$GITHUB_ENV"
-    - uses: actions/checkout@v2
+    - name: Restore Cache
+      uses: actions/cache@v2
+      id:   cache
+      with:
+        key: lite-xl-${{ runner.os }}-${{ hashFiles('resources/lhelper-lockfile') }}
+        path: ~/.local/var
     - name: Python Setup
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
     - name: Install Dependencies
-      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/install-dependencies.sh --debug
-    - name: Install Release Dependencies
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      run: |
-        bash scripts/install-dependencies.sh --debug --lhelper
-        bash scripts/lhelper.sh --debug
+      run: bash scripts/install-dependencies.sh --debug --lhelper
+    - name: Install lhelper
+      run: bash scripts/lhelper.sh --install --debug
+    - name: Install Build Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: bash scripts/lhelper.sh --setup --debug
     - name: Build
       run: |
         bash --version
+        source "$(lhelper env-source lite-xl)"
         bash scripts/build.sh --bundle --debug --forcefallback
     - name: Error Logs
       if: failure()
       run: |
         mkdir ${INSTALL_NAME}
-        cp /usr/var/lhenv/lite-xl/logs/* ${INSTALL_NAME}
+        cp ~/.local/var/lhenv/lite-xl/logs/* ${INSTALL_NAME}
         tar czvf ${INSTALL_NAME}.tar.gz ${INSTALL_NAME}
 #   - name: Package
 #     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -168,28 +191,38 @@ jobs:
           git
           zip
     - name: Set Environment Variables
+      # unless we inherit all PATH we'll need to add to .bash_profile instead
       run: |
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-$(uname -m)" >> "$GITHUB_ENV"
+        echo 'export PATH="$PATH:$HOME/.local/bin"' >> "$HOME/.bash_profile"
+        echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-${MSYSTEM_CARCH}" >> "$GITHUB_ENV"
         echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
+        echo "LHELPER_PATH=$(cygpath -w -a "$HOME/.local/var")" >> "$GITHUB_ENV"
+    - name: Restore Cache
+      uses: actions/cache@v2
+      id:   cache
+      with:
+        key: lite-xl-${{ runner.os }}-${{ matrix.msystem }}-${{ hashFiles('resources/lhelper-lockfile') }}
+        path: ${{ env.LHELPER_PATH }}
     - name: Install Dependencies
-      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/install-dependencies.sh --debug
-    - name: Install Release Dependencies
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: bash scripts/install-dependencies.sh --debug --lhelper
+    - name: Install lhelper
+      run: bash scripts/lhelper.sh --install --debug
+    - name: Install build dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: bash scripts/lhelper.sh --setup --debug
     - name: Build
       run: |
         bash --version
+        source "$(lhelper env-source lite-xl)"
         bash scripts/build.sh --debug --forcefallback
     - name: Error Logs
       if: failure()
       run: |
         mkdir ${INSTALL_NAME}
-        cp /usr/var/lhenv/lite-xl/logs/* ${INSTALL_NAME}
+        cp ~/.local/var/lhenv/lite-xl/logs/* ${INSTALL_NAME}
         tar czvf ${INSTALL_NAME}.tar.gz ${INSTALL_NAME}
     - name: Package
-      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary
+      run: bash scripts/package.sh --version ${INSTALL_REF} --arch ${MSYSTEM_CARCH} --debug --addons --binary
     - name: Build Installer
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: bash scripts/innosetup/innosetup.sh --debug

--- a/resources/lhelper-lockfile
+++ b/resources/lhelper-lockfile
@@ -1,0 +1,3 @@
+freetype2
+sdl2 2.0.16
+pcre2

--- a/scripts/lhelper.sh
+++ b/scripts/lhelper.sh
@@ -7,6 +7,9 @@ show_help() {
   echo
   echo "Available options:"
   echo
+  echo "   --install              Install lhelper."
+  echo "   --setup                Setup lite-xl environment."
+  echo
   echo "   --debug                Debug this script."
   echo "-h --help                 Show this help and exit."
   echo "-p --prefix PREFIX        Install directory prefix."
@@ -38,9 +41,9 @@ setup() {
   # Not using $(lhelper activate lite-xl) to support CI
   source "$(lhelper env-source lite-xl)"
 
-  while read -r line; do
+  tr -d '\r' < resources/lhelper-lockfile | while read -r line; do
     lhelper install $line
-  done < resources/lhelper-lockfile
+  done
 
   # Help MSYS2 to find the SDL2 include and lib directories to avoid errors
   # during build and linking when using lhelper.

--- a/scripts/lhelper.sh
+++ b/scripts/lhelper.sh
@@ -14,8 +14,45 @@ show_help() {
   echo
 }
 
+install() {
+  local lhelper_prefix=$1
+  if [[ -f ${lhelper_prefix}/bin/lhelper ]]; then
+    echo "lhelper is already installed."
+  else
+    git clone https://github.com/franko/lhelper.git
+
+    # FIXME: This should be set in ~/.bash_profile if not using CI
+    # export PATH="${HOME}/.local/bin:${PATH}"
+    mkdir -p "${lhelper_prefix}/bin"
+    pushd lhelper; bash install "${lhelper_prefix}"; popd
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      CC=clang CXX=clang++ lhelper create lite-xl -n
+    else
+      lhelper create lite-xl -n
+    fi
+  fi
+}
+
+setup() {
+  # Not using $(lhelper activate lite-xl) to support CI
+  source "$(lhelper env-source lite-xl)"
+
+  while read -r line; do
+    lhelper install $line
+  done < resources/lhelper-lockfile
+
+  # Help MSYS2 to find the SDL2 include and lib directories to avoid errors
+  # during build and linking when using lhelper.
+  if [[ "$OSTYPE" == "msys" ]]; then
+    CFLAGS=-I${LHELPER_ENV_PREFIX}/include/SDL2
+    LDFLAGS=-L${LHELPER_ENV_PREFIX}/lib
+  fi
+}
+
 main() {
   local lhelper_prefix="$HOME/.local"
+  local cmd=""
 
   for i in "$@"; do
     case $i in
@@ -27,6 +64,14 @@ main() {
         lhelper_prefix="$2"
         echo "LHelper prefix set to: \"${lhelper_prefix}\""
         shift
+        shift
+        ;;
+      --install)
+        cmd="install"
+        shift
+        ;;
+      --setup)
+        cmd="setup"
         shift
         ;;
       --debug)
@@ -41,34 +86,13 @@ main() {
 
   if [[ -n $1 ]]; then show_help; exit 1; fi
 
-  if [[ ! -f ${lhelper_prefix}/bin/lhelper ]]; then
-
-    git clone https://github.com/franko/lhelper.git
-
-    # FIXME: This should be set in ~/.bash_profile if not using CI
-    # export PATH="${HOME}/.local/bin:${PATH}"
-    mkdir -p "${lhelper_prefix}/bin"
-    pushd lhelper; bash install "${lhelper_prefix}"; popd
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      CC=clang CXX=clang++ lhelper create lite-xl -n
-    else
-      lhelper create lite-xl -n
-    fi
-  fi
-
-  # Not using $(lhelper activate lite-xl) to support CI
-  source "$(lhelper env-source lite-xl)"
-
-  lhelper install freetype2
-  lhelper install sdl2 2.0.14-wait-event-timeout-1
-  lhelper install pcre2
-
-  # Help MSYS2 to find the SDL2 include and lib directories to avoid errors
-  # during build and linking when using lhelper.
-  if [[ "$OSTYPE" == "msys" ]]; then
-    CFLAGS=-I${LHELPER_ENV_PREFIX}/include/SDL2
-    LDFLAGS=-L${LHELPER_ENV_PREFIX}/lib
+  if [[ $cmd == "install" ]]; then
+    install $lhelper_prefix
+  elif [[ $cmd == "setup" ]]; then
+    setup
+  else
+    show_help
+    exit 1
   fi
 }
 

--- a/scripts/lhelper.sh
+++ b/scripts/lhelper.sh
@@ -28,16 +28,16 @@ install() {
     # export PATH="${HOME}/.local/bin:${PATH}"
     mkdir -p "${lhelper_prefix}/bin"
     pushd lhelper; bash install "${lhelper_prefix}"; popd
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      CC=clang CXX=clang++ lhelper create lite-xl -n
-    else
-      lhelper create lite-xl -n
-    fi
   fi
 }
 
 setup() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    CC=clang CXX=clang++ lhelper create lite-xl -n
+  else
+    lhelper create lite-xl -n
+  fi
+
   # Not using $(lhelper activate lite-xl) to support CI
   source "$(lhelper env-source lite-xl)"
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -20,6 +20,7 @@ show_help() {
   echo "-h --help                 Show this help and exit."
   echo "-p --prefix PREFIX        Install directory prefix. Default: '/'."
   echo "-v --version VERSION      Sets the version on the package name."
+  echo "-a --arch ARCH            Sets the architecture of the package."
   echo "   --addons               Install 3rd party addons (currently Lite XL colors)."
   echo "   --debug                Debug this script."
   echo "-A --appimage             Create an AppImage (Linux only)."
@@ -121,6 +122,11 @@ main() {
         ;;
       -v|--version)
         if [[ -n $2 ]]; then version="-$2"; fi
+        shift
+        shift
+        ;;
+      -a|--arch)
+        arch="$2"
         shift
         shift
         ;;


### PR DESCRIPTION
This is a general update to the CI.

Instead of dynamic builds now the CI generates completely static builds so Windows user finally don't need MSYS2 to run (I personally ~~abuses~~ uses the CI to compile for Windows so I don't necessarily have MSYS2 set up).

For Windows it also generated x32 and x64 builds. 

Since some of the dependencies take forever to compile, I added caching for lhelper. I know ccache exists but it just doesn't work too well for this project. The build times are erratic at best and completely broken on MSYS2 and Mac. I find caching lhelper env to be the easiest for now.

A small problem is GHA's cache policy - cache will be evicted if untouched for 1 week and there's 0 ways to control that (I can't believe they **finally** thought of this after the proposal in 2019) so any kind of cache corruption would be _fun_ at least. It does improve compile time significantly though, so the benefits outweighs the risks.