### PR TITLE
TreeView Changes

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1172,12 +1172,13 @@ end
 
 local function get_title_filename(view)
   local doc_filename = view.get_filename and view:get_filename() or view:get_name()
-  return (doc_filename ~= "---") and doc_filename or ""
+  if doc_filename ~= "---" then return doc_filename end
+  return ""
 end
 
 
 function core.compose_window_title(title)
-  return title == "" and "Lite XL" or title .. " - Lite XL"
+  return (title == "" or title == nil) and "Lite XL" or title .. " - Lite XL"
 end
 
 
@@ -1216,7 +1217,7 @@ function core.step()
 
   -- update window title
   local current_title = get_title_filename(core.active_view)
-  if current_title ~= core.window_title then
+  if current_title ~= nil and current_title ~= core.window_title then
     system.set_window_title(core.compose_window_title(current_title))
     core.window_title = current_title
   end

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -11,8 +11,6 @@ local RootView = require "core.rootview"
 local CommandView = require "core.commandview"
 
 config.plugins.treeview = common.merge({
-  -- Amount of clicks to open a file
-  clicks_to_open = 1,
   -- Default treeview width
   size = 200 * SCALE
 }, config.plugins.treeview)
@@ -234,46 +232,6 @@ function TreeView:on_mouse_moved(px, py, ...)
   end
   if not item_changed then self.hovered_item = nil end
   if not tooltip_changed then self.tooltip.x, self.tooltip.y = nil, nil end
-end
-
-
-local function create_directory_in(item)
-  local path = item.abs_filename
-  core.command_view:enter("Create directory in " .. path, function(text)
-    local dirname = path .. PATHSEP .. text
-    local success, err = system.mkdir(dirname)
-    if not success then
-      core.error("cannot create directory %q: %s", dirname, err)
-    end
-    item.expanded = true
-  end)
-end
-
-
-function TreeView:on_mouse_pressed(button, x, y, clicks)
-  if not self.visible then return end
-  local caught = TreeView.super.on_mouse_pressed(self, button, x, y, clicks)
-  if caught or button ~= "left" then
-    return true
-  end
-
-  if self.hovered_item then
-    self:set_selection(self.hovered_item)
-
-    if keymap.modkeys["ctrl"] and button == "left" then
-      create_directory_in(self.selected_item)
-    elseif self.selected_item.type == "dir"
-      or (self.selected_item.type == "file"
-        and clicks >= config.plugins.treeview.clicks_to_open
-      )
-    then
-      command.perform "treeview:open"
-    end
-  else
-    return false
-  end
-
-  return true
 end
 
 
@@ -643,6 +601,17 @@ command.add(TreeView, {
   ["treeview:deselect"] = function()
     view.selected_item = nil
   end,
+  
+  ["treeview:select"] = function()
+    view:set_selection(view.hovered_item)
+  end,
+  
+  ["treeview:select-and-open"] = function()
+    if view.hovered_item then 
+      view:set_selection(view.hovered_item)
+      command.perform "treeview:open"
+    end
+  end,
 
   ["treeview:collapse"] = function()
     if view.selected_item then
@@ -775,7 +744,7 @@ command.add(function() return treeitem() ~= nil end, {
     elseif PLATFORM == "Linux" or string.find(PLATFORM, "BSD") then
       system.exec(string.format("xdg-open %q", hovered_item.abs_filename))
     end
-  end,
+  end
 })
 
 keymap.add {
@@ -787,7 +756,10 @@ keymap.add {
   ["return"]      = "treeview:open",
   ["escape"]      = "treeview:deselect",
   ["delete"]      = "treeview:delete",
-  ["ctrl+return"] = "treeview:new-folder"
+  ["ctrl+return"] = "treeview:new-folder",
+  ["lclick"]      = "treeview:select-and-open",
+  ["mclick"]      = "treeview:select",
+  ["ctrl+lclick"] = "treeview:new-folder"
 }
 
 -- Return the treeview with toolbar and contextmenu to allow

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -111,7 +111,7 @@ end
 
 
 function TreeView:get_name()
-  return "Project"
+  return nil
 end
 
 
@@ -264,7 +264,7 @@ function TreeView:on_mouse_pressed(button, x, y, clicks)
       create_directory_in(self.selected_item)
     elseif self.selected_item.type == "dir"
       or (self.selected_item.type == "file"
-        and clicks == config.plugins.treeview.clicks_to_open
+        and clicks >= config.plugins.treeview.clicks_to_open
       )
     then
       command.perform "treeview:open"

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -12,7 +12,7 @@ local CommandView = require "core.commandview"
 
 config.plugins.treeview = common.merge({
   -- Amount of clicks to open a file
-  clicks_to_open = 2,
+  clicks_to_open = 1,
   -- Default treeview width
   size = 200 * SCALE
 }, config.plugins.treeview)


### PR DESCRIPTION
A couple changes:

1. Fixed a bug where if you clicked *over* the amount of times your config said, treeview wouldn't register the click.
2. Made it so that treeview didn't change the title if you had it selected; as this seems out of line with other editors.
3. Made it 1-click by default, as per the unanimous voting on the RFC on discord: 
![image](https://user-images.githubusercontent.com/1034518/160005714-c241986b-2756-4a64-a3b8-1aee43e868a7.png)

I don't want to merge this just yet; and would like comments on 2+3. I think we should definitely still have a way to select the treeview, with the mouse, even if you're on 1 click instead of 2. Perhaps `shift`+`click`? Another option is a right click menu option.

I'd also be interested in maybe clicking on the row, but not the name would select; but people on discord didn't seem to hot on that idea; so I'm happy to go with modified+click, but thought I'd post here for completeness' sake.