### PR TITLE
Fixed anonymous syntaxes.

### DIFF
--- a/data/plugins/detectindent.lua
+++ b/data/plugins/detectindent.lua
@@ -76,7 +76,7 @@ end
 
 
 local function get_comment_patterns(syntax)
-  if comments_cache[syntax.name] then
+  if syntax.name and comments_cache[syntax.name] then
     if #comments_cache[syntax.name] > 0 then
       return comments_cache[syntax.name]
     else
@@ -123,7 +123,8 @@ local function get_comment_patterns(syntax)
         end
       end
     elseif pattern.syntax then
-      local subsyntax = core_syntax.get("file"..pattern.syntax, "")
+      local subsyntax = type(pattern.syntax) == 'table' and pattern.syntax
+        or core_syntax.get("file"..pattern.syntax, "")
       local sub_comments = get_comment_patterns(subsyntax)
       if sub_comments then
         for s=1, #sub_comments do
@@ -149,7 +150,9 @@ local function get_comment_patterns(syntax)
       table.insert(comments, {"p", "^%s*" .. block_comment[1], block_comment[2]})
     end
   end
-  comments_cache[syntax.name] = comments
+  if syntax.name then
+    comments_cache[syntax.name] = comments
+  end
   if #comments > 0 then
     return comments
   end

--- a/data/plugins/detectindent.lua
+++ b/data/plugins/detectindent.lua
@@ -76,9 +76,9 @@ end
 
 
 local function get_comment_patterns(syntax)
-  if syntax.name and comments_cache[syntax.name] then
-    if #comments_cache[syntax.name] > 0 then
-      return comments_cache[syntax.name]
+  if comments_cache[syntax] then
+    if #comments_cache[syntax] > 0 then
+      return comments_cache[syntax]
     else
       return nil
     end
@@ -150,9 +150,7 @@ local function get_comment_patterns(syntax)
       table.insert(comments, {"p", "^%s*" .. block_comment[1], block_comment[2]})
     end
   end
-  if syntax.name then
-    comments_cache[syntax.name] = comments
-  end
+  comments_cache[syntax] = comments
   if #comments > 0 then
     return comments
   end


### PR DESCRIPTION
Up until recently, you were able to add annoymous sub-syntaxes to the syntax list.

As in the liquid plugin:

```lua

local syntax = require "core.syntax"

local liquid_syntax = {
  patterns = {
    { pattern = { '"', '"', '\\' },        type = "string"   },
    { pattern = { "'", "'", '\\' },        type = "string"   },
    { pattern = "-?%d+[%d%.]*f?",          type = "number"   },
    { pattern = "-?%.?%d+f?",              type = "number"   },
    { pattern = "%w+",                     type = "symbol" },
  },
  symbols = {
    ["abs"] = "keyword2",
    ...
  },
}

syntax.add {
  name = "Liquid",
  files = { "%.liquid?$" },
  patterns = {
    { pattern = { "{%%", "%%}" }, syntax = liquid_syntax, type = "function" },
    { pattern = { "{{", "}}" }, syntax = liquid_syntax, type = "function" },
    ...
```

This was broken recently by the detectindent plugin; I've just changed it so that the plugin's no longer requiring a name, and no longer requiring that `syntax` be a reference instead of an inline-table.