### PR TITLE
Don't animate scrolling when dragging the scroll bar

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -4,6 +4,7 @@ config.fps = 60
 config.max_log_items = 80
 config.message_timeout = 5
 config.mouse_wheel_scroll = 50 * SCALE
+config.animate_drag_scroll = false
 config.scroll_past_end = true
 config.file_size_limit = 10
 config.ignore_files = { "^%." }

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -134,6 +134,9 @@ function View:on_mouse_moved(x, y, dx, dy)
   if self.dragging_scrollbar then
     local delta = self:get_scrollable_size() / self.size.y * dy
     self.scroll.to.y = self.scroll.to.y + delta
+    if not config.animate_drag_scroll then
+      self.scroll.y = self.scroll.to.y
+    end
   end
   self.hovered_scrollbar = self:scrollbar_overlaps_point(x, y)
   self.hovered_scrollbar_track = self.hovered_scrollbar or self:scrollbar_track_overlaps_point(x, y)


### PR DESCRIPTION
It's not something applications in general do, and in our case it increases CPU usage.

The behavior can be re-enabled by setting `config.animate_drag_scroll = true`.