### PR TITLE
Fix cases of nil node.

### DIFF
--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -30,7 +30,7 @@ local t = {
     for i, v in ipairs(core.docs) do if v ~= active_doc then table.insert(docs, v) end end
     core.confirm_close_docs(docs, core.root_view.close_all_docviews, core.root_view, true)
   end,
-  
+
   ["root:switch-to-previous-tab"] = function()
     local node = core.root_view:get_active_node()
     local idx = node:get_view_idx(core.active_view)
@@ -64,7 +64,7 @@ local t = {
       table.insert(node.views, idx + 1, core.active_view)
     end
   end,
-  
+
   ["root:shrink"] = function()
     local node = core.root_view:get_active_node()
     local parent = node:get_parent_node(core.root_view.root_node)

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -30,7 +30,9 @@ end
 
 
 function RootView:get_active_node()
-  return self.root_node:get_node_for_view(core.active_view)
+  local node = self.root_node:get_node_for_view(core.active_view)
+  if not node then node = self:get_primary_node() end
+  return node
 end
 
 
@@ -46,6 +48,7 @@ end
 
 function RootView:get_active_node_default()
   local node = self.root_node:get_node_for_view(core.active_view)
+  if not node then node = self:get_primary_node() end
   if node.locked then
     local default_view = self:get_primary_node().views[1]
     assert(default_view, "internal error: cannot find original document node.")
@@ -254,7 +257,7 @@ function RootView:on_mouse_moved(x, y, dx, dy)
   self.root_node:on_mouse_moved(x, y, dx, dy)
 
   self.overlapping_node = self.root_node:get_child_overlapping_point(x, y)
-  
+
   local div = self.root_node:get_divider_overlapping_point(x, y)
   local tab_index = self.overlapping_node and self.overlapping_node:get_tab_overlapping_point(x, y)
   if self.overlapping_node and self.overlapping_node:get_scroll_button_index(x, y) then


### PR DESCRIPTION
When fixing the [widgets](https://github.com/jgmdev/lite-xl-widgets) library to work with latest master changes noticed that when setting the active view to the focused widget (to prevent mouse pressed/released events on main docview while a textbox widget is active) and then trying to execute a command like `core.root_view:open_doc()` or pressing `ctrl + shift + p` resulted in nil node for the related functions so with this pull requests it fallbacks to the primary node. This also fixes an issue on the [lite-xl-finder](https://github.com/takase1121/lite-xl-finder) plugin not opening the selected file.