### PR TITLE
Send `mouseleft` event when the mouse leaves the window

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1140,6 +1140,8 @@ function core.on_event(type, ...)
     end
   elseif type == "mousereleased" then
     core.root_view:on_mouse_released(...)
+  elseif type == "mouseleft" then
+    core.root_view:on_mouse_left()
   elseif type == "mousewheel" then
     if not core.root_view:on_mouse_wheel(...) then
       did_keymap = keymap.on_mouse_wheel(...)

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -51,6 +51,15 @@ function Node:on_mouse_released(...)
 end
 
 
+function Node:on_mouse_left()
+  if self.type == "leaf" then
+    self.active_view:on_mouse_left()
+  else
+    self:propagate("on_mouse_left")
+  end
+end
+
+
 function Node:consume(node)
   for k, _ in pairs(self) do self[k] = nil end
   for k, v in pairs(node) do self[k] = v   end

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -169,8 +169,12 @@ end
 
 function Node:set_active_view(view)
   assert(self.type == "leaf", "Tried to set active view on non-leaf node")
+  local last_active_view = self.active_view
   self.active_view = view
   core.set_active_view(view)
+  if last_active_view and last_active_view ~= view then
+    last_active_view:on_mouse_left()
+  end
 end
 
 

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -256,7 +256,12 @@ function RootView:on_mouse_moved(x, y, dx, dy)
 
   self.root_node:on_mouse_moved(x, y, dx, dy)
 
+  local last_overlapping_node = self.overlapping_node
   self.overlapping_node = self.root_node:get_child_overlapping_point(x, y)
+
+  if last_overlapping_node and last_overlapping_node ~= self.overlapping_node then
+    last_overlapping_node:on_mouse_left()
+  end
 
   local div = self.root_node:get_divider_overlapping_point(x, y)
   local tab_index = self.overlapping_node and self.overlapping_node:get_tab_overlapping_point(x, y)
@@ -273,7 +278,9 @@ end
 
 
 function RootView:on_mouse_left()
-  self.root_node:on_mouse_left()
+  if self.overlapping_node then
+    self.overlapping_node:on_mouse_left()
+  end
 end
 
 

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -272,6 +272,11 @@ function RootView:on_mouse_moved(x, y, dx, dy)
 end
 
 
+function RootView:on_mouse_left()
+  self.root_node:on_mouse_left()
+end
+
+
 function RootView:on_file_dropped(filename, x, y)
   local node = self.root_node:get_child_overlapping_point(x, y)
   return node and node.active_view:on_file_dropped(filename, x, y)

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -140,6 +140,12 @@ function View:on_mouse_moved(x, y, dx, dy)
 end
 
 
+function View:on_mouse_left()
+  self.hovered_scrollbar = false
+  self.hovered_scrollbar_track = false
+end
+
+
 function View:on_file_dropped(filename, x, y)
   return false
 end

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -161,6 +161,9 @@ top:
       } else if (e.window.event == SDL_WINDOWEVENT_RESTORED) {
         lua_pushstring(L, "restored");
         return 1;
+      } else if (e.window.event == SDL_WINDOWEVENT_LEAVE) {
+        lua_pushstring(L, "mouseleft");
+        return 1;
       }
       if (e.window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
         lua_pushstring(L, "focuslost");


### PR DESCRIPTION
This allows us to reduce the size of the scrollbar when the mouse leaves the window.

Before:

https://user-images.githubusercontent.com/2798487/163510495-6b6d17e3-ef4c-4761-a6bd-cd05c5872379.mp4


After:

https://user-images.githubusercontent.com/2798487/163510517-15944a39-dac6-4fb1-8841-ac7d3d53180f.mp4

For now the `mouseleft` event is sent to every `active_view`.
We could decide to send it only to the last `View` that received mouse events, but I think it should be fine as it is now.

There is the possibility that `View:on_mouse_left` could lead developers to erroneously think that it is about the mouse leaving the `View` area, so maybe it should be renamed to something like `on_mouse_left_window`.
We could also implement an actual `View:on_mouse_left` relative to the `View` itself if there is a need for that.