### PR TITLE
Move cursor to the beginning/end of its selection

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -578,18 +578,20 @@ commands["doc:move-to-previous-char"] = function()
   for idx, line1, col1, line2, col2 in doc():get_selections(true) do
     if line1 ~= line2 or col1 ~= col2 then
       doc():set_selections(idx, line1, col1)
+    else
+      doc():move_to_cursor(idx, translate.previous_char)
     end
   end
-  doc():move_to(translate.previous_char)
 end
 
 commands["doc:move-to-next-char"] = function()
   for idx, line1, col1, line2, col2 in doc():get_selections(true) do
     if line1 ~= line2 or col1 ~= col2 then
       doc():set_selections(idx, line2, col2)
+    else
+      doc():move_to_cursor(idx, translate.next_char)
     end
   end
-  doc():move_to(translate.next_char)
 end
 
 command.add("core.docview", commands)


### PR DESCRIPTION
When using `doc:move-to-{previous,next}-char` in a selection, we were moving the cursor to the character before the initial/after the last character of the selection.
With this PR, we follow what other editors do and move it to just before the initial/just after the final character.

Before

https://user-images.githubusercontent.com/2798487/159146959-4b5664dc-b143-4f0e-9b48-ed85addd6e43.mp4

After

https://user-images.githubusercontent.com/2798487/159146962-864d1754-fb17-4769-a063-6adfa7cf9c6b.mp4