### PR TITLE
Improvements on core.add_thread function

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -1,5 +1,3 @@
-local config = require 'core.config'
-
 local common = {}
 
 
@@ -24,7 +22,7 @@ function common.merge(a, b)
   for k, v in pairs(a) do t[k] = v end
   if b then for k, v in pairs(b) do t[k] = v end end
   return t
-end 
+end
 
 
 function common.round(n)
@@ -447,15 +445,5 @@ function common.rm(path, recursively)
   return true
 end
 
----@param filename string
----@return boolean
-function common.match_ignore_files(filename)
-  for _, pattern in ipairs(config.ignore_files) do
-    if common.match_pattern(filename, pattern) then
-      return true
-    end
-  end
-  return false
-end
 
 return common

--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -1,3 +1,5 @@
+local config = require 'core.config'
+
 local common = {}
 
 
@@ -443,6 +445,17 @@ function common.rm(path, recursively)
   end
 
   return true
+end
+
+---@param filename string
+---@return boolean
+function common.match_ignore_files(filename)
+  for _, pattern in ipairs(config.ignore_files) do
+    if common.match_pattern(filename, pattern) then
+      return true
+    end
+  end
+  return false
 end
 
 return common

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -6,7 +6,7 @@ config.message_timeout = 5
 config.mouse_wheel_scroll = 50 * SCALE
 config.scroll_past_end = true
 config.file_size_limit = 10
-config.ignore_files = "^%."
+config.ignore_files = { "^%.", "node_modules" }
 config.symbol_pattern = "[%a_][%w_]*"
 config.non_word_chars = " \t\n/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
 config.undo_merge_timeout = 0.3

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -6,7 +6,7 @@ config.message_timeout = 5
 config.mouse_wheel_scroll = 50 * SCALE
 config.scroll_past_end = true
 config.file_size_limit = 10
-config.ignore_files = { "^%.", "node_modules" }
+config.ignore_files = { "^%." }
 config.symbol_pattern = "[%a_][%w_]*"
 config.non_word_chars = " \t\n/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
 config.undo_merge_timeout = 0.3
@@ -32,11 +32,11 @@ config.max_clicks = 3
 
 config.plugins = {}
 -- Allow you to set plugin configs even if we haven't seen the plugin before.
-setmetatable(config.plugins, { 
-  __index = function(t, k) 
-    if rawget(t, k) == nil then rawset(t, k, {}) end 
-    return rawget(t, k) 
-  end 
+setmetatable(config.plugins, {
+  __index = function(t, k)
+    if rawget(t, k) == nil then rawset(t, k, {}) end
+    return rawget(t, k)
+  end
 })
 
 -- Disable these plugins by default.

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -100,7 +100,7 @@ local function get_project_file_info(root, file)
   if info then
     info.filename = strip_leading_path(file)
     return (info.size < config.file_size_limit * 1e6 and
-      not common.match_pattern(common.basename(info.filename), config.ignore_files)
+      not common.match_ignore_files(common.basename(info.filename))
       and info)
   end
 end
@@ -462,7 +462,7 @@ end
 
 local function project_scan_add_file(dir, filepath)
   for fragment in string.gmatch(filepath, "([^/\\]+)") do
-    if common.match_pattern(fragment, config.ignore_files) then
+    if common.match_ignore_files(fragment) then
       return
     end
   end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -953,9 +953,11 @@ function core.show_title_bar(show)
 end
 
 
-function core.add_thread(f, weak_ref)
+function core.add_thread(f, weak_ref, ...)
   local key = weak_ref or #core.threads + 1
-  local fn = function() return core.try(f) end
+  local args = {...}
+  local unpack = unpack or table.unpack
+  local fn = function() return core.try(f, unpack(args)) end
   core.threads[key] = { cr = coroutine.create(fn), wake = 0 }
   return key
 end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -956,8 +956,8 @@ end
 function core.add_thread(f, weak_ref, ...)
   local key = weak_ref or #core.threads + 1
   local args = {...}
-  local unpack = unpack or table.unpack
-  local fn = function() return core.try(f, unpack(args)) end
+  local table_unpack = rawget(_G, 'unpack') or rawget(_G.table, 'unpack')
+  local fn = function() return core.try(f, table_unpack(args)) end
   core.threads[key] = { cr = coroutine.create(fn), wake = 0 }
   return key
 end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -100,7 +100,7 @@ local function get_project_file_info(root, file)
   if info then
     info.filename = strip_leading_path(file)
     return (info.size < config.file_size_limit * 1e6 and
-      not common.match_ignore_files(common.basename(info.filename))
+      not common.match_pattern(common.basename(info.filename), config.ignore_files)
       and info)
   end
 end
@@ -462,7 +462,7 @@ end
 
 local function project_scan_add_file(dir, filepath)
   for fragment in string.gmatch(filepath, "([^/\\]+)") do
-    if common.match_ignore_files(fragment) then
+    if common.match_pattern(fragment, config.ignore_files) then
       return
     end
   end
@@ -956,8 +956,7 @@ end
 function core.add_thread(f, weak_ref, ...)
   local key = weak_ref or #core.threads + 1
   local args = {...}
-  local table_unpack = rawget(_G, 'unpack') or rawget(_G.table, 'unpack')
-  local fn = function() return core.try(f, table_unpack(args)) end
+  local fn = function() return core.try(f, table.unpack(args)) end
   core.threads[key] = { cr = coroutine.create(fn), wake = 0 }
   return key
 end


### PR DESCRIPTION
In this pull request I have added the following features:

  - Support for an array of ignored files(`config.ignore_files`) and "node_modules" added by default due to have many files in this folder;
  - `core.add_thread` now accept extra arguments that is passed to the thread on call.

Using new `core.add_thread`:

```lua
-- mod-version:2

local core = require 'core'
local command = require 'core.command'

local function test(foo, bar)
  core.log(("In 'foo' I have '%s' and in 'bar' I have '%s'"):format(foo, bar))
end

command.add(nil, {
  ["pull:test"] = function()
    core.add_thread(test, nil, "hello", "world")
  end
})
```