### PR TITLE
Boost in tokenizer performance with 3 liner

### DIFF
--- a/data/core/syntax.lua
+++ b/data/core/syntax.lua
@@ -7,6 +7,11 @@ local plain_text_syntax = { name = "Plain Text", patterns = {}, symbols = {} }
 
 
 function syntax.add(t)
+  -- this rule gives us a performance gain for the tokenizer in lines with
+  -- long amounts of consecutive spaces without affecting other patterns
+  if t.patterns then
+    table.insert(t.patterns, 1, { pattern = "%s+", type = "normal" })
+  end
   table.insert(syntax.items, t)
 end
 


### PR DESCRIPTION
While working on improving responsiveness of lite-xl while highlithing on #885 I noticed that the slow downs in tokenization process where occurring on lines with long amounts of consecutive spaces. It seems the tokenizer was trying to apply each of its rules to each of the spaces found which slowed things a lot. 

Adding a rule of %s+ that matches to "normal" in the beginning of every syntax table, will hugely improve the performance of the tokenizer basically for free! I haven't measured yet the gains but it is noticeable how tokenization is much more faster now.