### PR TITLE
Added Background Threads

### DIFF
--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -13,7 +13,7 @@ function Highlighter:new(doc)
   self:reset()
 
   -- init incremental syntax highlighting
-  core.add_thread(function()
+  core.add_foreground_thread(function()
     while true do
       if self.first_invalid_line > self.max_wanted_line then
         self.max_wanted_line = 0

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1284,11 +1284,11 @@ function core.run()
     core.frame_start = system.get_time()
     local did_redraw = false
     local min_foreground_wait = math.huge
-    if should_step then
+    local min_background_wait = run_background_threads()
+    if should_step or core.redraw then
       did_redraw = core.step()
       min_foreground_wait = run_foreground_threads()
     end
-    local min_background_wait = run_background_threads()
     if core.restart_request or core.quit_request then break end
     if not did_redraw and min_foreground_wait > 0 then
       idle_iterations = idle_iterations + 1

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -280,7 +280,7 @@ function core.add_project_directory(path)
         end
         return refresh_directory(topdir, dirpath)
       end, 0.01, 0.01)
-      coroutine.yield(system.window_has_focus() and 0.1 or 0.5)
+      coroutine.yield(0.1)
     end
   end)
 
@@ -1280,7 +1280,9 @@ function core.run()
   while true do
     core.frame_start = system.get_time()
     local did_redraw = core.step()
-    local min_foreground_wait = run_foreground_threads()
+    local has_focus = system.window_has_focus()
+    local min_foreground_wait = math.huge
+    if has_focus then min_foreground_wait = run_foreground_threads() end
     local min_background_wait = run_background_threads()
     if core.restart_request or core.quit_request then break end
     if not did_redraw and min_foreground_wait > 0 then
@@ -1288,7 +1290,7 @@ function core.run()
       -- do not wait of events at idle_iterations = 1 to give a chance at core.step to run
       -- and set "redraw" flag.
       if idle_iterations > 1 then
-        if system.window_has_focus() or min_background_wait < math.huge then
+        if has_focus or min_background_wait < math.huge then
           -- keep running even with no events to make the cursor blinks
           local t = system.get_time() - core.blink_start
           local h = config.blink_period / 2

--- a/data/plugins/autocomplete.lua
+++ b/data/plugins/autocomplete.lua
@@ -73,7 +73,7 @@ end
 --
 local max_symbols = config.plugins.autocomplete.max_symbols
 
-core.add_thread(function()
+core.add_foreground_thread(function()
   local cache = setmetatable({}, { __mode = "k" })
 
   local function get_symbols(doc)

--- a/data/plugins/language_md.lua
+++ b/data/plugins/language_md.lua
@@ -220,7 +220,7 @@ syntax.add {
 }
 
 -- Adjust the color on theme changes
-core.add_thread(function()
+core.add_foreground_thread(function()
   while true do
     if initial_color ~= style.syntax["keyword2"] then
       for _, attr in pairs({"bold", "italic", "bold_italic"}) do

--- a/data/plugins/projectsearch.lua
+++ b/data/plugins/projectsearch.lua
@@ -53,7 +53,7 @@ function ResultsView:begin_search(text, fn)
   self.searching = true
   self.selected_idx = 0
 
-  core.add_thread(function()
+  core.add_foreground_thread(function()
     local i = 1
     for dir_name, file in core.get_project_files() do
       if file.type == "file" then


### PR DESCRIPTION
As a response to discussion in #899 ; made a distinction between foreground and background threads; background threads are threads which'll always run in the background, regardless of whether or not a window is in focus. Foreground threads only run when a window is in focus (and some other times). 

I did some profiling, and the watch change (at least on linux), adds no measurable CPU overhead when not in focus, but also fixes the issue with the UI being "snappy" when not in focus.