### PR TITLE
config: added skip_plugins_version

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -29,6 +29,9 @@ config.borderless = false
 config.tab_close_button = true
 config.max_clicks = 3
 
+-- set as true to be able to test non supported plugins
+config.skip_plugins_version = false
+
 config.plugins = {}
 -- Allow you to set plugin configs even if we haven't seen the plugin before.
 setmetatable(config.plugins, {

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -891,12 +891,11 @@ function core.load_plugins()
     local plugin_dir, basename = files[filename], filename:match("(.-)%.lua$") or filename
     local is_lua_file, version_match = check_plugin_version(plugin_dir .. '/' .. filename)
     if is_lua_file then
-      if not version_match then
+      if not config.skip_plugins_version and not version_match then
         core.log_quiet("Version mismatch for plugin %q from %s", basename, plugin_dir)
         local list = refused_list[plugin_dir:find(USERDIR, 1, true) == 1 and 'userdir' or 'datadir'].plugins
         table.insert(list, filename)
-      end
-      if version_match and config.plugins[basename] ~= false then
+      elseif config.plugins[basename] ~= false then
         local ok = core.try(require, "plugins." .. basename)
         if ok then core.log_quiet("Loaded plugin %q from %s", basename, plugin_dir) end
         if not ok then


### PR DESCRIPTION
This new config flag ignores the plugins version check at startup which helps a lot when working on new or old plugins that doesn't match the mod or lite-xl version and you still desire to load them to fix them by checking with lite-xl it self which errors need to be corrected.