### PR TITLE
Fixed rendering computations for y offset.

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -380,9 +380,8 @@ function DocView:draw_line_gutter(idx, x, y, width)
       break
     end
   end
-  local yoffset = self:get_line_text_y_offset()
   x = x + style.padding.x
-  common.draw_text(self:get_font(), color, idx, "right", x, y + yoffset, width,  self:get_line_height())
+  common.draw_text(self:get_font(), color, idx, "right", x, y, width,  self:get_line_height())
 end
 
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -114,8 +114,10 @@ static void font_load_glyphset(RenFont* font, int idx) {
     font->sets[j][idx] = set;
     for (int i = 0; i < MAX_GLYPHSET; ++i) {
       int glyph_index = FT_Get_Char_Index(font->face, i + idx * MAX_GLYPHSET);
-      if (!glyph_index || FT_Load_Glyph(font->face, glyph_index, load_option | FT_LOAD_BITMAP_METRICS_ONLY) || font_set_style(&font->face->glyph->outline, j * (64 / SUBPIXEL_BITMAPS_CACHED), font->style) || FT_Render_Glyph(font->face->glyph, render_option))
+      if (!glyph_index || FT_Load_Glyph(font->face, glyph_index, load_option | FT_LOAD_BITMAP_METRICS_ONLY)
+        || font_set_style(&font->face->glyph->outline, j * (64 / SUBPIXEL_BITMAPS_CACHED), font->style) || FT_Render_Glyph(font->face->glyph, render_option)) {
         continue;
+      }
       FT_GlyphSlot slot = font->face->glyph;
       int glyph_width = slot->bitmap.width / byte_width;
       if (font->antialiasing == FONT_ANTIALIASING_NONE)
@@ -124,8 +126,10 @@ static void font_load_glyphset(RenFont* font, int idx) {
       pen_x += glyph_width;
       font->max_height = slot->bitmap.rows > font->max_height ? slot->bitmap.rows : font->max_height;
       // In order to fix issues with monospacing; we need the unhinted xadvance; as FreeType doesn't correctly report the hinted advance for spaces on monospace fonts (like RobotoMono). See #843.
-      if (!glyph_index || FT_Load_Glyph(font->face, glyph_index, (load_option | FT_LOAD_BITMAP_METRICS_ONLY | FT_LOAD_NO_HINTING) & ~FT_LOAD_FORCE_AUTOHINT) || font_set_style(&font->face->glyph->outline, j * (64 / SUBPIXEL_BITMAPS_CACHED), font->style) || FT_Render_Glyph(font->face->glyph, render_option))
+      if (!glyph_index || FT_Load_Glyph(font->face, glyph_index, (load_option | FT_LOAD_BITMAP_METRICS_ONLY | FT_LOAD_NO_HINTING) & ~FT_LOAD_FORCE_AUTOHINT)
+        || font_set_style(&font->face->glyph->outline, j * (64 / SUBPIXEL_BITMAPS_CACHED), font->style) || FT_Render_Glyph(font->face->glyph, render_option)) {
         continue;
+      }
       slot = font->face->glyph;
       set->metrics[i].xadvance = slot->advance.x / 64.0f;
     }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -134,6 +134,8 @@ static void font_load_glyphset(RenFont* font, int idx) {
     }
     if (pen_x == 0)
       continue;
+    // Some monospace fonts aren't actually marked as monospace. In order to compensate for this, if the lower ascii all has the same integer advance,
+    // force this font to be monospace; i.e. have all "space advance" width spacing. Fixes fonts that FreeType doesn't think are monospace, like RobotoMono.
     if (idx == 0 && saved_advance > 0)
       font->monospace = true;
     set->surface = check_alloc(SDL_CreateRGBSurface(0, pen_x, font->max_height, font->antialiasing == FONT_ANTIALIASING_SUBPIXEL ? 24 : 8, 0, 0, 0, 0));

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -47,7 +47,6 @@ typedef struct RenFont {
   ERenFontAntialiasing antialiasing;
   ERenFontHinting hinting;
   unsigned char style;
-  bool monospace;
   char path[0];
 } RenFont;
 
@@ -113,7 +112,6 @@ static void font_load_glyphset(RenFont* font, int idx) {
   for (int j = 0, pen_x = 0; j < bitmaps_cached; ++j) {
     GlyphSet* set = check_alloc(calloc(1, sizeof(GlyphSet)));
     font->sets[j][idx] = set;
-    int saved_advance = -1;
     for (int i = 0; i < MAX_GLYPHSET; ++i) {
       int glyph_index = FT_Get_Char_Index(font->face, i + idx * MAX_GLYPHSET);
       if (!glyph_index || FT_Load_Glyph(font->face, glyph_index, load_option | FT_LOAD_BITMAP_METRICS_ONLY) || font_set_style(&font->face->glyph->outline, j * (64 / SUBPIXEL_BITMAPS_CACHED), font->style) || FT_Render_Glyph(font->face->glyph, render_option))
@@ -123,21 +121,16 @@ static void font_load_glyphset(RenFont* font, int idx) {
       if (font->antialiasing == FONT_ANTIALIASING_NONE)
         glyph_width *= 8;
       set->metrics[i] = (GlyphMetric){ pen_x, pen_x + glyph_width, 0, slot->bitmap.rows, true, slot->bitmap_left, slot->bitmap_top, (slot->advance.x + slot->lsb_delta - slot->rsb_delta) / 64.0f};
-      if (idx == 0 && i >= 32 && i <= 127) {
-        if (saved_advance == -1)
-          saved_advance = slot->advance.x;
-        else if (saved_advance != slot->advance.x)
-          saved_advance = -2;
-      }
       pen_x += glyph_width;
       font->max_height = slot->bitmap.rows > font->max_height ? slot->bitmap.rows : font->max_height;
+      // In order to fix issues with monospacing; we need the unhinted xadvance; as FreeType doesn't correctly report the hinted advance for spaces on monospace fonts (like RobotoMono). See #843.
+      if (!glyph_index || FT_Load_Glyph(font->face, glyph_index, (load_option | FT_LOAD_BITMAP_METRICS_ONLY | FT_LOAD_NO_HINTING) & ~FT_LOAD_FORCE_AUTOHINT) || font_set_style(&font->face->glyph->outline, j * (64 / SUBPIXEL_BITMAPS_CACHED), font->style) || FT_Render_Glyph(font->face->glyph, render_option))
+        continue;
+      slot = font->face->glyph;
+      set->metrics[i].xadvance = slot->advance.x / 64.0f;
     }
     if (pen_x == 0)
       continue;
-    // Some monospace fonts aren't actually marked as monospace. In order to compensate for this, if the lower ascii all has the same integer advance,
-    // force this font to be monospace; i.e. have all "space advance" width spacing. Fixes fonts that FreeType doesn't think are monospace, like RobotoMono.
-    if (idx == 0 && saved_advance > 0)
-      font->monospace = true;
     set->surface = check_alloc(SDL_CreateRGBSurface(0, pen_x, font->max_height, font->antialiasing == FONT_ANTIALIASING_SUBPIXEL ? 24 : 8, 0, 0, 0, 0));
     unsigned char* pixels = set->surface->pixels;
     for (int i = 0; i < MAX_GLYPHSET; ++i) {
@@ -254,7 +247,7 @@ float ren_font_group_get_width(RenFont **fonts, const char *text) {
     unsigned int codepoint;
     text = utf8_to_codepoint(text, &codepoint);
     RenFont* font = font_group_get_glyph(&set, &metric, fonts, codepoint, 0);
-    width += !font || (!font->monospace && metric->xadvance) ? metric->xadvance : fonts[0]->space_advance;
+    width += (!font || metric->xadvance) ? metric->xadvance : fonts[0]->space_advance;
   }
   const int surface_scale = renwin_surface_scale(&window_renderer);
   return width / surface_scale;
@@ -310,7 +303,7 @@ float ren_draw_text(RenFont **fonts, const char *text, float x, int y, RenColor 
         }
       }
     }
-    pen_x += !font->monospace && metric->xadvance ? metric->xadvance : font->space_advance;
+    pen_x += metric->xadvance ? metric->xadvance : font->space_advance;
   }
   if (fonts[0]->style & FONT_STYLE_UNDERLINE)
     ren_draw_rect((RenRect){ x, y / surface_scale + ren_font_group_get_height(fonts) - 1, (pen_x - x) / surface_scale, 1 }, color);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -43,7 +43,7 @@ typedef struct RenFont {
   FT_Face face;
   GlyphSet* sets[SUBPIXEL_BITMAPS_CACHED][MAX_LOADABLE_GLYPHSETS];
   float size, space_advance, tab_advance;
-  short max_height;
+  short max_height, baseline, height;
   ERenFontAntialiasing antialiasing;
   ERenFontHinting hinting;
   unsigned char style;
@@ -185,6 +185,8 @@ RenFont* ren_font_load(const char* path, float size, ERenFontAntialiasing antial
   strcpy(font->path, path);
   font->face = face;
   font->size = size;
+  font->height = (short)((face->height / (float)face->units_per_EM) * font->size);
+  font->baseline = (short)((face->bbox.yMax / (float)face->units_per_EM) * font->size);
   font->antialiasing = antialiasing;
   font->hinting = hinting;
   font->style = style;
@@ -229,7 +231,7 @@ float ren_font_group_get_size(RenFont **fonts) {
   return fonts[0]->size;
 }
 int ren_font_group_get_height(RenFont **fonts) {
-  return fonts[0]->size + 3;
+  return fonts[0]->height;
 }
 
 float ren_font_group_get_width(RenFont **fonts, const char *text) {
@@ -271,7 +273,7 @@ float ren_draw_text(RenFont **fonts, const char *text, float x, int y, RenColor 
     if (set->surface && color.a > 0 && end_x >= clip.x && start_x < clip_end_x) {
       unsigned char* source_pixels = set->surface->pixels;
       for (int line = metric->y0; line < metric->y1; ++line) {
-        int target_y = line + y - metric->y0 - metric->bitmap_top + font->size * surface_scale;
+        int target_y = line + y - metric->bitmap_top + font->baseline * surface_scale;
         if (target_y < clip.y)
           continue;
         if (target_y >= clip_end_y)


### PR DESCRIPTION
Should close #841 .

I'd also like to fix some issues with some monospace fonts not actually being monospace as reported by freetype (characters having slightly different xadvance values). I'm going to see if i can figure out what's going on there.