### PR TITLE
highlighter: added lazy mode for low end machines.

### DIFF
--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -5,76 +5,206 @@ local tokenizer = require "core.tokenizer"
 local Object = require "core.object"
 
 local considered_slow = 0.05
+local considered_huge = 10000
+local maximum_context = 50
 local max_line_len_when_slow = config.line_limit + 20
 
 local Highlighter = Object:extend()
 
-
 function Highlighter:new(doc)
   self.doc = doc
   self.lazy_mode = false
-  self.last_line_edited = 0
-  self.last_tokenize_time = {line = 0, time=0}
-  self.incremental_running = false
+  self.last_line_edited = nil
+  self.last_tokenize_time = {line = 0, time = 0}
+  self.visible_lines = {first = 1, last = 1}
+  self.tokenized_visible = false
+  self.first_tokenization_run = false
+  self.first_lines = false
   self:reset()
 
   -- init incremental syntax highlighting
   core.add_thread(function()
     while true do
-      if self.first_invalid_line > self.max_wanted_line then
-        self.max_wanted_line = 0
+      local doc_lines = #self.doc.lines
+
+      if self.tokenized_visible or not self.doc.syntax or doc_lines <= 0 then
         coroutine.yield(1 / config.fps)
 
       else
-        self.incremental_running = true
-        local last_invalid = self.first_invalid_line
-        local max = math.min(self.first_invalid_line + 40, self.max_wanted_line)
-
-        local start_time = system.get_time();
-        for i = self.first_invalid_line, max do
-          local state = (i > 1) and self.lines[i - 1].state
-          local line = self.lines[i]
-          local line_len = #self.doc.lines[i]
-          if not (
-            line and line.init_state == state
-            and
-            line_len < 2 and line.text == self.doc.lines[i]
+        local first_run_next_min = nil
+        ::tokenize::
+        -- check if we should first tokenize visible lines
+        local two_pass = false
+        if
+          self.lazy_mode and self.first_lines and not self.last_line_edited
+          and
+          (
+            not self.lines[self.visible_lines.first]
+            or
+            not self.lines[self.visible_lines.last]
           )
-          then
-            local yield_tokenizer = self.lazy_mode
-              and not line
-              and line_len > max_line_len_when_slow
-              and i ~= self.last_line_edited
-
-            self.lines[i] = self:tokenize_line(i, state, yield_tokenizer)
-            local end_time = system.get_time()
-            local total_time = end_time - start_time
-
-            if total_time >= considered_slow then
-              core.redraw = true
-              coroutine.yield()
-              if max > #self.doc.lines then
-                break
-              elseif last_invalid ~= self.first_invalid_line then
-                i = self.first_invalid_line - 1
-                last_invalid = i + 1
-              end
-              start_time = system.get_time();
-            else
-              start_time = end_time
-            end
-          end
+        then
+          two_pass = true
         end
 
-        self.incremental_running = false
-        self.first_invalid_line = max + 1
-        core.redraw = true
+        local min, max = 0, 0
+        local first_visible = self.visible_lines.first
+        local last_visible = self.visible_lines.last
+        local last_edited = self.last_line_edited
+        local yielded = false
+
+        if
+          not self.first_tokenization_run
+          and
+          not (doc_lines > considered_huge or self.lazy_mode)
+        then
+          min = first_run_next_min or 1
+          max = doc_lines
+        elseif not two_pass then
+          if last_edited and self.doc.lines[last_edited] then
+            min = self.last_line_edited
+            self.last_line_edited = nil
+          else
+            min = math.max(
+              (doc_lines > considered_huge or self.lazy_mode)
+                and self.visible_lines.first - maximum_context
+                or self.visible_lines.first,
+              1
+            )
+          end
+          max = math.min(
+            (doc_lines > considered_huge or self.lazy_mode)
+              and self.visible_lines.first + maximum_context
+              or doc_lines,
+            doc_lines
+          )
+        else
+          min = math.max(self.visible_lines.first, 1)
+          max = math.min(self.visible_lines.last, doc_lines)
+        end
+
+        if min > 0 then
+          local reset_line, start_time = false, system.get_time();
+
+          ::tokenize_loop::
+          for i = min, max do
+            local state = ((i > 1) and self.lines[i - 1])
+              and self.lines[i - 1].state or nil
+            local line = self.lines[i]
+            local line_len = 0
+            if self.doc.lines[i] then
+              line_len = #self.doc.lines[i]
+            else
+              break
+            end
+            if not (
+              line and line.lazy and line.init_state == state
+              and
+              line_len < 2 and line.text == self.doc.lines[i]
+            )
+            then
+              -- yield currently non visible lines or long lines in lazy_mode
+              local yield_tokenizer = (i < self.visible_lines.first
+                or i > self.visible_lines.last) or (
+                  self.lazy_mode and line_len > max_line_len_when_slow
+              )
+
+              self.lines[i] = self:tokenize_line(i, state, yield_tokenizer)
+              self.lines[i].lazy = true
+              local end_time = system.get_time()
+              local total_time = end_time - start_time
+
+              -- check the rest of the lines that follow the last edited
+              -- to see if they do not require tokenization and exit
+              if
+                last_edited and i > last_edited
+                and self:tokens_same(line, self.lines[i])
+              then
+                self.tokenized_visible = true
+                break
+              end
+
+              if reset_line or (not yield_tokenizer and total_time >= considered_slow) then
+                reset_line, core.redraw, yielded = false, true, true
+                coroutine.yield()
+                if max > #self.doc.lines then break end
+                start_time = system.get_time();
+              else
+                yielded, start_time = yield_tokenizer, end_time
+              end
+            end
+            first_run_next_min = i
+            -- restart tokenization from last edited line
+            if self.last_line_edited then
+              if self.last_line_edited <= i then
+                min = math.min(self.last_line_edited, #self.doc.lines)
+                self.last_line_edited, reset_line = nil, true
+                goto tokenize_loop
+              end
+            end
+          end
+
+          if
+            first_visible == self.visible_lines.first
+            and
+            last_visible == self.visible_lines.last
+          then
+            self.tokenized_visible = true
+          end
+
+          if not self.tokenized_visible or two_pass then
+            if not yielded then coroutine.yield() end
+            two_pass = false
+            goto tokenize
+          end
+
+          self.first_tokenization_run = true
+          self.first_lines = true
+
+          core.redraw = true
+        end
         coroutine.yield()
       end
     end
   end, self)
 end
 
+function Highlighter:tokens_same(line1, line2)
+  if not line1 or not line2 or #line1.tokens ~= #line2.tokens then
+    return false
+  end
+  for i, token in ipairs(line1.tokens) do
+    if token ~= line2.tokens[i] then return false end
+  end
+  return true
+end
+
+function Highlighter:set_visible_lines(first, last)
+  if first ~= 1 and last ~= 1 and self.first_lines then
+    if
+      first < last
+      and
+      (first ~= self.visible_lines.first or last ~= self.visible_lines.last)
+    then
+      self.visible_lines.first = first
+      self.visible_lines.last = last
+      if self.lazy_mode then
+        self.tokenized_visible = false
+      else
+        for i=first, last do
+          if not self.lines[i] or not self.lines[i].lazy then
+            self.tokenized_visible = false
+            return
+          end
+        end
+      end
+    end
+  elseif not self.first_lines then
+    self.visible_lines.first = 1
+    self.visible_lines.last = 100
+    self.tokenized_visible = false
+  end
+end
 
 function Highlighter:reset()
   self.lines = {}
@@ -85,18 +215,10 @@ function Highlighter:soft_reset()
   for i=1,#self.lines do
     self.lines[i] = false
   end
-  self.first_invalid_line = 1
-  self.max_wanted_line = 0
-end
-
-function Highlighter:invalidate(idx)
-  self.first_invalid_line = math.min(self.first_invalid_line, idx)
-  self.max_wanted_line = math.min(self.max_wanted_line, #self.doc.lines)
 end
 
 function Highlighter:insert_notify(line, n)
   self.last_line_edited = line
-  self:invalidate(line)
   local blanks = { }
   for i = 1, n do
     blanks[i] = false
@@ -106,10 +228,8 @@ end
 
 function Highlighter:remove_notify(line, n)
   self.last_line_edited = line
-  self:invalidate(line)
   common.splice(self.lines, line, n)
 end
-
 
 function Highlighter:tokenize_line(idx, state, yield)
   local res = {}
@@ -119,30 +239,24 @@ function Highlighter:tokenize_line(idx, state, yield)
   return res
 end
 
-
 function Highlighter:get_line(idx, force)
   local line = self.lines[idx]
   if not line or line.text ~= self.doc.lines[idx] then
     local line_len = #self.doc.lines[idx]
     if
-      line_len > 1 and ((force or not self.lazy_mode) or (
+      line_len > 1 and ((force or not self.lazy_mode)
+      or
+      line_len <= max_line_len_when_slow
+      or
+      (
+        self.last_line_edited == idx
+        and
         -- edited a single line and tokenization time is fast even if long
         -- otherwise lazy tokenize to avoid typing lag
         (
-          self.last_line_edited == idx
-          and
-          (
-            self.last_tokenize_time.line ~= idx
-            or
-            self.last_tokenize_time.time < considered_slow
-            or
-            (self.incremental_running and self.first_invalid_line ~= idx)
-          )
-        )
-        -- if the line is considered short should tokenize fast enough
-        or
-        (
-          line_len <= max_line_len_when_slow
+          self.last_tokenize_time.line ~= idx
+          or
+          self.last_tokenize_time.time < considered_slow
         )
       )
     )
@@ -150,7 +264,9 @@ function Highlighter:get_line(idx, force)
       local prev = self.lines[idx - 1]
       local start_time = system.get_time()
       line = self:tokenize_line(idx, prev and prev.state)
-      local total_time = system.get_time() - start_time
+      line.lazy = false
+      local end_time = system.get_time()
+      local total_time = end_time - start_time
 
       self.last_tokenize_time.line = idx
       self.last_tokenize_time.time = total_time
@@ -170,15 +286,14 @@ function Highlighter:get_line(idx, force)
           self.doc.lines[idx]
         }
       }
-      if line_len > 1 then
-        self:invalidate(idx)
-      end
-      self.max_wanted_line = math.max(self.max_wanted_line, idx)
+    end
+    if self.first_lines then
+      self.visible_lines.first = idx
+      self.tokenized_visible = false
     end
   end
   return line
 end
-
 
 function Highlighter:each_token(idx, force)
   return tokenizer.each_token(self:get_line(idx, force).tokens)

--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -5,15 +5,17 @@ local tokenizer = require "core.tokenizer"
 local Object = require "core.object"
 
 local considered_slow = 0.05
-local max_line_len_when_slow = 100
+local max_line_len_when_slow = config.line_limit + 20
 
 local Highlighter = Object:extend()
 
 
 function Highlighter:new(doc)
   self.doc = doc
-  -- mode activated on slow machines where tokenization is taking too long
   self.lazy_mode = false
+  self.last_line_edited = 0
+  self.last_tokenize_time = {line = 0, time=0}
+  self.incremental_running = false
   self:reset()
 
   -- init incremental syntax highlighting
@@ -24,22 +26,47 @@ function Highlighter:new(doc)
         coroutine.yield(1 / config.fps)
 
       else
+        self.incremental_running = true
+        local last_invalid = self.first_invalid_line
         local max = math.min(self.first_invalid_line + 40, self.max_wanted_line)
 
+        local start_time = system.get_time();
         for i = self.first_invalid_line, max do
           local state = (i > 1) and self.lines[i - 1].state
           local line = self.lines[i]
-          if not (line and line.init_state == state and line.text == self.doc.lines[i]) then
-            local start_time = system.get_time();
-            self.lines[i] = self:tokenize_line(i, state)
-            local total_time = system.get_time() - start_time
+          local line_len = #self.doc.lines[i]
+          if not (
+            line and line.init_state == state
+            and
+            line_len < 2 and line.text == self.doc.lines[i]
+          )
+          then
+            local yield_tokenizer = self.lazy_mode
+              and not line
+              and line_len > max_line_len_when_slow
+              and i ~= self.last_line_edited
+
+            self.lines[i] = self:tokenize_line(i, state, yield_tokenizer)
+            local end_time = system.get_time()
+            local total_time = end_time - start_time
+
             if total_time >= considered_slow then
               core.redraw = true
-              coroutine.yield(0)
+              coroutine.yield()
+              if max > #self.doc.lines then
+                break
+              elseif last_invalid ~= self.first_invalid_line then
+                i = self.first_invalid_line - 1
+                last_invalid = i + 1
+              end
+              start_time = system.get_time();
+            else
+              start_time = end_time
             end
           end
         end
 
+        self.incremental_running = false
         self.first_invalid_line = max + 1
         core.redraw = true
         coroutine.yield()
@@ -68,6 +95,7 @@ function Highlighter:invalidate(idx)
 end
 
 function Highlighter:insert_notify(line, n)
+  self.last_line_edited = line
   self:invalidate(line)
   local blanks = { }
   for i = 1, n do
@@ -77,29 +105,57 @@ function Highlighter:insert_notify(line, n)
 end
 
 function Highlighter:remove_notify(line, n)
+  self.last_line_edited = line
   self:invalidate(line)
   common.splice(self.lines, line, n)
 end
 
 
-function Highlighter:tokenize_line(idx, state)
+function Highlighter:tokenize_line(idx, state, yield)
   local res = {}
   res.init_state = state
   res.text = self.doc.lines[idx]
-  res.tokens, res.state = tokenizer.tokenize(self.doc.syntax, res.text, state)
+  res.tokens, res.state = tokenizer.tokenize(self.doc.syntax, res.text, state, yield)
   return res
 end
 
 
-function Highlighter:get_line(idx)
+function Highlighter:get_line(idx, force)
   local line = self.lines[idx]
   if not line or line.text ~= self.doc.lines[idx] then
-    if not self.lazy_mode or (self.doc.lines[idx]:len() <= max_line_len_when_slow) then
+    local line_len = #self.doc.lines[idx]
+    if
+      line_len > 1 and ((force or not self.lazy_mode) or (
+        -- edited a single line and tokenization time is fast even if long
+        -- otherwise lazy tokenize to avoid typing lag
+        (
+          self.last_line_edited == idx
+          and
+          (
+            self.last_tokenize_time.line ~= idx
+            or
+            self.last_tokenize_time.time < considered_slow
+            or
+            (self.incremental_running and self.first_invalid_line ~= idx)
+          )
+        )
+        -- if the line is considered short should tokenize fast enough
+        or
+        (
+          line_len <= max_line_len_when_slow
+        )
+      )
+    )
+    then
       local prev = self.lines[idx - 1]
-      local start_time = system.get_time();
+      local start_time = system.get_time()
       line = self:tokenize_line(idx, prev and prev.state)
       local total_time = system.get_time() - start_time
-      if total_time >= considered_slow then
+
+      self.last_tokenize_time.line = idx
+      self.last_tokenize_time.time = total_time
+
+      if not self.lazy_mode and total_time >= considered_slow then
         self.lazy_mode = true
         core.log(
           "%s: slow tokenization detected, lazy mode activated",
@@ -114,16 +170,18 @@ function Highlighter:get_line(idx)
           self.doc.lines[idx]
         }
       }
-      self:invalidate(idx)
+      if line_len > 1 then
+        self:invalidate(idx)
+      end
+      self.max_wanted_line = math.max(self.max_wanted_line, idx)
     end
   end
-  self.max_wanted_line = math.max(self.max_wanted_line, idx)
   return line
 end
 
 
-function Highlighter:each_token(idx)
-  return tokenizer.each_token(self:get_line(idx).tokens)
+function Highlighter:each_token(idx, force)
+  return tokenizer.each_token(self:get_line(idx, force).tokens)
 end
 
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -410,6 +410,10 @@ function DocView:draw()
   local minline, maxline = self:get_visible_line_range()
   local lh = self:get_line_height()
 
+  if self.size.y > 0 then
+    self.doc.highlighter:set_visible_lines(minline, maxline)
+  end
+
   local x, y = self:get_line_screen_position(minline)
   local gw, gpad = self:get_gutter_width()
   for i = minline, maxline do

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -183,7 +183,7 @@ function tokenizer.tokenize(incoming_syntax, text, state, yield)
         -- and if it is not itself escaped.
         if count % 2 == 0 then break end
       end
-      if yield and find_cycle % 10 == 0 then
+      if yield and find_cycle % 400 == 0 then
         coroutine.yield()
       end
       find_cycle = find_cycle + 1


### PR DESCRIPTION
On lower end computers or single board computers like the [one I'm using ](https://wiki.odroid.com/odroid-n2/odroid-n2) tokenizing a line usually takes from 0.0007 seconds to 0.004s etc... which is pretty fast, but as I mentioned on #883, when opening files like this [readme](https://github.com/lite-xl/lite-xl/blob/master/README.md) things get ridiculously slow due to the long lines and expressive syntax file. Tokenizing a single line then can take 0.1s - 0.8s making the interface basically unresponsive, so what this change does is detect if tokenizing a line took too much and enable lazy mode which what basically does is return to the DocView draw calls plain text and let the highlighter co-routine perform the lazy tokenization while yielding to allow a more responsive UI. This change should not affect users with beefy computers since they shouldn't trigger lazy mode unless you are opening something huge. Here some captures to demonstrate:

**Highlighter without lazy mode:**

https://user-images.githubusercontent.com/1702572/158751064-7c7f1f74-89f4-4cfb-9f82-f2c0cfd5fb71.mp4

Notice that even with the detectindent performance improvement I worked on #883 it still opens a bit slow on my system due to the slow tokenization, now the other video.

**Highlighter with lazy mode automatically enabled when performance seems bad:**

https://user-images.githubusercontent.com/1702572/158751495-124df44c-e144-422b-815b-97a2ef39bd20.mp4

That is all for the moment!