### PR TITLE
Use epsilon to compare values in `View:move_towards`

### DIFF
--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -25,7 +25,8 @@ function View:move_towards(t, k, dest, rate)
     return self:move_towards(self, t, k, dest, rate)
   end
   local val = t[k]
-  if not config.transitions or math.abs(val - dest) < 0.5 then
+  local diff = math.abs(val - dest)
+  if not config.transitions or diff < 0.5 then
     t[k] = dest
   else
     rate = rate or 0.5
@@ -35,7 +36,7 @@ function View:move_towards(t, k, dest, rate)
     end
     t[k] = common.lerp(val, dest, rate)
   end
-  if val ~= dest then
+  if diff > 1e-8 then
     core.redraw = true
   end
 end


### PR DESCRIPTION
In some cases the current value and `dest` are never _exactly_ equal, so `core.redraw` is always set.
Comparing the values using a small number avoids the problem.

Fixes #856.