### PR TITLE
Cleanup

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,30 +69,37 @@ endif
 if not get_option('source-only')
     libm = cc.find_library('m', required : false)
     libdl = cc.find_library('dl', required : false)
-    lua_fallback = ['lua', 'lua_dep']
-    lua_quick_fallback = []
-    if get_option('wrap_mode') == 'forcefallback'
-        lua_quick_fallback = lua_fallback
-    endif
 
-    lua_dep = dependency('lua5.4', fallback: lua_quick_fallback, required : false)
-    if not lua_dep.found()
-        lua_dep = dependency('lua', fallback: ['lua', 'lua_dep'],
+    default_fallback_options = ['warning_level=0', 'werror=false']
+
+    # Lua has no official .pc file
+    # so distros come up with their own names
+    lua_names = [
+        'lua5.4', # Debian
+        'lua-5.4', # FreeBSD
+        'lua',    # Fedora
+    ]
+
+    foreach lua : lua_names
+        lua_dep = dependency(lua, fallback: ['lua', 'lua_dep'], required : (lua == lua_names[-1]),
             version: '>= 5.4',
-            default_options: ['default_library=static', 'line_editing=false', 'interpreter=false']
+            default_options: default_fallback_options + ['default_library=static', 'line_editing=false', 'interpreter=false']
         )
-    endif
+        if lua_dep.found()
+            break
+        endif
+    endforeach
 
     pcre2_dep = dependency('libpcre2-8', fallback: ['pcre2', 'libpcre2_8'],
-        default_options: ['default_library=static', 'grep=false', 'test=false']
+        default_options: default_fallback_options + ['default_library=static', 'grep=false', 'test=false']
     )
 
     freetype_dep = dependency('freetype2', fallback: ['freetype2', 'freetype_dep'],
-        default_options: ['default_library=static', 'zlib=disabled', 'bzip2=disabled', 'png=disabled', 'harfbuzz=disabled', 'brotli=disabled']
+        default_options: default_fallback_options + ['default_library=static', 'zlib=disabled', 'bzip2=disabled', 'png=disabled', 'harfbuzz=disabled', 'brotli=disabled']
     )
 
     sdl_dep = dependency('sdl2', fallback: ['sdl2', 'sdl2_dep'],
-        default_options: ['default_library=static']
+        default_options: default_fallback_options + ['default_library=static']
     )
 
     lite_deps = [lua_dep, sdl_dep, freetype_dep, pcre2_dep, libm, libdl]

--- a/meson.build
+++ b/meson.build
@@ -81,7 +81,8 @@ if not get_option('source-only')
     ]
 
     foreach lua : lua_names
-        lua_dep = dependency(lua, fallback: ['lua', 'lua_dep'], required : (lua == lua_names[-1]),
+        last_lua = (lua == lua_names[-1])
+        lua_dep = dependency(lua, fallback: last_lua ? ['lua', 'lua_dep'] : [], required : last_lua,
             version: '>= 5.4',
             default_options: default_fallback_options + ['default_library=static', 'line_editing=false', 'interpreter=false']
         )

--- a/src/api/dirmonitor.c
+++ b/src/api/dirmonitor.c
@@ -1,12 +1,7 @@
 #include "api.h"
 #include <stdlib.h>
-#ifdef _WIN32
+#ifdef DIRMONITOR_WIN32
   #include <windows.h>
-#elif __linux__
-  #include <sys/inotify.h>
-  #include <limits.h>
-#else
-  #include <sys/event.h>
 #endif
 #include <unistd.h>
 #include <errno.h>

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <SDL.h>
+#include <assert.h>
 
 #if _WIN32
   // https://stackoverflow.com/questions/60645/overlapped-i-o-on-anonymous-pipe
@@ -21,19 +22,23 @@
 
 #define READ_BUF_SIZE 2048
 
+#if _WIN32
+typedef HANDLE process_handle;
+#else
+typedef int process_handle;
+#endif
+
 typedef struct {
   bool running;
   int returncode, deadline;
   long pid;
   #if _WIN32
     PROCESS_INFORMATION process_information;
-    HANDLE child_pipes[3][2];
     OVERLAPPED overlapped[2];
     bool reading[2];
     char buffer[2][READ_BUF_SIZE];
-  #else
-    int child_pipes[3][2];
   #endif
+    process_handle child_pipes[3][2];
 } process_t;
 
 typedef enum {
@@ -117,8 +122,9 @@ static bool signal_process(process_t* proc, signal_e sig) {
 }
 
 static int process_start(lua_State* L) {
+  int retval = 1;
   size_t env_len = 0, key_len, val_len;
-  const char *cmd[256], *env_names[256] = { NULL }, *env_values[256] = { NULL }, *cwd = NULL;
+  const char *cmd[256] = { NULL }, *env_names[256] = { NULL }, *env_values[256] = { NULL }, *cwd = NULL;
   bool detach = false;
   int deadline = 10, new_fds[3] = { STDIN_FD, STDOUT_FD, STDERR_FD };
   luaL_checktype(L, 1, LUA_TTABLE);
@@ -134,7 +140,11 @@ static int process_start(lua_State* L) {
     lua_rawget(L, 1);
     cmd[i-1] = luaL_checkstring(L, -1);
   }
-  cmd[cmd_len] = NULL;
+
+  // this should never trip
+  // but if it does we are in deep trouble
+  assert(cmd[0]);
+
   if (arg_len > 1) {
     lua_getfield(L, 2, "env");
     if (!lua_isnil(L, -1)) {
@@ -158,8 +168,14 @@ static int process_start(lua_State* L) {
     lua_getfield(L, 2, "stdout");  new_fds[STDOUT_FD] = luaL_optnumber(L, -1, STDOUT_FD);
     lua_getfield(L, 2, "stderr");  new_fds[STDERR_FD] = luaL_optnumber(L, -1, STDERR_FD);
     for (int stream = STDIN_FD; stream <= STDERR_FD; ++stream) {
-      if (new_fds[stream] > STDERR_FD || new_fds[stream] < REDIRECT_PARENT)
-        return luaL_error(L, "redirect to handles, FILE* and paths are not supported");
+      if (new_fds[stream] > STDERR_FD || new_fds[stream] < REDIRECT_PARENT) {
+        for (size_t i = 0; i < env_len; ++i) {
+          free((char*)env_names[i]);
+          free((char*)env_values[i]);
+        }
+        retval = luaL_error(L, "redirect to handles, FILE* and paths are not supported");
+        goto cleanup;
+      }
     }
   }
   
@@ -188,16 +204,21 @@ static int process_start(lua_State* L) {
             sprintf(pipeNameBuffer, "\\\\.\\Pipe\\RemoteExeAnon.%08lx.%08lx", GetCurrentProcessId(), InterlockedIncrement(&PipeSerialNumber));
             self->child_pipes[i][0] = CreateNamedPipeA(pipeNameBuffer, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
               PIPE_TYPE_BYTE | PIPE_WAIT, 1, READ_BUF_SIZE, READ_BUF_SIZE, 0, NULL);
-            if (self->child_pipes[i][0] == INVALID_HANDLE_VALUE)
-              return luaL_error(L, "Error creating read pipe: %d.", GetLastError());
+            if (self->child_pipes[i][0] == INVALID_HANDLE_VALUE) {
+              retval = luaL_error(L, "Error creating read pipe: %d.", GetLastError());
+              goto cleanup;
+            }
             self->child_pipes[i][1] = CreateFileA(pipeNameBuffer, GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
             if (self->child_pipes[i][1] == INVALID_HANDLE_VALUE) {
               CloseHandle(self->child_pipes[i][0]);
-              return luaL_error(L, "Error creating write pipe: %d.", GetLastError());
+              retval = luaL_error(L, "Error creating write pipe: %d.", GetLastError());
+              goto cleanup;
             }
             if (!SetHandleInformation(self->child_pipes[i][i == STDIN_FD ? 1 : 0], HANDLE_FLAG_INHERIT, 0) ||
-                !SetHandleInformation(self->child_pipes[i][i == STDIN_FD ? 0 : 1], HANDLE_FLAG_INHERIT, 1))
-                  return luaL_error(L, "Error inheriting pipes: %d.", GetLastError());
+                !SetHandleInformation(self->child_pipes[i][i == STDIN_FD ? 0 : 1], HANDLE_FLAG_INHERIT, 1)) {
+                  retval = luaL_error(L, "Error inheriting pipes: %d.", GetLastError());
+                  goto cleanup;
+            }
           }
         } break;
       }
@@ -237,24 +258,25 @@ static int process_start(lua_State* L) {
     environmentBlock[offset++] = 0;
     if (env_len > 0)
       MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED, environmentBlock, offset, (LPWSTR)wideEnvironmentBlock, sizeof(wideEnvironmentBlock));
-    if (!CreateProcess(NULL, commandLine, NULL, NULL, true, (detach ? DETACHED_PROCESS : CREATE_NO_WINDOW) | CREATE_UNICODE_ENVIRONMENT, env_len > 0 ? wideEnvironmentBlock : NULL, cwd, &siStartInfo, &self->process_information))
-      return luaL_error(L, "Error creating a process: %d.", GetLastError());
+    if (!CreateProcess(NULL, commandLine, NULL, NULL, true, (detach ? DETACHED_PROCESS : CREATE_NO_WINDOW) | CREATE_UNICODE_ENVIRONMENT, env_len > 0 ? wideEnvironmentBlock : NULL, cwd, &siStartInfo, &self->process_information)) {
+      retval = luaL_error(L, "Error creating a process: %d.", GetLastError());
+      goto cleanup;
+    }
     self->pid = (long)self->process_information.dwProcessId;
     if (detach) 
       CloseHandle(self->process_information.hProcess);
     CloseHandle(self->process_information.hThread);
   #else
     for (int i = 0; i < 3; ++i) { // Make only the parents fd's non-blocking. Children should block.
-      if (pipe(self->child_pipes[i]) || fcntl(self->child_pipes[i][i == STDIN_FD ? 1 : 0], F_SETFL, O_NONBLOCK) == -1)
-        return luaL_error(L, "Error creating pipes: %s", strerror(errno));
+      if (pipe(self->child_pipes[i]) || fcntl(self->child_pipes[i][i == STDIN_FD ? 1 : 0], F_SETFL, O_NONBLOCK) == -1) {
+        retval = luaL_error(L, "Error creating pipes: %s", strerror(errno));
+        goto cleanup;
+      }
     }
     self->pid = (long)fork();
     if (self->pid < 0) {
-      for (int i = 0; i < 3; ++i) {
-        close(self->child_pipes[i][0]);
-        close(self->child_pipes[i][1]);
-      }
-      return luaL_error(L, "Error running fork: %s.", strerror(errno));
+      retval = luaL_error(L, "Error running fork: %s.", strerror(errno));
+      goto cleanup;
     } else if (!self->pid) {
       setpgrp();
       for (int stream = 0; stream < 3; ++stream) {
@@ -268,20 +290,25 @@ static int process_start(lua_State* L) {
       size_t set;
       for (set = 0; set < env_len && setenv(env_names[set], env_values[set], 1) == 0; ++set);
       if (set == env_len && (!detach || setsid() != -1) && (!cwd || chdir(cwd) != -1))
-        execvp((const char*)cmd[0], (char* const*)cmd);
+        execvp(cmd[0], (char** const)cmd);
       const char* msg = strerror(errno);
       size_t result = write(STDERR_FD, msg, strlen(msg)+1);
       _exit(result == strlen(msg)+1 ? -1 : -2);
     }
   #endif
+  cleanup:
   for (size_t i = 0; i < env_len; ++i) {
     free((char*)env_names[i]);
     free((char*)env_values[i]);
   }
-  for (int stream = 0; stream < 3; ++stream)
-    close_fd(&self->child_pipes[stream][stream == STDIN_FD ? 0 : 1]);
+  for (int stream = 0; stream < 3; ++stream) {
+    process_handle* pipe = &self->child_pipes[stream][stream == STDIN_FD ? 0 : 1];
+    if (*pipe) {
+      close_fd(pipe);
+    }
+  }
   self->running = true;
-  return 1;
+  return retval;
 }
 
 static int g_read(lua_State* L, int stream, unsigned long read_size) {

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -91,7 +91,7 @@ static bool poll_process(process_t* proc, int timeout) {
     #endif
     if (timeout)
       SDL_Delay(5);
-  } while (timeout == WAIT_INFINITE || SDL_GetTicks() - ticks < timeout);
+  } while (timeout == WAIT_INFINITE || (int)SDL_GetTicks() - ticks < timeout);
 
   return proc->running;
 }
@@ -265,12 +265,12 @@ static int process_start(lua_State* L) {
           dup2(self->child_pipes[new_fds[stream]][new_fds[stream] == STDIN_FD ? 0 : 1], stream);
         close(self->child_pipes[stream][stream == STDIN_FD ? 1 : 0]);
       }
-      int set;
+      size_t set;
       for (set = 0; set < env_len && setenv(env_names[set], env_values[set], 1) == 0; ++set);
       if (set == env_len && (!detach || setsid() != -1) && (!cwd || chdir(cwd) != -1))
         execvp((const char*)cmd[0], (char* const*)cmd);
       const char* msg = strerror(errno);
-      int result = write(STDERR_FD, msg, strlen(msg)+1);
+      size_t result = write(STDERR_FD, msg, strlen(msg)+1);
       _exit(result == strlen(msg)+1 ? -1 : -2);
     }
   #endif

--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "api.h"
 #include "../renderer.h"
 #include "../rencache.h"
@@ -166,14 +167,14 @@ static int f_get_size(lua_State *L) {
 }
 
 
-static int f_begin_frame(lua_State *L) {
-  rencache_begin_frame(L);
+static int f_begin_frame(UNUSED lua_State *L) {
+  rencache_begin_frame();
   return 0;
 }
 
 
-static int f_end_frame(lua_State *L) {
-  rencache_end_frame(L);
+static int f_end_frame(UNUSED lua_State *L) {
+  rencache_end_frame();
   return 0;
 }
 
@@ -214,7 +215,7 @@ static int f_draw_text(lua_State *L) {
   float x = luaL_checknumber(L, 3);
   int y = luaL_checknumber(L, 4);
   RenColor color = checkcolor(L, 5, 255);
-  x = rencache_draw_text(L, fonts, text, x, y, color);
+  x = rencache_draw_text(fonts, text, x, y, color);
   lua_pushnumber(L, x);
   return 1;
 }

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdalign.h>
+#include <string.h>
 
 #include <lauxlib.h>
 #include "rencache.h"
@@ -28,7 +29,7 @@ typedef struct {
   RenColor color;
   RenFont *fonts[FONT_FALLBACK_MAX];
   float text_x;
-  char text[0];
+  char text[];
 } Command;
 
 static unsigned cells_buf1[CELLS_X * CELLS_Y];
@@ -134,7 +135,7 @@ void rencache_draw_rect(RenRect rect, RenColor color) {
   }
 }
 
-float rencache_draw_text(lua_State *L, RenFont **fonts, const char *text, float x, int y, RenColor color)
+float rencache_draw_text(RenFont **fonts, const char *text, float x, int y, RenColor color)
 {
   float width = ren_font_group_get_width(fonts, text);
   RenRect rect = { x, y, (int)width, ren_font_group_get_height(fonts) };
@@ -159,7 +160,7 @@ void rencache_invalidate(void) {
 }
 
 
-void rencache_begin_frame(lua_State *L) {
+void rencache_begin_frame() {
   /* reset all cells if the screen width/height has changed */
   int w, h;
   ren_get_size(&w, &h);
@@ -200,7 +201,7 @@ static void push_rect(RenRect r, int *count) {
 }
 
 
-void rencache_end_frame(lua_State *L) {
+void rencache_end_frame() {
   /* update cells from commands */
   Command *cmd = NULL;
   RenRect cr = screen_rect;

--- a/src/rencache.h
+++ b/src/rencache.h
@@ -8,10 +8,9 @@
 void  rencache_show_debug(bool enable);
 void  rencache_set_clip_rect(RenRect rect);
 void  rencache_draw_rect(RenRect rect, RenColor color);
-float rencache_draw_text(lua_State *L, RenFont **font, 
-  const char *text, float x, int y, RenColor color);
+float rencache_draw_text(RenFont **font, const char *text, float x, int y, RenColor color);
 void  rencache_invalidate(void);
-void  rencache_begin_frame(lua_State *L);
-void  rencache_end_frame(lua_State *L);
+void  rencache_begin_frame();
+void  rencache_end_frame();
 
 #endif

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -302,6 +302,7 @@ float ren_draw_text(RenFont **fonts, const char *text, float x, int y, RenColor 
         uint8_t* source_pixel = &source_pixels[line * set->surface->pitch + glyph_start * (font->antialiasing == FONT_ANTIALIASING_SUBPIXEL ? 3 : 1)];
         for (int x = glyph_start; x < glyph_end; ++x) {
           uint32_t destination_color = *destination_pixel;
+          // the standard way of doing this would be SDL_GetRGBA, but that introduces a performance regression. needs to be investigated
           SDL_Color dst = { (destination_color & surface->format->Rmask) >> surface->format->Rshift, (destination_color & surface->format->Gmask) >> surface->format->Gshift, (destination_color & surface->format->Bmask) >> surface->format->Bshift, (destination_color & surface->format->Amask) >> surface->format->Ashift };
           SDL_Color src;
 
@@ -320,6 +321,7 @@ float ren_draw_text(RenFont **fonts, const char *text, float x, int y, RenColor 
           r = (color.r * src.r * color.a + dst.r * (65025 - src.r * color.a) + 32767) / 65025;
           g = (color.g * src.g * color.a + dst.g * (65025 - src.g * color.a) + 32767) / 65025;
           b = (color.b * src.b * color.a + dst.b * (65025 - src.b * color.a) + 32767) / 65025;
+          // the standard way of doing this would be SDL_GetRGBA, but that introduces a performance regression. needs to be investigated
           *destination_pixel++ = dst.a << surface->format->Ashift | r << surface->format->Rshift | g << surface->format->Gshift | b << surface->format->Bshift;
         }
       }

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -5,6 +5,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __GNUC__
+#define UNUSED __attribute__((__unused__))
+#else
+#define UNUSED
+#endif
+
 #define FONT_FALLBACK_MAX 4
 typedef struct RenFont RenFont;
 typedef enum { FONT_HINTING_NONE, FONT_HINTING_SLIGHT, FONT_HINTING_FULL } ERenFontHinting;

--- a/src/renwindow.c
+++ b/src/renwindow.c
@@ -27,7 +27,7 @@ static void setup_renderer(RenWindow *ren, int w, int h) {
 #endif
 
 
-void renwin_init_surface(RenWindow *ren) {
+void renwin_init_surface(UNUSED RenWindow *ren) {
 #ifdef LITE_USE_SDL_RENDERER
   if (ren->surface) {
     SDL_FreeSurface(ren->surface);
@@ -39,7 +39,7 @@ void renwin_init_surface(RenWindow *ren) {
 #endif
 }
 
-int renwin_surface_scale(RenWindow *ren) {
+int renwin_surface_scale(UNUSED RenWindow *ren) {
 #ifdef LITE_USE_SDL_RENDERER
   return ren->surface_scale;
 #else
@@ -72,7 +72,7 @@ SDL_Surface *renwin_get_surface(RenWindow *ren) {
 #endif
 }
 
-void renwin_resize_surface(RenWindow *ren) {
+void renwin_resize_surface(UNUSED RenWindow *ren) {
 #ifdef LITE_USE_SDL_RENDERER
   int new_w, new_h;
   SDL_GL_GetDrawableSize(ren->window, &new_w, &new_h);


### PR DESCRIPTION
Update meson.build
- add logic to loop over more lua names (in the future more names might be discovered)
  - also fixes error where forcing fallback would compile lua dynamically
- disable warnings and errors on dependencies

adding missing includes and checks, correct data types, pointer mess

- various functions from string.h were used but never defined
- logic was done across multiple different data types with different signedness, got all of them up to snuff
- give 0 sized array size of 1 (array of size 0 is illegal, but rewriting the code is out of the scope of this commit)
- add preprocessor that marks possibly unused argument as such (does not mean they will get optimized out or anything)
- correctly initialize structs with all data needed
- work around function pointers and data pointers being used like they are the same (thats illegal)