### PR TITLE
RFC: Safe mode

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -230,4 +230,7 @@ command.add(nil, {
       return common.home_encode_list(common.dir_list_suggest(text, dir_list))
     end)
   end,
+  ["core:crash"] = function()
+    core.crash = true
+  end,
 })

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1602,6 +1602,7 @@ end)
 function core.run()
   local idle_iterations = 0
   while true do
+    if core.crash then error("Crashing as requested") end
     core.frame_start = system.get_time()
     local did_redraw = core.step()
     local need_more_work = run_threads() or core.has_pending_rescan()

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -805,6 +805,7 @@ end
 
 
 function core.load_user_directory()
+  if SAFE_MODE then return true end
   return core.try(function()
     local stat_dir = system.get_file_info(USERDIR)
     if not stat_dir then
@@ -1132,7 +1133,7 @@ function core.load_plugins()
     datadir = {dir = DATADIR, plugins = {}},
   }
   local files, ordered = {}, {}
-  for _, root_dir in ipairs {DATADIR, USERDIR} do
+  for _, root_dir in ipairs {DATADIR, not SAFE_MODE and USERDIR or nil} do
     local plugin_dir = root_dir .. "/plugins"
     for _, filename in ipairs(system.list_dir(plugin_dir) or {}) do
       if not files[filename] then table.insert(ordered, filename) end
@@ -1164,6 +1165,7 @@ end
 
 
 function core.load_project_module()
+  if SAFE_MODE then return true end
   local filename = ".lite_project.lua"
   if system.get_file_info(filename) then
     return core.try(function()

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -2,6 +2,8 @@
 VERSION = "@PROJECT_VERSION@"
 MOD_VERSION = "2"
 
+SAFE_MODE = os.getenv("LITE_SAFE_MODE") or false
+
 SCALE = tonumber(os.getenv("LITE_SCALE") or os.getenv("GDK_SCALE") or os.getenv("QT_SCALE_FACTOR")) or SCALE
 PATHSEP = package.config:sub(1, 1)
 

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -2,7 +2,7 @@
 VERSION = "@PROJECT_VERSION@"
 MOD_VERSION = "2"
 
-SAFE_MODE = os.getenv("LITE_SAFE_MODE") or false
+SAFE_MODE = os.getenv("LITE_SAFE_MODE") or SAFE_MODE
 
 SCALE = tonumber(os.getenv("LITE_SCALE") or os.getenv("GDK_SCALE") or os.getenv("QT_SCALE_FACTOR")) or SCALE
 PATHSEP = package.config:sub(1, 1)

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -99,6 +99,17 @@ function StatusView:draw_items(items, right_align, yoffset)
     draw_items(self, items, x, y, common.draw_text)
   else
     x = x + style.padding.x
+    if SAFE_MODE then
+      local new_items = { table.unpack(items) }
+      table.insert(new_items, 1, style.text)
+      table.insert(new_items, 1, self.separator2)
+      table.insert(new_items, 1, style.dim)
+      table.insert(new_items, 1, "Safe mode")
+      table.insert(new_items, 1, style.font)
+      table.insert(new_items, 1, style.warn)
+      draw_items(self, new_items, x, y, common.draw_text)
+      return
+    end
     draw_items(self, items, x, y, common.draw_text)
   end
 end

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -132,6 +132,15 @@ function system.set_window_size(width, height, x, y) end
 function system.window_has_focus() end
 
 ---
+---Opens a YES-NO message box to display an error message.
+---
+---
+---@param title string
+---@param message string
+---@return boolean choice True for YES false for NO
+function system.show_fatal_choice(title, message) end
+
+---
 ---Opens a message box to display an error message.
 ---
 ---@param title string

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -414,6 +414,32 @@ static int f_get_window_mode(lua_State *L) {
 }
 
 
+static int f_show_fatal_choice(lua_State *L) {
+  const char *title = luaL_checkstring(L, 1);
+  const char *msg = luaL_checkstring(L, 2);
+  int choice;
+
+#ifdef _WIN32
+  choice = MessageBox(0, msg, title, MB_YESNO | MB_ICONERROR);
+  lua_pushboolean(L, choice == IDYES);
+#else
+  SDL_MessageBoxButtonData buttons[] = {
+    { SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Yes" },
+    { SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, "No" },
+  };
+  SDL_MessageBoxData data = {
+    .title = title,
+    .message = msg,
+    .numbuttons = 2,
+    .buttons = buttons,
+  };
+  SDL_ShowMessageBox(&data, &choice);
+  lua_pushboolean(L, choice);
+#endif
+  return 1;
+}
+
+
 static int f_show_fatal_error(lua_State *L) {
   const char *title = luaL_checkstring(L, 1);
   const char *msg = luaL_checkstring(L, 2);
@@ -946,6 +972,7 @@ static const luaL_Reg lib[] = {
   { "set_window_size",     f_set_window_size     },
   { "window_has_focus",    f_window_has_focus    },
   { "show_fatal_error",    f_show_fatal_error    },
+  { "show_fatal_choice",   f_show_fatal_choice   },
   { "rmdir",               f_rmdir               },
   { "chdir",               f_chdir               },
   { "mkdir",               f_mkdir               },

--- a/src/main.c
+++ b/src/main.c
@@ -117,6 +117,7 @@ int main(int argc, char **argv) {
   ren_init(window);
 
   lua_State *L;
+  bool safe_mode = false;
 init_lua:
   L = luaL_newstate();
   luaL_openlibs(L);
@@ -136,6 +137,9 @@ init_lua:
   lua_pushnumber(L, get_scale());
   lua_setglobal(L, "SCALE");
 
+  lua_pushboolean(L, safe_mode);
+  lua_setglobal(L, "SAFE_MODE");
+
   char exename[2048];
   get_exe_filename(exename, sizeof(exename));
   lua_pushstring(L, exename);
@@ -150,12 +154,15 @@ init_lua:
 
   const char *init_lite_code = \
     "local core\n"
+    "local safe_mode\n"
+    "local loaded\n"
     "xpcall(function()\n"
     "  HOME = os.getenv('" LITE_OS_HOME "')\n"
     "  local exedir = EXEFILE:match('^(.*)" LITE_PATHSEP_PATTERN LITE_NONPATHSEP_PATTERN "$')\n"
     "  local prefix = exedir:match('^(.*)" LITE_PATHSEP_PATTERN "bin$')\n"
     "  dofile((MACOS_RESOURCES or (prefix and prefix .. '/share/lite-xl' or exedir .. '/data')) .. '/core/start.lua')\n"
     "  core = require(os.getenv('LITE_XL_RUNTIME') or 'core')\n"
+    "  loaded = true\n"
     "  core.init()\n"
     "  core.run()\n"
     "end, function(err)\n"
@@ -172,19 +179,21 @@ init_lua:
     "    fp:write(debug.traceback(nil, 4)..'\\n')\n"
     "    fp:close()\n"
     "  end\n"
-    "  system.show_fatal_error('Lite XL internal error',\n"
+    "  local error_dialog = loaded and system.show_fatal_choice or system.show_fatal_error\n"
+    "  safe_mode = error_dialog('Lite XL internal error',\n"
     "    'An internal error occurred in a critical part of the application.\\n\\n'..\n"
-    "    'Please verify the file \\\"error.txt\\\" in the directory '..error_dir)\n"
-    "  os.exit(1)\n"
+    "    'Please verify the file \\\"error.txt\\\" in the directory '..error_dir..\n"
+    "    (loaded and '\\n\\nDo you want to restart in safe mode?' or ''))\n"
     "end)\n"
-    "return core and core.restart_request\n";
+    "return core and (safe_mode or core.restart_request), safe_mode\n";
 
   if (luaL_loadstring(L, init_lite_code)) {
     fprintf(stderr, "internal error when starting the application\n");
     exit(1);
   }
-  lua_pcall(L, 0, 1, 0);
-  if (lua_toboolean(L, -1)) {
+  lua_pcall(L, 0, 2, 0);
+  safe_mode = lua_toboolean(L, -1);
+  if (lua_toboolean(L, -2)) {
     lua_close(L);
     rencache_invalidate();
     goto init_lua;


### PR DESCRIPTION
When a fatal crash occurs, the user will be prompted to restart in safe mode.

Safe mode disables the loading of user plugins, user module and project module.

The mode can also be activated with the `LITE_SAFE_MODE` env variable.

What else could we do for a safe mode?
Should the `error.txt` file automatically open after a safe mode restart?