### PR TITLE
Asynchronous Reads for Dirmonitor

### DIFF
--- a/data/core/dirwatch.lua
+++ b/data/core/dirwatch.lua
@@ -85,7 +85,9 @@ end
 
 -- designed to be run inside a coroutine.
 function dirwatch:check(change_callback, scan_time, wait_time)
+  local had_change = false
   self.monitor:check(function(id)
+    had_change = true
     if PLATFORM == "Windows" then
       change_callback(common.dirname(self.windows_watch_top .. PATHSEP .. id))
     elseif self.reverse_watched[id] then
@@ -98,6 +100,7 @@ function dirwatch:check(change_callback, scan_time, wait_time)
       local new_modified = system.get_file_info(directory).modified
       if old_modified < new_modified then
         change_callback(directory)
+        had_change = true
         self.scanned[directory] = new_modified
       end
     end
@@ -106,6 +109,7 @@ function dirwatch:check(change_callback, scan_time, wait_time)
       start_time = system.get_time()
     end
   end
+  return had_change
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -269,7 +269,7 @@ function core.add_project_directory(path)
   -- time; the watch will yield in this coroutine after 0.01 second, for 0.1 seconds.
   topdir.watch_thread = core.add_thread(function()
     while true do
-      topdir.watch:check(function(target)
+      local changed = topdir.watch:check(function(target)
         if target == topdir.name then return refresh_directory(topdir) end
         local dirpath = target:sub(#topdir.name + 2)
         local abs_dirpath = topdir.name .. PATHSEP .. dirpath
@@ -280,7 +280,7 @@ function core.add_project_directory(path)
         end
         return refresh_directory(topdir, dirpath)
       end, 0.01, 0.01)
-      coroutine.yield(0.05)
+      coroutine.yield(changed and 0.05 or 0)
     end
   end)
 
@@ -1116,14 +1116,6 @@ function core.try(fn, ...)
   return false, err
 end
 
-local scheduled_rescan = {}
-
-function core.has_pending_rescan()
-  for _ in pairs(scheduled_rescan) do
-    return true
-  end
-end
-
 function core.on_event(type, ...)
   local did_keymap = false
   if type == "textinput" then
@@ -1270,8 +1262,8 @@ function core.run()
   local idle_iterations = 0
   while true do
     core.frame_start = system.get_time()
+    local need_more_work = run_threads()
     local did_redraw = core.step()
-    local need_more_work = run_threads() or core.has_pending_rescan()
     if core.restart_request or core.quit_request then break end
     if not did_redraw and not need_more_work then
       idle_iterations = idle_iterations + 1

--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,6 @@ endif
 if not get_option('source-only')
     libm = cc.find_library('m', required : false)
     libdl = cc.find_library('dl', required : false)
-    librt = cc.find_library('rt', required : false)
     lua_fallback = ['lua', 'lua_dep']
     lua_quick_fallback = []
     if get_option('wrap_mode') == 'forcefallback'
@@ -96,7 +95,7 @@ if not get_option('source-only')
         default_options: ['default_library=static']
     )
 
-    lite_deps = [lua_dep, sdl_dep, freetype_dep, pcre2_dep, libm, libdl, librt]
+    lite_deps = [lua_dep, sdl_dep, freetype_dep, pcre2_dep, libm, libdl]
 endif
 #===============================================================================
 # Install Configuration

--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,7 @@ endif
 if not get_option('source-only')
     libm = cc.find_library('m', required : false)
     libdl = cc.find_library('dl', required : false)
+    librt = cc.find_library('rt', required : false)
     lua_fallback = ['lua', 'lua_dep']
     lua_quick_fallback = []
     if get_option('wrap_mode') == 'forcefallback'
@@ -95,7 +96,7 @@ if not get_option('source-only')
         default_options: ['default_library=static']
     )
 
-    lite_deps = [lua_dep, sdl_dep, freetype_dep, pcre2_dep, libm, libdl]
+    lite_deps = [lua_dep, sdl_dep, freetype_dep, pcre2_dep, libm, libdl, librt]
 endif
 #===============================================================================
 # Install Configuration

--- a/src/api/dirmonitor/dummy.c
+++ b/src/api/dirmonitor/dummy.c
@@ -1,22 +1,8 @@
 #include <stdlib.h>
 
-struct dirmonitor {
-};
-
-struct dirmonitor* init_dirmonitor_dummy() {
-  return NULL;
-}
-
-void deinit_dirmonitor_dummy(struct dirmonitor* monitor) {
-}
-
-int check_dirmonitor_dummy(struct dirmonitor* monitor, int (*change_callback)(int, const char*, void*), void* data) {
-  return -1;
-}
-
-int add_dirmonitor_dummy(struct dirmonitor* monitor, const char* path) {
-  return -1;
-}
-
-void remove_dirmonitor_dummy(struct dirmonitor* monitor, int fd) {
-}
+struct dirmonitor_internal* init_dirmonitor() { return NULL; }
+void deinit_dirmonitor(struct dirmonitor_internal*) { }
+int get_changes_dirmonitor(struct dirmonitor_internal*, char*, size_t) { return -1; }
+int translate_changes_dirmonitor(struct dirmonitor_internal*, char*, int, int (*)(int, const char*, void*), void*) { return -1; }
+int add_dirmonitor(struct dirmonitor_internal*, const char*) { return -1; }
+void remove_dirmonitor(struct dirmonitor_internal*, int) { }

--- a/src/api/dirmonitor/inotify.c
+++ b/src/api/dirmonitor/inotify.c
@@ -1,58 +1,83 @@
+#include <SDL.h>
 #include <sys/inotify.h>
 #include <limits.h>
 #include <unistd.h>
-#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <fcntl.h>
+#include <aio.h>
+#include <signal.h>
+
+enum EState {
+  MONITOR_STATE_READY,
+  MONITOR_STATE_WAITING,
+  MONITOR_STATE_COMPLETE
+};
 
 struct dirmonitor {
-  int fd;
+  struct aiocb cb;
+  char buffer[(PATH_MAX + sizeof(struct inotify_event)) * 16];
+  int buffer_length;
+  enum EState state;
 };
+
+static unsigned int DIR_EVENT_TYPE = 0;
+static void dirmonitor_notify(int sig, siginfo_t * info, void * udata) {
+  struct dirmonitor* monitor = info->si_ptr;
+  monitor->state = MONITOR_STATE_COMPLETE;
+  ssize_t len = aio_return(&monitor->cb);
+  if (len >= 0) {
+    monitor->buffer_length += len;
+    SDL_Event event = { .type = DIR_EVENT_TYPE };
+    SDL_PushEvent(&event);
+  } else
+    monitor->buffer_length = 0;
+}
+
 
 struct dirmonitor* init_dirmonitor_inotify() {
   struct dirmonitor* monitor = calloc(sizeof(struct dirmonitor), 1);
-
-  monitor->fd = inotify_init();
-  fcntl(monitor->fd, F_SETFL, O_NONBLOCK);
-
-
+  if (DIR_EVENT_TYPE == 0)
+    DIR_EVENT_TYPE = SDL_RegisterEvents(1);
+  monitor->cb.aio_fildes = inotify_init();
+  monitor->cb.aio_sigevent.sigev_notify = SIGEV_SIGNAL;
+  monitor->cb.aio_sigevent.sigev_signo = SIGUSR1;
+  monitor->cb.aio_sigevent.sigev_value.sival_ptr = monitor;
+  struct sigaction sigac = {0};
+  sigac.sa_flags = SA_SIGINFO;
+  sigac.sa_sigaction = dirmonitor_notify;
+  sigaction(SIGUSR1, &sigac, NULL);
   return monitor;
 }
 
 void deinit_dirmonitor_inotify(struct dirmonitor* monitor) {
-  close(monitor->fd);
+  close(monitor->cb.aio_fildes);
   free(monitor);
 }
 
 int check_dirmonitor_inotify(struct dirmonitor* monitor, int (*change_callback)(int, const char*, void*), void* data) {
-  char buf[PATH_MAX + sizeof(struct inotify_event)];
-  ssize_t offset = 0;
-
-  while (1) {
-    ssize_t len = read(monitor->fd, &buf[offset], sizeof(buf) - offset);
-
-    if (len == -1 && errno != EAGAIN) {
-      return errno;
+  if (monitor->state == MONITOR_STATE_WAITING) 
+    return 0;
+  if (monitor->state == MONITOR_STATE_COMPLETE) {
+    while (monitor->buffer_length > sizeof(struct inotify_event) && monitor->buffer_length >= ((struct inotify_event*)monitor->buffer)->len + sizeof(struct inotify_event)) {
+      change_callback(((const struct inotify_event *)monitor->buffer)->wd, NULL, data);
+      monitor->buffer_length -= sizeof(struct inotify_event) + ((struct inotify_event*)monitor->buffer)->len;
+      memmove(monitor->buffer, &monitor->buffer[sizeof(struct inotify_event) + ((struct inotify_event*)monitor->buffer)->len], monitor->buffer_length);
     }
-
-    if (len <= 0) {
-      return 0;
-    }
-
-    while (len > sizeof(struct inotify_event) && len >= ((struct inotify_event*)buf)->len + sizeof(struct inotify_event)) {
-      change_callback(((const struct inotify_event *)buf)->wd, NULL, data);
-      len -= sizeof(struct inotify_event) + ((struct inotify_event*)buf)->len;
-      memmove(buf, &buf[sizeof(struct inotify_event) + ((struct inotify_event*)buf)->len], len);
-      offset = len;
-    }
+    monitor->state = MONITOR_STATE_READY;
   }
+  monitor->cb.aio_buf = &monitor->buffer[monitor->buffer_length];
+  monitor->cb.aio_nbytes = sizeof(monitor->buffer) - monitor->buffer_length;
+  if (aio_read(&monitor->cb) == 0) {
+    monitor->state = MONITOR_STATE_WAITING;
+    return 0;
+  }
+  return errno;
 }
 
 int add_dirmonitor_inotify(struct dirmonitor* monitor, const char* path) {
-  return inotify_add_watch(monitor->fd, path, IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
+  return inotify_add_watch(monitor->cb.aio_fildes, path, IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
 }
 
 void remove_dirmonitor_inotify(struct dirmonitor* monitor, int fd) {
-  inotify_rm_watch(monitor->fd, fd);
+  inotify_rm_watch(monitor->cb.aio_fildes, fd);
 }

--- a/src/api/dirmonitor/inotify.c
+++ b/src/api/dirmonitor/inotify.c
@@ -1,83 +1,43 @@
-#include <SDL.h>
 #include <sys/inotify.h>
-#include <limits.h>
-#include <unistd.h>
-#include <string.h>
+#include <stdlib.h>
 #include <errno.h>
-#include <aio.h>
-#include <signal.h>
+#include <unistd.h>
 
-enum EState {
-  MONITOR_STATE_READY,
-  MONITOR_STATE_WAITING,
-  MONITOR_STATE_COMPLETE
+
+struct dirmonitor_internal {
+  int fd;
 };
 
-struct dirmonitor {
-  struct aiocb cb;
-  char buffer[(PATH_MAX + sizeof(struct inotify_event)) * 16];
-  int buffer_length;
-  enum EState state;
-};
 
-static unsigned int DIR_EVENT_TYPE = 0;
-static void dirmonitor_notify(int sig, siginfo_t * info, void * udata) {
-  struct dirmonitor* monitor = info->si_ptr;
-  monitor->state = MONITOR_STATE_COMPLETE;
-  ssize_t len = aio_return(&monitor->cb);
-  if (len >= 0) {
-    monitor->buffer_length += len;
-    SDL_Event event = { .type = DIR_EVENT_TYPE };
-    SDL_PushEvent(&event);
-  } else
-    monitor->buffer_length = 0;
-}
-
-
-struct dirmonitor* init_dirmonitor_inotify() {
-  struct dirmonitor* monitor = calloc(sizeof(struct dirmonitor), 1);
-  if (DIR_EVENT_TYPE == 0)
-    DIR_EVENT_TYPE = SDL_RegisterEvents(1);
-  monitor->cb.aio_fildes = inotify_init();
-  monitor->cb.aio_sigevent.sigev_notify = SIGEV_SIGNAL;
-  monitor->cb.aio_sigevent.sigev_signo = SIGUSR1;
-  monitor->cb.aio_sigevent.sigev_value.sival_ptr = monitor;
-  struct sigaction sigac = {0};
-  sigac.sa_flags = SA_SIGINFO;
-  sigac.sa_sigaction = dirmonitor_notify;
-  sigaction(SIGUSR1, &sigac, NULL);
+struct dirmonitor_internal* init_dirmonitor() {
+  struct dirmonitor_internal* monitor = calloc(sizeof(struct dirmonitor_internal), 1);
+  monitor->fd = inotify_init();
   return monitor;
 }
 
-void deinit_dirmonitor_inotify(struct dirmonitor* monitor) {
-  close(monitor->cb.aio_fildes);
-  free(monitor);
+
+void deinit_dirmonitor(struct dirmonitor_internal* monitor) {
+  close(monitor->fd);
 }
 
-int check_dirmonitor_inotify(struct dirmonitor* monitor, int (*change_callback)(int, const char*, void*), void* data) {
-  if (monitor->state == MONITOR_STATE_WAITING) 
-    return 0;
-  if (monitor->state == MONITOR_STATE_COMPLETE) {
-    while (monitor->buffer_length > sizeof(struct inotify_event) && monitor->buffer_length >= ((struct inotify_event*)monitor->buffer)->len + sizeof(struct inotify_event)) {
-      change_callback(((const struct inotify_event *)monitor->buffer)->wd, NULL, data);
-      monitor->buffer_length -= sizeof(struct inotify_event) + ((struct inotify_event*)monitor->buffer)->len;
-      memmove(monitor->buffer, &monitor->buffer[sizeof(struct inotify_event) + ((struct inotify_event*)monitor->buffer)->len], monitor->buffer_length);
-    }
-    monitor->state = MONITOR_STATE_READY;
-  }
-  monitor->cb.aio_buf = &monitor->buffer[monitor->buffer_length];
-  monitor->cb.aio_nbytes = sizeof(monitor->buffer) - monitor->buffer_length;
-  if (aio_read(&monitor->cb) == 0) {
-    monitor->state = MONITOR_STATE_WAITING;
-    return 0;
-  }
-  return errno;
+
+int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int length) {
+  return read(monitor->fd, buffer, length);
 }
 
-int add_dirmonitor_inotify(struct dirmonitor* monitor, const char* path) {
-  return inotify_add_watch(monitor->cb.aio_fildes, path, IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
+
+int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int length, int (*change_callback)(int, const char*, void*), void* data) {
+  for (struct inotify_event* info = (struct inotify_event*)buffer; (char*)info < buffer + length; info = (struct inotify_event*)((char*)info + sizeof(struct inotify_event)))
+    change_callback(info->wd, NULL, data);
+  return 0;
 }
 
-void remove_dirmonitor_inotify(struct dirmonitor* monitor, int fd) {
-  inotify_rm_watch(monitor->cb.aio_fildes, fd);
+
+int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
+  return inotify_add_watch(monitor->fd, path, IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
+}
+
+
+void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
+  inotify_rm_watch(monitor->fd, fd);
 }

--- a/src/api/dirmonitor/inotify.c
+++ b/src/api/dirmonitor/inotify.c
@@ -1,7 +1,6 @@
 #include <sys/inotify.h>
 #include <sys/select.h>
 #include <stdlib.h>
-#include <errno.h>
 #include <unistd.h>
 
 

--- a/src/api/dirmonitor/kqueue.c
+++ b/src/api/dirmonitor/kqueue.c
@@ -25,7 +25,7 @@ void deinit_dirmonitor(struct dirmonitor* monitor) {
 int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size) {
   int nev = kevent(monitor->fd, NULL, 0, (kevent*)buffer, buffer_size / sizeof(kevent), NULL);
   if (nev == -1)
-    return errno;
+    return -1;
   if (nev <= 0)
     return 0;
   return nev * sizeof(kevent);

--- a/src/api/dirmonitor/kqueue.c
+++ b/src/api/dirmonitor/kqueue.c
@@ -5,40 +5,41 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-struct dirmonitor {
+struct dirmonitor_internal {
   int fd;
 };
 
-struct dirmonitor* init_dirmonitor_kqueue() {
+
+struct dirmonitor* init_dirmonitor() {
   struct dirmonitor* monitor = calloc(sizeof(struct dirmonitor), 1);
   monitor->fd = kqueue();
   return monitor;
 }
 
-void deinit_dirmonitor_kqueue(struct dirmonitor* monitor) {
+
+void deinit_dirmonitor(struct dirmonitor* monitor) {
   close(monitor->fd);
-  free(monitor);
 }
 
-int check_dirmonitor_kqueue(struct dirmonitor* monitor, int (*change_callback)(int, const char*, void*), void* data) {
-  struct kevent event;
-  while (1) {
-    struct timespec tm = {0};
-    int nev = kevent(monitor->fd, NULL, 0, &event, 1, &tm);
 
-    if (nev == -1) {
-      return errno;
-    }
-
-    if (nev <= 0) {
-      return 0;
-    }
-
-    change_callback(event.ident, NULL, data);
-  }
+int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size) {
+  int nev = kevent(monitor->fd, NULL, 0, (kevent*)buffer, buffer_size / sizeof(kevent), NULL);
+  if (nev == -1)
+    return errno;
+  if (nev <= 0)
+    return 0;
+  return nev * sizeof(kevent);
 }
 
-int add_dirmonitor_kqueue(struct dirmonitor* monitor, const char* path) {
+
+int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size, int (*change_callback)(int, const char*, void*), void* data) {
+  for (kevent* info = (kevent*)buffer; (char*)info < buffer + buffer_size; info = (kevent*)(((char*)info) + sizeof(kevent)))
+    change_callback(info->ident, NULL, data);
+  return 0;
+}
+
+
+int add_dirmonitor(struct dirmonitor* monitor, const char* path) {
   int fd = open(path, O_RDONLY);
   struct kevent change;
 
@@ -48,6 +49,7 @@ int add_dirmonitor_kqueue(struct dirmonitor* monitor, const char* path) {
   return fd;
 }
 
-void remove_dirmonitor_kqueue(struct dirmonitor* monitor, int fd) {
+
+void remove_dirmonitor(struct dirmonitor* monitor, int fd) {
   close(fd);
 }

--- a/src/api/dirmonitor/win32.c
+++ b/src/api/dirmonitor/win32.c
@@ -7,9 +7,10 @@ struct dirmonitor_internal {
 
 
 int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size) {
-  if (monitor->handle && monitor->handle != INVALID_HANDLE_VALUE) {
+  HANDLE handle = monitor->handle;
+  if (handle && handle != INVALID_HANDLE_VALUE) {
     DWORD bytes_transferred;
-    if (ReadDirectoryChangesW(monitor->handle, buffer, buffer_size, TRUE,  FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME, &bytes_transferred, NULL, NULL) == 0)
+    if (ReadDirectoryChangesW(handle, buffer, buffer_size, TRUE,  FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME, &bytes_transferred, NULL, NULL) == 0)
       return 0;
     return bytes_transferred;
   }

--- a/src/api/dirmonitor/win32.c
+++ b/src/api/dirmonitor/win32.c
@@ -7,10 +7,13 @@ struct dirmonitor_internal {
 
 
 int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size) {
-  DWORD bytes_transferred;
-  if (ReadDirectoryChangesW(monitor->handle, buffer, buffer_size, TRUE,  FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME, &bytes_transferred, NULL, NULL) == 0)
-    return -1;
-  return bytes_transferred;
+  if (monitor->handle && monitor->handle != INVALID_HANDLE_VALUE) {
+    DWORD bytes_transferred;
+    if (ReadDirectoryChangesW(monitor->handle, buffer, buffer_size, TRUE,  FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME, &bytes_transferred, NULL, NULL) == 0)
+      return 0;
+    return bytes_transferred;
+  }
+  return 0;
 }
 
 
@@ -20,7 +23,12 @@ struct dirmonitor* init_dirmonitor() {
 
 
 static void close_monitor_handle(struct dirmonitor_internal* monitor) {
-  CloseHandle(monitor->handle);
+  if (monitor->handle && monitor->handle != INVALID_HANDLE_VALUE) {
+    HANDLE handle = monitor->handle;
+    monitor->handle = NULL;
+    CancelIoEx(handle, NULL);
+    CloseHandle(handle);
+  }
 }
 
 
@@ -33,7 +41,7 @@ int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buff
   for (FILE_NOTIFY_INFORMATION* info = (FILE_NOTIFY_INFORMATION*)buffer; (char*)info < buffer + buffer_size; info = (FILE_NOTIFY_INFORMATION*)(((char*)info) + info->NextEntryOffset)) {
     char transform_buffer[PATH_MAX*4];
     int count = WideCharToMultiByte(CP_UTF8, 0, (WCHAR*)info->FileName, info->FileNameLength, transform_buffer, PATH_MAX*4 - 1, NULL, NULL);
-    change_callback(info->FileNameLength / sizeof(WCHAR), buffer, data);
+    change_callback(count, buffer, data);
     if (!info->NextEntryOffset)
       break;
   }
@@ -43,7 +51,7 @@ int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buff
 
 int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
   close_monitor_handle(monitor);
-  monitor->handle = CreateFileA(path, FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL);
+  monitor->handle = CreateFileA(path, FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
   return !monitor->handle || monitor->handle == INVALID_HANDLE_VALUE ? -1 : 1;
 }
 

--- a/src/api/dirmonitor/win32.c
+++ b/src/api/dirmonitor/win32.c
@@ -1,5 +1,3 @@
-#include <SDL.h>
-#include <stdbool.h>
 #include <windows.h>
 
 

--- a/src/api/dirmonitor/win32.c
+++ b/src/api/dirmonitor/win32.c
@@ -13,7 +13,7 @@ struct dirmonitor {
   char buffer[64512];
   OVERLAPPED overlapped;
   SDL_Thread* thread;
-  SDL_Mutex* mutex;
+  SDL_mutex* mutex;
   volatile enum EState state;
 };
 

--- a/src/api/dirmonitor/win32.c
+++ b/src/api/dirmonitor/win32.c
@@ -2,82 +2,96 @@
 #include <stdbool.h>
 #include <windows.h>
 
+enum EState {
+  MONITOR_STATE_WAITING,
+  MONITOR_STATE_DATA_AVAIALBLE,
+  MONITOR_STATE_EXITING
+};
+
 struct dirmonitor {
   HANDLE handle;
   char buffer[64512];
   OVERLAPPED overlapped;
-  bool running;
+  SDL_Thread* thread;
+  SDL_Mutex* mutex;
+  volatile enum EState state;
 };
 
+
 static unsigned int DIR_EVENT_TYPE = 0;
+static int dirmonitor_check_thread(void* data) {
+  struct dirmonitor* monitor = data;
+  while (monitor->state != MONITOR_STATE_EXITING) {
+    if (monitor->handle && monitor->state == MONITOR_STATE_WAITING && ReadDirectoryChangesW(monitor->handle, monitor->buffer, sizeof(monitor->buffer), TRUE,  FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME, NULL, &monitor->overlapped, NULL) != 0) {
+      DWORD bytes_transferred;
+      GetOverlappedResult(monitor->handle, &monitor->overlapped, &bytes_transferred, TRUE);
+      SDL_LockMutex(monitor->mutex);
+      if (monitor->state == MONITOR_STATE_WAITING)
+        monitor->state = MONITOR_STATE_DATA_AVAIALBLE;
+      SDL_UnlockMutex(monitor->mutex);
+    } else
+      SDL_Delay(1);
+    SDL_Event event = { .type = DIR_EVENT_TYPE };
+    SDL_PushEvent(&event);
+  }
+  return 0;
+}
+
 struct dirmonitor* init_dirmonitor_win32() {
   if (DIR_EVENT_TYPE == 0)
     DIR_EVENT_TYPE = SDL_RegisterEvents(1);
-  return calloc(sizeof(struct dirmonitor), 1);
+  struct dirmonitor* monitor = calloc(sizeof(struct dirmonitor), 1);
+  monitor->mutex = SDL_CreateMutex();
+  return monitor;
 }
 
-static void dirmonitor_notify(DWORD dwErrorCode, DWORD dwNumberOfBytesTransfered, LPOVERLAPPED lpOverlapped) {
-  SDL_Event event = { .type = DIR_EVENT_TYPE };
-  SDL_PushEvent(&event);
-}
 
 static void close_monitor_handle(struct dirmonitor* monitor) {
   if (monitor->handle) {
-    if (monitor->running) {
-      BOOL result = CancelIoEx(monitor->handle, &monitor->overlapped);
-      DWORD error = GetLastError();
-      if (result == TRUE || error != ERROR_NOT_FOUND) {
-        DWORD bytes_transferred;
-        GetOverlappedResult( monitor->handle, &monitor->overlapped, &bytes_transferred, TRUE );
-      }
-      monitor->running = false;
+    monitor->state = MONITOR_STATE_EXITING;
+    BOOL result = CancelIoEx(monitor->handle, &monitor->overlapped);
+    DWORD error = GetLastError();
+    if (result == TRUE || error != ERROR_NOT_FOUND) {
+      DWORD bytes_transferred;
+      GetOverlappedResult( monitor->handle, &monitor->overlapped, &bytes_transferred, TRUE );
     }
     CloseHandle(monitor->handle);
+    SDL_WaitThread(monitor->thread, NULL);
+    monitor->state = MONITOR_STATE_WAITING;
   }
   monitor->handle = NULL;
 }
 
+
 void deinit_dirmonitor_win32(struct dirmonitor* monitor) {
   close_monitor_handle(monitor);
+  SDL_DestroyMutex(monitor->mutex);
   free(monitor);
 }
 
+
 int check_dirmonitor_win32(struct dirmonitor* monitor, int (*change_callback)(int, const char*, void*), void* data) {
-  if (!monitor->running) {
-    if (ReadDirectoryChangesW(monitor->handle, monitor->buffer, sizeof(monitor->buffer), TRUE,  FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME, NULL, &monitor->overlapped, dirmonitor_notify) == 0) {
-      return GetLastError();
+  if (monitor->state == MONITOR_STATE_DATA_AVAIALBLE) {
+    for (FILE_NOTIFY_INFORMATION* info = (FILE_NOTIFY_INFORMATION*)monitor->buffer; (char*)info < monitor->buffer + sizeof(monitor->buffer); info = (FILE_NOTIFY_INFORMATION*)(((char*)info) + info->NextEntryOffset)) {
+      change_callback(info->FileNameLength / sizeof(WCHAR), (char*)info->FileName, data);
+      if (!info->NextEntryOffset)
+        break;
     }
-    monitor->running = true;
+    monitor->state = MONITOR_STATE_WAITING;
   }
-
-  DWORD bytes_transferred;
-
-  if (!GetOverlappedResult(monitor->handle, &monitor->overlapped, &bytes_transferred, FALSE)) {
-    int error = GetLastError();
-    return error == ERROR_IO_PENDING || error == ERROR_IO_INCOMPLETE ? 0 : error;
-  }
-
-  monitor->running = false;
-
-  for (FILE_NOTIFY_INFORMATION* info = (FILE_NOTIFY_INFORMATION*)monitor->buffer; (char*)info < monitor->buffer + sizeof(monitor->buffer); info = (FILE_NOTIFY_INFORMATION*)(((char*)info) + info->NextEntryOffset)) {
-    change_callback(info->FileNameLength / sizeof(WCHAR), (char*)info->FileName, data);
-    if (!info->NextEntryOffset)
-      break;
-  }
-
-  monitor->running = false;
   return 0;
 }
+
 
 int add_dirmonitor_win32(struct dirmonitor* monitor, const char* path) {
   close_monitor_handle(monitor);
   monitor->handle = CreateFileA(path, FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL);
-  if (monitor->handle && monitor->handle != INVALID_HANDLE_VALUE) {
-    return 1;
-  }
-  monitor->handle = NULL;
-  return -1;
+  if (!monitor->handle || monitor->handle == INVALID_HANDLE_VALUE) 
+    return -1;
+  monitor->thread = SDL_CreateThread(dirmonitor_check_thread, "dirmonitor_check_thread", monitor);
+  return 1;
 }
+
 
 void remove_dirmonitor_win32(struct dirmonitor* monitor, int fd) {
   close_monitor_handle(monitor);

--- a/src/api/dirmonitor/win32.c
+++ b/src/api/dirmonitor/win32.c
@@ -2,53 +2,28 @@
 #include <stdbool.h>
 #include <windows.h>
 
-enum EState {
-  MONITOR_STATE_WAITING,
-  MONITOR_STATE_DATA_AVAIALBLE,
-  MONITOR_STATE_EXITING
-};
 
-struct dirmonitor {
+struct dirmonitor_internal {
   HANDLE handle;
-  char buffer[64512];
   OVERLAPPED overlapped;
-  SDL_Thread* thread;
-  SDL_mutex* mutex;
-  volatile enum EState state;
 };
 
 
-static unsigned int DIR_EVENT_TYPE = 0;
-static int dirmonitor_check_thread(void* data) {
-  struct dirmonitor* monitor = data;
-  while (monitor->state != MONITOR_STATE_EXITING) {
-    if (monitor->handle && monitor->state == MONITOR_STATE_WAITING && ReadDirectoryChangesW(monitor->handle, monitor->buffer, sizeof(monitor->buffer), TRUE,  FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME, NULL, &monitor->overlapped, NULL) != 0) {
-      DWORD bytes_transferred;
-      GetOverlappedResult(monitor->handle, &monitor->overlapped, &bytes_transferred, TRUE);
-      SDL_LockMutex(monitor->mutex);
-      if (monitor->state == MONITOR_STATE_WAITING)
-        monitor->state = MONITOR_STATE_DATA_AVAIALBLE;
-      SDL_UnlockMutex(monitor->mutex);
-    } else
-      SDL_Delay(1);
-    SDL_Event event = { .type = DIR_EVENT_TYPE };
-    SDL_PushEvent(&event);
-  }
-  return 0;
-}
-
-struct dirmonitor* init_dirmonitor_win32() {
-  if (DIR_EVENT_TYPE == 0)
-    DIR_EVENT_TYPE = SDL_RegisterEvents(1);
-  struct dirmonitor* monitor = calloc(sizeof(struct dirmonitor), 1);
-  monitor->mutex = SDL_CreateMutex();
-  return monitor;
+int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size) {
+  ReadDirectoryChangesW(monitor->handle, buffer, buffer_size, TRUE,  FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME, NULL, &monitor->overlapped, NULL) != 0) {
+  DWORD bytes_transferred;
+  GetOverlappedResult(monitor->handle, &monitor->overlapped, &bytes_transferred, TRUE);
+  return bytes_transferred;
 }
 
 
-static void close_monitor_handle(struct dirmonitor* monitor) {
+struct dirmonitor* init_dirmonitor() {
+  return calloc(sizeof(struct dirmonitor_internal), 1);
+}
+
+
+static void close_monitor_handle(struct dirmonitor_internal* monitor) {
   if (monitor->handle) {
-    monitor->state = MONITOR_STATE_EXITING;
     BOOL result = CancelIoEx(monitor->handle, &monitor->overlapped);
     DWORD error = GetLastError();
     if (result == TRUE || error != ERROR_NOT_FOUND) {
@@ -56,43 +31,34 @@ static void close_monitor_handle(struct dirmonitor* monitor) {
       GetOverlappedResult( monitor->handle, &monitor->overlapped, &bytes_transferred, TRUE );
     }
     CloseHandle(monitor->handle);
-    SDL_WaitThread(monitor->thread, NULL);
-    monitor->state = MONITOR_STATE_WAITING;
   }
-  monitor->handle = NULL;
 }
 
 
-void deinit_dirmonitor_win32(struct dirmonitor* monitor) {
+void deinit_dirmonitor(struct dirmonitor_internal* monitor) {
   close_monitor_handle(monitor);
-  SDL_DestroyMutex(monitor->mutex);
-  free(monitor);
 }
 
 
-int check_dirmonitor_win32(struct dirmonitor* monitor, int (*change_callback)(int, const char*, void*), void* data) {
-  if (monitor->state == MONITOR_STATE_DATA_AVAIALBLE) {
-    for (FILE_NOTIFY_INFORMATION* info = (FILE_NOTIFY_INFORMATION*)monitor->buffer; (char*)info < monitor->buffer + sizeof(monitor->buffer); info = (FILE_NOTIFY_INFORMATION*)(((char*)info) + info->NextEntryOffset)) {
-      change_callback(info->FileNameLength / sizeof(WCHAR), (char*)info->FileName, data);
-      if (!info->NextEntryOffset)
-        break;
-    }
-    monitor->state = MONITOR_STATE_WAITING;
+int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size, int (*change_callback)(int, const char*, void*), void* data) {
+  for (FILE_NOTIFY_INFORMATION* info = (FILE_NOTIFY_INFORMATION*)buffer; (char*)info < buffer + buffer_size; info = (FILE_NOTIFY_INFORMATION*)(((char*)info) + info->NextEntryOffset)) {
+    char transform_buffer[PATH_MAX*4];
+    int count = WideCharToMultiByte(CP_UTF8, 0, (WCHAR*)info->FileName, info->FileNameLength, transform_buffer, PATH_MAX*4 - 1, NULL, NULL);
+    change_callback(info->FileNameLength / sizeof(WCHAR), buffer, data);
+    if (!info->NextEntryOffset)
+      break;
   }
   return 0;
 }
 
 
-int add_dirmonitor_win32(struct dirmonitor* monitor, const char* path) {
+int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
   close_monitor_handle(monitor);
   monitor->handle = CreateFileA(path, FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL);
-  if (!monitor->handle || monitor->handle == INVALID_HANDLE_VALUE) 
-    return -1;
-  monitor->thread = SDL_CreateThread(dirmonitor_check_thread, "dirmonitor_check_thread", monitor);
-  return 1;
+  return !monitor->handle || monitor->handle == INVALID_HANDLE_VALUE ? -1 : 1;
 }
 
 
-void remove_dirmonitor_win32(struct dirmonitor* monitor, int fd) {
+void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
   close_monitor_handle(monitor);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,8 +41,6 @@ lite_sources += [
     'api/dirmonitor.c',
     'api/dirmonitor/' + dirmonitor_backend + '.c',
 ]
-lite_cargs += '-DDIRMONITOR_BACKEND=' + dirmonitor_backend
-lite_cargs += '-DDIRMONITOR_' + dirmonitor_backend.to_upper()
 
 
 lite_rc = []


### PR DESCRIPTION
Persuant to the discussion in #899; I've had some time to commit my tentative PR here.

So, the idea is that we use the normal posix `aio_read` function to perform the read, rather than `read`. This allows us to wake up from a wait, and enables us to use 0% CPU on Linux, without threading, mutexes, or any other complications.

I've also contributed the windows version, which should be fairly straightforward (involving the `LPOVERLAPPED_COMPLETION_ROUTINE`). I'll be testing that in a moment, and likely fixing it up. This should also allow 0% CPU on Windows, also without threading.

With kqueue, which works in FreeBSD, and Mac, I'd like to use `EVFILT_AIO`, which would do what we want on FreeBSD, but I found some outdated documentation that indicates this may not work on Mac, and we may need to use your solution of spawning a thread, @franko . Nevertheless, I'd like to investigate this further. The issue is, that Jan was the one who was helping test the kqueue implementation, and after the discussion in #880, he's decided to step back from the project.

I will try and get a working Macbook to test this out soon. But it may take a moment for me to enhance the kqueue implementation.