### PR TITLE
Add syntax symbols for auto-complete

### DIFF
--- a/data/plugins/autocomplete.lua
+++ b/data/plugins/autocomplete.lua
@@ -76,10 +76,19 @@ local max_symbols = config.plugins.autocomplete.max_symbols
 core.add_thread(function()
   local cache = setmetatable({}, { __mode = "k" })
 
+  local function get_syntax_symbols(symbols, doc)
+    if doc.syntax then
+      for sym in pairs(doc.syntax.symbols) do
+        symbols[sym] = true
+      end
+    end
+  end
+
   local function get_symbols(doc)
-    if doc.disable_symbols then return {} end
-    local i = 1
     local s = {}
+    get_syntax_symbols(s, doc)
+    if doc.disable_symbols then return s end
+    local i = 1
     local symbols_count = 0
     while i < #doc.lines do
       for sym in doc.lines[i]:gmatch(config.symbol_pattern) do


### PR DESCRIPTION
Make the auto-complete plugin suggest the symbols from the syntax file, in addition to the symbols found from the open documents.