### PR TITLE
Improve bit32 polyfill

### DIFF
--- a/data/core/bit.lua
+++ b/data/core/bit.lua
@@ -12,19 +12,20 @@ local function mask(n)
 end
 
 function bit.extract(n, field, width)
-	local r = trim(field)
-	local f = width
-	r = (r >> f) & mask(width)
-	return r
+	local w = width or 1
+	assert(w > 0, "width must be positive")
+	assert(field + w < LUA_NBITS and field + w >= 0, "trying to access non-existent bits")
+	local m = trim(n)
+	return m >> field & mask(w)
 end
 
 function bit.replace(n, v, field, width)
-	local r = trim(v);
-	local v = trim(field);
-	local f = width
-	local m = mask(width);
-	r = (r & ~(m << f)) | ((v & m) << f);
-	return r
+	local w = width or 1
+	assert(w > 0, "width must be positive")
+	assert(field + w < LUA_NBITS and field + w >= 0, "trying to access non-existent bits")
+	local m = trim(n)
+	local x = v & mask(width);
+	return m & ~(mask(w) << field) | (x << field)
 end
 
 return bit

--- a/data/core/bit.lua
+++ b/data/core/bit.lua
@@ -11,18 +11,23 @@ local function mask(n)
 	return (~((ALLONES << 1) << ((n) - 1)))
 end
 
+local function check_args(field, width)
+	assert(field >= 0, "field cannot be negative")
+	assert(width > 0, "width must be positive")
+	assert(field + width < LUA_NBITS and field + width >= 0,
+	       "trying to access non-existent bits")
+end
+
 function bit.extract(n, field, width)
 	local w = width or 1
-	assert(w > 0, "width must be positive")
-	assert(field + w < LUA_NBITS and field + w >= 0, "trying to access non-existent bits")
+	check_args(field, w)
 	local m = trim(n)
 	return m >> field & mask(w)
 end
 
 function bit.replace(n, v, field, width)
 	local w = width or 1
-	assert(w > 0, "width must be positive")
-	assert(field + w < LUA_NBITS and field + w >= 0, "trying to access non-existent bits")
+	check_args(field, w)
 	local m = trim(n)
 	local x = v & mask(width);
 	return m & ~(mask(w) << field) | (x << field)

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -32,3 +32,5 @@ end }
 
 table.pack = table.pack or pack or function(...) return {...} end
 table.unpack = table.unpack or unpack
+
+bit32 = bit32 or require "core.bit"

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -1,6 +1,5 @@
 local syntax = require "core.syntax"
 local common = require "core.common"
-local bit32 = require "core.bit"
 
 local tokenizer = {}
 


### PR DESCRIPTION
Do we need to keep this polyfill, or should we just make the tokenizer use the new bitwise operators directly?

Also, could anyone verify if my implementation is correct?