### PR TITLE
language_md: parenthesis support to numbered bullets

### DIFF
--- a/data/plugins/language_md.lua
+++ b/data/plugins/language_md.lua
@@ -134,7 +134,7 @@ syntax.add {
     { pattern = "^%s*%-%s",                 type = "number" },
     { pattern = "^%s*%+%s",                 type = "number" },
     -- numbered bullet
-    { pattern = "^%s*[0-9]+%.%s",           type = "number" },
+    { pattern = "^%s*[0-9]+[%.%)]%s",       type = "number" },
     -- blockquote
     { pattern = "^%s*>+%s",                 type = "string" },
     -- bold and italic


### PR DESCRIPTION
As title says, this is a minor change and adds support for coloring numbered bullets with parenthesis as:

```
1)
```

this is supported by github markdown