### PR TITLE
Use the syntax with the longest match

### DIFF
--- a/data/core/syntax.lua
+++ b/data/core/syntax.lua
@@ -30,12 +30,17 @@ end
 
 
 local function find(string, field)
+  local best_match = 0
+  local best_syntax
   for i = #syntax.items, 1, -1 do
     local t = syntax.items[i]
-    if common.match_pattern(string, t[field] or {}) then
-      return t
+    local s, e = common.match_pattern(string, t[field] or {})
+    if s and e - s > best_match then
+      best_match = e - s
+      best_syntax = t
     end
   end
+  return best_syntax
 end
 
 function syntax.get(filename, header)


### PR DESCRIPTION
This way, for example, a syntax that applies to `docker-compose.yml` files will take precedence over one that applies to `*.yml` files.

Caveat: if a syntax specifies multiple file matching patterns, only the first one that actually matches will be considered (because `common.match_pattern` - correctly - returns on the first match found).
This won't be a problem as long as the patterns are declared from the longest to the shortest.

This needs testing using `headers` matching.