### PR TITLE
Fix keeping scroll position when restoring a `DocView`

### DIFF
--- a/data/plugins/workspace.lua
+++ b/data/plugins/workspace.lua
@@ -117,7 +117,7 @@ local function load_view(t)
     -- cannot be read.
     if dv and dv.doc then
       dv.doc:set_selection(table.unpack(t.selection))
-      dv.last_line, dv.last_col = dv.doc:get_selection()
+      dv.last_line1, dv.last_col1, dv.last_line2, dv.last_col2 = dv.doc:get_selection()
       dv.scroll.x, dv.scroll.to.x = t.scroll.x, t.scroll.x
       dv.scroll.y, dv.scroll.to.y = t.scroll.y, t.scroll.y
     end


### PR DESCRIPTION
Since 5526041da32a37a11c9f1400b5eaf6fb82a78254 we check a pair of line&column to decide if we should scroll to the cursor.
Previously we only considered a single line&column.

Fixes #909.