### PR TITLE
Provide Rencache Hinting

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -403,6 +403,7 @@ function DocView:draw_overlay()
 end
 
 function DocView:draw()
+  DocView.super.draw(self)
   self:draw_background(style.background)
   local _, indent_size = self.doc:get_indent_info()
   self:get_font():set_tab_size(indent_size)

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -128,28 +128,35 @@ end
 
 function View:update()
   self:clamp_scroll_position()
-  local x, y = self.scroll.x, self.scroll.y
   self:move_towards(self.scroll, "x", self.scroll.to.x, 0.3)
   self:move_towards(self.scroll, "y", self.scroll.to.y, 0.3)
-  local dx, dy = x - self.scroll.x, y - self.scroll.y
-  if dx or dy then
-    local src = { 0, 0, self.size.x - dx, self.size.y - dy }
-    local dst = { 0, 0, self.size.x - dx, self.size.y - dy }
-    if dx < 0 then
-      src[1] = self.position.x + dx
-      dst[1] = self.position.x
-    else
-      src[1] = self.position.x
-      dst[1] = self.position.x + dx
+  if self.blit_hint_scroll then 
+    local dx, dy = self.scroll.x - self.blit_hint_scroll.x, self.scroll.y - self.blit_hint_scroll.y
+    if math.abs(dx) >= 1 or math.abs(dy) >= 1 then
+      local src, dst = { }, { }
+      if dx < 0 then
+        src[1] = common.clamp(self.position.x - dx, self.position.x, self.size.x)
+        dst[1] = self.position.x
+      else
+        src[1] = self.position.x
+        dst[1] = common.clamp(self.position.x - dx, self.position.x, self.size.x)
+      end
+      if dy < 0 then
+        src[2] = common.clamp(self.position.y - dy, self.position.y, self.size.y)
+        dst[2] = common.clamp(self.position.y + dy, self.position.y, self.size.y)
+      else
+        src[2] = common.clamp(self.position.y + dy, self.position.y, self.size.y)
+        dst[2] = common.clamp(self.position.y - dy, self.position.y, self.size.y)
+      end
+      src[3] = self.size.x - math.abs(dst[1] - src[1])
+      src[4] = self.size.y - math.abs(dst[2] - dst[2])
+      dst[3] = src[3]
+      dst[4] = src[4]
+      print("HINTA", table.unpack(src))
+      print("HINTB", table.unpack(dst))
+      print("HINTC", dx, dy)
+      renderer.blit_hint(src, dst)
     end
-    if dy < 0 then
-      src[2] = self.position.y + dy
-      dst[2] = self.position.y
-    else
-      src[2] = self.position.y
-      dst[2] = self.position.y + dy
-    end
-    renderer.blit_hint(src, dst)
   end
 end
 
@@ -158,6 +165,7 @@ function View:draw_background(color)
   local x, y = self.position.x, self.position.y
   local w, h = self.size.x, self.size.y
   renderer.draw_rect(x, y, w, h, color)
+  -- renderer.draw_rect(576, 480, 96, 96, { common.color "#ffffff" })
 end
 
 
@@ -170,6 +178,7 @@ end
 
 
 function View:draw()
+  self.blit_hint_scroll = { x = self.scroll.x, y = self.scroll.y }
 end
 
 

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -128,8 +128,29 @@ end
 
 function View:update()
   self:clamp_scroll_position()
+  local x, y = self.scroll.x, self.scroll.y
   self:move_towards(self.scroll, "x", self.scroll.to.x, 0.3)
   self:move_towards(self.scroll, "y", self.scroll.to.y, 0.3)
+  local dx, dy = x - self.scroll.x, y - self.scroll.y
+  if dx or dy then
+    local src = { 0, 0, self.size.x - dx, self.size.y - dy }
+    local dst = { 0, 0, self.size.x - dx, self.size.y - dy }
+    if dx < 0 then
+      src[1] = self.position.x + dx
+      dst[1] = self.position.x
+    else
+      src[1] = self.position.x
+      dst[1] = self.position.x + dx
+    end
+    if dy < 0 then
+      src[2] = self.position.y + dy
+      dst[2] = self.position.y
+    else
+      src[2] = self.position.y
+      dst[2] = self.position.y + dy
+    end
+    renderer.blit_hint(src, dst)
+  end
 end
 
 

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -16,6 +16,7 @@ function View:new()
   self.position = { x = 0, y = 0 }
   self.size = { x = 0, y = 0 }
   self.scroll = { x = 0, y = 0, to = { x = 0, y = 0 } }
+  self.blit_hint_scroll = { x = 0, y = 0 }
   self.cursor = "arrow"
   self.scrollable = false
 end
@@ -130,30 +131,29 @@ function View:update()
   self:clamp_scroll_position()
   self:move_towards(self.scroll, "x", self.scroll.to.x, 0.5)
   self:move_towards(self.scroll, "y", self.scroll.to.y, 0.5)
-  if self.blit_hint_scroll then 
-    local dx, dy = math.floor(self.scroll.x - self.blit_hint_scroll.x), math.floor(self.scroll.y - self.blit_hint_scroll.y)
-    if math.abs(dx) >= 1 or math.abs(dy) >= 1 then
-      local src, dst = { }, { }
-      if dx < 0 then
-        src[1] = common.clamp(self.position.x - dx, self.position.x, self.size.x)
-        dst[1] = self.position.x
-      else
-        src[1] = self.position.x
-        dst[1] = common.clamp(self.position.x + dx, self.position.x, self.size.x)
-      end
-      if dy < 0 then
-        src[2] = self.position.y
-        dst[2] = common.clamp(self.position.y - dy, self.position.y, self.size.y)
-      else
-        src[2] = common.clamp(self.position.y + dy, self.position.y, self.size.y)
-        dst[2] = self.position.y
-      end
-      src[3] = self.size.x - math.abs(dst[1] - src[1])
-      src[4] = self.size.y - math.abs(dst[2] - src[2])
-      dst[3] = src[3]
-      dst[4] = src[4]
-      renderer.blit_hint(src, dst)
+  local dx, dy = common.round(self.scroll.x) - self.blit_hint_scroll.x, common.round(self.scroll.y) - self.blit_hint_scroll.y
+  if math.abs(dx) >= 1 or math.abs(dy) >= 1 then
+    local src, dst = { }, { }
+    if dx < 0 then
+      src[1] = common.clamp(self.position.x - dx, self.position.x, self.size.x)
+      dst[1] = self.position.x
+    else
+      src[1] = self.position.x
+      dst[1] = common.clamp(self.position.x + dx, self.position.x, self.size.x)
     end
+    if dy < 0 then
+      src[2] = self.position.y
+      dst[2] = common.clamp(self.position.y - dy, self.position.y, self.size.y)
+    else
+      src[2] = common.clamp(self.position.y + dy, self.position.y, self.size.y)
+      dst[2] = self.position.y
+    end
+    src[3] = self.size.x - math.abs(dst[1] - src[1])
+    src[4] = self.size.y - math.abs(dst[2] - src[2])
+    dst[3] = src[3]
+    dst[4] = src[4]
+    renderer.blit_hint(src, dst)
+    self.blit_hint_scroll = { x = common.round(self.scroll.x), y = common.round(self.scroll.y) }
   end
 end
 
@@ -162,7 +162,6 @@ function View:draw_background(color)
   local x, y = self.position.x, self.position.y
   local w, h = self.size.x, self.size.y
   renderer.draw_rect(x, y, w, h, color)
-  -- renderer.draw_rect(576, 480, 96, 96, { common.color "#ffffff" })
 end
 
 
@@ -174,9 +173,7 @@ function View:draw_scrollbar()
 end
 
 
-function View:draw()
-  self.blit_hint_scroll = { x = self.scroll.x, y = self.scroll.y }
-end
+function View:draw() end
 
 
 return View

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -128,10 +128,10 @@ end
 
 function View:update()
   self:clamp_scroll_position()
-  self:move_towards(self.scroll, "x", self.scroll.to.x, 0.3)
-  self:move_towards(self.scroll, "y", self.scroll.to.y, 0.3)
+  self:move_towards(self.scroll, "x", self.scroll.to.x, 0.5)
+  self:move_towards(self.scroll, "y", self.scroll.to.y, 0.5)
   if self.blit_hint_scroll then 
-    local dx, dy = self.scroll.x - self.blit_hint_scroll.x, self.scroll.y - self.blit_hint_scroll.y
+    local dx, dy = math.floor(self.scroll.x - self.blit_hint_scroll.x), math.floor(self.scroll.y - self.blit_hint_scroll.y)
     if math.abs(dx) >= 1 or math.abs(dy) >= 1 then
       local src, dst = { }, { }
       if dx < 0 then
@@ -139,22 +139,19 @@ function View:update()
         dst[1] = self.position.x
       else
         src[1] = self.position.x
-        dst[1] = common.clamp(self.position.x - dx, self.position.x, self.size.x)
+        dst[1] = common.clamp(self.position.x + dx, self.position.x, self.size.x)
       end
       if dy < 0 then
-        src[2] = common.clamp(self.position.y - dy, self.position.y, self.size.y)
-        dst[2] = common.clamp(self.position.y + dy, self.position.y, self.size.y)
+        src[2] = self.position.y
+        dst[2] = common.clamp(self.position.y - dy, self.position.y, self.size.y)
       else
         src[2] = common.clamp(self.position.y + dy, self.position.y, self.size.y)
-        dst[2] = common.clamp(self.position.y - dy, self.position.y, self.size.y)
+        dst[2] = self.position.y
       end
       src[3] = self.size.x - math.abs(dst[1] - src[1])
-      src[4] = self.size.y - math.abs(dst[2] - dst[2])
+      src[4] = self.size.y - math.abs(dst[2] - src[2])
       dst[3] = src[3]
       dst[4] = src[4]
-      print("HINTA", table.unpack(src))
-      print("HINTB", table.unpack(dst))
-      print("HINTC", dx, dy)
       renderer.blit_hint(src, dst)
     end
   end

--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -219,6 +219,24 @@ static int f_draw_text(lua_State *L) {
   return 1;
 }
 
+static int f_blit_hint(lua_State* L) {
+  RenRect rects[2];
+  for (int i = 0; i < 2; ++i) {
+    lua_rawgeti(L, i+1, 1);
+    lua_rawgeti(L, i+1, 2);
+    lua_rawgeti(L, i+1, 3);
+    lua_rawgeti(L, i+1, 4);
+    lua_Number x = luaL_checknumber(L, -4);
+    lua_Number y = luaL_checknumber(L, -3);
+    lua_Number w = luaL_checknumber(L, -2);
+    lua_Number h = luaL_checknumber(L, -1);
+    rects[i] = rect_to_grid(x, y, w, h);
+    lua_pop(L, 4);
+  }
+  lua_pushinteger(L, rencache_blit_hint(rects[0], rects[1]));
+  return 1;
+}
+
 static const luaL_Reg lib[] = {
   { "show_debug",         f_show_debug         },
   { "get_size",           f_get_size           },
@@ -227,6 +245,7 @@ static const luaL_Reg lib[] = {
   { "set_clip_rect",      f_set_clip_rect      },
   { "draw_rect",          f_draw_rect          },
   { "draw_text",          f_draw_text          },
+  { "blit_hint",          f_blit_hint          },
   { NULL,                 NULL                 }
 };
 

--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -178,7 +178,11 @@ static int f_end_frame(lua_State *L) {
 }
 
 
-static RenRect rect_to_grid(lua_Number x, lua_Number y, lua_Number w, lua_Number h) {
+static RenRect rect_to_grid(lua_State* L, int index) {
+  lua_Number x = luaL_checknumber(L, index);
+  lua_Number y = luaL_checknumber(L, index+1);
+  lua_Number w = luaL_checknumber(L, index+2);
+  lua_Number h = luaL_checknumber(L, index+3);
   int x1 = (int) (x + 0.5), y1 = (int) (y + 0.5);
   int x2 = (int) (x + w + 0.5), y2 = (int) (y + h + 0.5);
   return (RenRect) {x1, y1, x2 - x1, y2 - y1};
@@ -186,24 +190,13 @@ static RenRect rect_to_grid(lua_Number x, lua_Number y, lua_Number w, lua_Number
 
 
 static int f_set_clip_rect(lua_State *L) {
-  lua_Number x = luaL_checknumber(L, 1);
-  lua_Number y = luaL_checknumber(L, 2);
-  lua_Number w = luaL_checknumber(L, 3);
-  lua_Number h = luaL_checknumber(L, 4);
-  RenRect rect = rect_to_grid(x, y, w, h);
-  rencache_set_clip_rect(rect);
+  rencache_set_clip_rect(rect_to_grid(L, 1));
   return 0;
 }
 
 
 static int f_draw_rect(lua_State *L) {
-  lua_Number x = luaL_checknumber(L, 1);
-  lua_Number y = luaL_checknumber(L, 2);
-  lua_Number w = luaL_checknumber(L, 3);
-  lua_Number h = luaL_checknumber(L, 4);
-  RenRect rect = rect_to_grid(x, y, w, h);
-  RenColor color = checkcolor(L, 5, 255);
-  rencache_draw_rect(rect, color);
+  rencache_draw_rect(rect_to_grid(L, 1), checkcolor(L, 5, 255));
   return 0;
 }
 
@@ -222,15 +215,9 @@ static int f_draw_text(lua_State *L) {
 static int f_blit_hint(lua_State* L) {
   RenRect rects[2];
   for (int i = 0; i < 2; ++i) {
-    lua_rawgeti(L, i+1, 1);
-    lua_rawgeti(L, i+1, 2);
-    lua_rawgeti(L, i+1, 3);
-    lua_rawgeti(L, i+1, 4);
-    lua_Number x = luaL_checknumber(L, -4);
-    lua_Number y = luaL_checknumber(L, -3);
-    lua_Number w = luaL_checknumber(L, -2);
-    lua_Number h = luaL_checknumber(L, -1);
-    rects[i] = rect_to_grid(x, y, w, h);
+    for (int j = 1; j <= 4; ++j)
+      lua_rawgeti(L, i+1, j);
+    rects[i] = rect_to_grid(L, -4);
     lua_pop(L, 4);
   }
   lua_pushinteger(L, rencache_blit_hint(rects[0], rects[1]));

--- a/src/rencache.h
+++ b/src/rencache.h
@@ -10,6 +10,7 @@ void  rencache_set_clip_rect(RenRect rect);
 void  rencache_draw_rect(RenRect rect, RenColor color);
 float rencache_draw_text(lua_State *L, RenFont **font, 
   const char *text, float x, int y, RenColor color);
+int   rencache_blit_hint(RenRect src, RenRect dst);
 void  rencache_invalidate(void);
 void  rencache_begin_frame(lua_State *L);
 void  rencache_end_frame(lua_State *L);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -348,6 +348,13 @@ void ren_draw_rect(RenRect rect, RenColor color) {
   }
 }
 
+void ren_blit_rect(RenRect src, RenRect dst) {
+  SDL_Surface *surface = renwin_get_surface(&window_renderer);
+  SDL_Rect sdl_src = { src.x, src.y, src.width, src.height };
+  SDL_Rect sdl_dst = { dst.x, dst.y, dst.width, dst.height };
+  SDL_BlitSurface(surface, &sdl_src, surface, &sdl_dst);
+}
+
 /*************** Window Management ****************/
 void ren_free_window_resources() {
   renwin_free(&window_renderer);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -29,6 +29,7 @@ void ren_init(SDL_Window *win);
 void ren_resize_window();
 void ren_update_rects(RenRect *rects, int count);
 void ren_set_clip_rect(RenRect rect);
+void ren_blit_rect(RenRect src, RenRect dst);
 void ren_get_size(int *x, int *y); /* Reports the size in points. */
 void ren_free_window_resources();
 


### PR DESCRIPTION
Initial commit to allow rencache hinting.

This essentially "solves" the scrolling performance issue, by allowing a view to hint to the rencache an appropriate way of handling a scroll; allowing the rencache to blit the entire moving rect a certain amount of pixels in a single direction, and then recomputing the rencache hashes appropriately based on that blit.

If all goes well, the straight blit should be significantly faster than re-rendering everything; and should allow for smoother transitions with much less CPU usage, *without* fully rewriting the rendering system to involve the graphics card.

This currently only works *without* transitions, unfortunately; probably something to do with fractional numbers being off in the sync. Will continue to work on this.