### PR TITLE
Set the correct working directory for the AppImage version

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -34,3 +34,12 @@ table.pack = table.pack or pack or function(...) return {...} end
 table.unpack = table.unpack or unpack
 
 bit32 = bit32 or require "core.bit"
+
+-- Because AppImages change the working directory before running the executable,
+-- we need to change it back to the original one.
+-- https://github.com/AppImage/AppImageKit/issues/172
+-- https://github.com/AppImage/AppImageKit/pull/191
+local appimage_owd = os.getenv("OWD")
+if os.getenv("APPIMAGE") and appimage_owd then
+  system.chdir(appimage_owd)
+end


### PR DESCRIPTION
When AppImages are executed, they change the working directory to the one the executable is mounted to.
This causes issues when using relative paths.

To solve this, we could either provide our own `AppRun` that sets the correct working directory, or just do it on the Lua side.
I went with the second option because of its simplicity.

Fixes #936.