### PR TITLE
plugin treeview: skip rootview events if not visible.

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -186,6 +186,7 @@ end
 
 
 function TreeView:on_mouse_moved(px, py, ...)
+  if not self.visible then return end
   TreeView.super.on_mouse_moved(self, px, py, ...)
   if self.dragging_scrollbar then return end
 
@@ -223,6 +224,7 @@ end
 
 
 function TreeView:on_mouse_pressed(button, x, y, clicks)
+  if not self.visible then return end
   local caught = TreeView.super.on_mouse_pressed(self, button, x, y, clicks)
   if caught or button ~= "left" then
     return true
@@ -262,6 +264,8 @@ function TreeView:update()
   else
     self:move_towards(self.size, "x", dest)
   end
+
+  if not self.visible then return end
 
   local duration = system.get_time() - self.tooltip.begin
   if self.hovered_item and self.tooltip.x and duration > tooltip_delay then
@@ -372,6 +376,7 @@ end
 
 
 function TreeView:draw()
+  if not self.visible then return end
   self:draw_background(style.background2)
   local _y, _h = self.position.y, self.size.y
 


### PR DESCRIPTION
Fixes an issue where the treeview still draws when it is not visible and one clicks near where the treeview would have been drawing as shown below:

![2022-03-07_15:37:12](https://user-images.githubusercontent.com/1702572/157116275-1cf117cb-8282-48f9-a181-0b977d7e2571.png)

![2022-03-07_15:39:40](https://user-images.githubusercontent.com/1702572/157116308-18d219df-2fc8-4d11-b4d9-c4256f53a073.png)

![2022-03-07_15:58:22](https://user-images.githubusercontent.com/1702572/157116323-633ab56b-eec7-4b7a-affb-0beacfb916e8.png)

Also the nonicons plugin needs this since it overwrites the treeview draw method.