### PR TITLE
Enhance scrollbar

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -227,7 +227,7 @@ end
 function DocView:on_mouse_moved(x, y, ...)
   DocView.super.on_mouse_moved(self, x, y, ...)
 
-  if self:scrollbar_overlaps_point(x, y) or self.dragging_scrollbar then
+  if self.hovered_scrollbar or self.dragging_scrollbar then
     self.cursor = "arrow"
   else
     self.cursor = "ibeam"

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -270,8 +270,8 @@ function DocView:mouse_selection(doc, snap_type, line1, col1, line2, col2)
 end
 
 
-function DocView:on_mouse_released(button)
-  DocView.super.on_mouse_released(self, button)
+function DocView:on_mouse_released(...)
+  DocView.super.on_mouse_released(self, ...)
   self.mouse_selecting = nil
 end
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -227,7 +227,7 @@ end
 function DocView:on_mouse_moved(x, y, ...)
   DocView.super.on_mouse_moved(self, x, y, ...)
 
-  if self.hovered_scrollbar or self.dragging_scrollbar then
+  if self.hovered_scrollbar_track or self.dragging_scrollbar then
     self.cursor = "arrow"
   else
     self.cursor = "ibeam"

--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -4,6 +4,7 @@ local style = {}
 style.padding = { x = common.round(14 * SCALE), y = common.round(7 * SCALE) }
 style.divider_size = common.round(1 * SCALE)
 style.scrollbar_size = common.round(4 * SCALE)
+style.expanded_scrollbar_size = common.round(12 * SCALE)
 style.caret_width = common.round(2 * SCALE)
 style.tab_width = common.round(170 * SCALE)
 
@@ -43,6 +44,7 @@ style.line_number2 = { common.color "#83838f" } -- With cursor
 style.line_highlight = { common.color "#343438" }
 style.scrollbar = { common.color "#414146" }
 style.scrollbar2 = { common.color "#4b4b52" } -- Hovered
+style.scrollbar_track = { common.color "#252529" }
 style.nagbar = { common.color "#FF0000" }
 style.nagbar_text = { common.color "#FFFFFF" }
 style.nagbar_dim = { common.color "rgba(0, 0, 0, 0.45)" }

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -101,12 +101,12 @@ end
 
 function View:scrollbar_overlaps_point(x, y)
   local sx, sy, sw, sh = self:get_scrollbar_rect()
-  return x >= sx - style.scrollbar_size * 3 and x < sx + sw and y >= sy and y < sy + sh
+  return x >= sx - style.scrollbar_size * 3 and x < sx + sw and y > sy and y <= sy + sh
 end
 
 function View:scrollbar_track_overlaps_point(x, y)
   local sx, sy, sw, sh = self:get_scrollbar_track_rect()
-  return x >= sx - style.scrollbar_size * 3 and x < sx + sw and y >= sy and y < sy + sh
+  return x >= sx - style.scrollbar_size * 3 and x < sx + sw and y > sy and y <= sy + sh
 end
 
 


### PR DESCRIPTION
This makes the scrollbar more interactive, by increasing its visibility and allowing clicking on the "track" to move to the corresponding part of the document.

https://user-images.githubusercontent.com/2798487/162860134-db3bf37f-300f-4d7b-8c5b-75bc7a9d0d1b.mp4

This breaks the `minimap` plugin, but can be fixed with something like:
```diff
@@ -190,6 +190,14 @@ DocView.get_scrollbar_rect = function(self)
 	       self.position.y, config.plugins.minimap.width * SCALE, self.size.y
 end
 
+local prev_get_scrollbar_track_rect = DocView.get_scrollbar_track_rect
+DocView.get_scrollbar_track_rect = function(self)
+	if not show_minimap() then return prev_get_scrollbar_track_rect(self) end
+
+	return self.position.x + self.size.x - config.plugins.minimap.width * SCALE,
+	       self.position.y, config.plugins.minimap.width * SCALE, self.size.y
+end
+
 -- Overloaded so we can render the minimap in the "scrollbar area".
 local prev_draw_scrollbar = DocView.draw_scrollbar
 DocView.draw_scrollbar = function(self)
```
Other plugins might need testing.