### PR TITLE
plugin scale: replace non existing font.set_size with font.copy

### DIFF
--- a/data/plugins/scale.lua
+++ b/data/plugins/scale.lua
@@ -50,12 +50,8 @@ local function set_scale(scale)
     style.code_font = renderer.font.copy(style.code_font, s * style.code_font:get_size())
   end
 
-  for _, font in pairs(style.syntax_fonts) do
-    renderer.font.set_size(font, s * font:get_size())
-  end
-
-  for _, font in pairs(style.syntax_fonts) do
-    renderer.font.set_size(font, s * font:get_size())
+  for name, font in pairs(style.syntax_fonts) do
+    style.syntax_fonts[name] = renderer.font.copy(font, s * font:get_size())
   end
 
   -- restore scroll positions


### PR DESCRIPTION
Corrects leftover of font:set_size when scaling `style.syntax_fonts`