### PR TITLE
Add animation categories to enable finer transitions control

### DIFF
--- a/data/core/commandview.lua
+++ b/data/core/commandview.lua
@@ -202,31 +202,31 @@ function CommandView:update()
   end
 
   -- update gutter text color brightness
-  self:move_towards("gutter_text_brightness", 0, 0.1)
+  self:move_towards("gutter_text_brightness", 0, 0.1, "commandview")
 
   -- update gutter width
   local dest = self:get_font():get_width(self.label) + style.padding.x
   if self.size.y <= 0 then
     self.gutter_width = dest
   else
-    self:move_towards("gutter_width", dest)
+    self:move_towards("gutter_width", dest, nil, "commandview")
   end
 
   -- update suggestions box height
   local lh = self:get_suggestion_line_height()
   local dest = self.show_suggestions and math.min(#self.suggestions, max_suggestions) * lh or 0
-  self:move_towards("suggestions_height", dest)
+  self:move_towards("suggestions_height", dest, nil, "commandview")
 
   -- update suggestion cursor offset
   local dest = math.min(self.suggestion_idx, max_suggestions) * self:get_suggestion_line_height()
-  self:move_towards("selection_offset", dest)
+  self:move_towards("selection_offset", dest, nil, "commandview")
 
   -- update size based on whether this is the active_view
   local dest = 0
   if self == core.active_view then
     dest = style.font:get_height() + style.padding.y * 2
   end
-  self:move_towards(self.size, "y", dest)
+  self:move_towards(self.size, "y", dest, nil, "commandview")
 end
 
 

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -21,6 +21,7 @@ config.tab_type = "soft"
 config.line_limit = 80
 config.max_project_files = 2000
 config.transitions = true
+config.disabled_transitions = { }
 config.animation_rate = 1.0
 config.blink_period = 0.8
 config.disable_blink = false

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -21,7 +21,16 @@ config.tab_type = "soft"
 config.line_limit = 80
 config.max_project_files = 2000
 config.transitions = true
-config.disabled_transitions = { }
+config.disabled_transitions = {
+  scroll = false,
+  commandview = false,
+  contextmenu = false,
+  logview = false,
+  nagbar = false,
+  tabs = false,
+  tab_drag = false,
+  statusbar = false,
+}
 config.animation_rate = 1.0
 config.blink_period = 0.8
 config.disable_blink = false

--- a/data/core/contextmenu.lua
+++ b/data/core/contextmenu.lua
@@ -5,6 +5,7 @@ local config = require "core.config"
 local keymap = require "core.keymap"
 local style = require "core.style"
 local Object = require "core.object"
+local View = require "core.view"
 
 local border_width = 1
 local divider_width = 1
@@ -187,30 +188,11 @@ function ContextMenu:on_mouse_pressed(button, px, py, clicks)
   return caught
 end
 
--- copied from core.docview
-function ContextMenu:move_towards(t, k, dest, rate)
-  if type(t) ~= "table" then
-    return self:move_towards(self, t, k, dest, rate)
-  end
-  local val = t[k]
-  if not config.transitions or math.abs(val - dest) < 0.5 then
-    t[k] = dest
-  else
-    rate = rate or 0.5
-    if config.fps ~= 60 or config.animation_rate ~= 1 then
-      local dt = 60 / config.fps
-      rate = 1 - common.clamp(1 - rate, 1e-8, 1 - 1e-8)^(config.animation_rate * dt)
-    end
-    t[k] = common.lerp(val, dest, rate)
-  end
-  if val ~= dest then
-    core.redraw = true
-  end
-end
+ContextMenu.move_towards = View.move_towards
 
 function ContextMenu:update()
   if self.show_context_menu then
-    self:move_towards("height", self.items.height)
+    self:move_towards("height", self.items.height, nil, "contextmenu")
   end
 end
 

--- a/data/core/logview.lua
+++ b/data/core/logview.lua
@@ -118,13 +118,13 @@ function LogView:update()
 
   local expanding = self.expanding[1]
   if expanding then
-    self:move_towards(expanding, "current", expanding.target)
+    self:move_towards(expanding, "current", expanding.target, nil, "logview")
     if expanding.current == expanding.target then
       table.remove(self.expanding, 1)
     end
   end
 
-  self:move_towards("yoffset", 0)
+  self:move_towards("yoffset", 0, nil, "logview")
 
   LogView.super.update(self)
 end

--- a/data/core/nagview.lua
+++ b/data/core/nagview.lua
@@ -170,10 +170,10 @@ function NagView:update()
   NagView.super.update(self)
 
   if self.visible and core.active_view == self and self.title then
-    self:move_towards(self, "show_height", self:get_target_height())
-    self:move_towards(self, "underline_progress", 1)
+    self:move_towards(self, "show_height", self:get_target_height(), nil, "nagbar")
+    self:move_towards(self, "underline_progress", 1, nil, "nagbar")
   else
-    self:move_towards(self, "show_height", 0)
+    self:move_towards(self, "show_height", 0, nil, "nagbar")
     if self.show_height <= 0 then
       self.title = nil
       self.message = nil

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -468,8 +468,8 @@ function Node:update()
     end
     self:tab_hovered_update(self.hovered.x, self.hovered.y)
     local tab_width = self:target_tab_width()
-    self:move_towards("tab_shift", tab_width * (self.tab_offset - 1))
-    self:move_towards("tab_width", tab_width)
+    self:move_towards("tab_shift", tab_width * (self.tab_offset - 1), nil, "tabs")
+    self:move_towards("tab_width", tab_width, nil, "tabs")
   else
     self.a:update()
     self.b:update()

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -297,12 +297,12 @@ end
 
 
 function RootView:interpolate_drag_overlay(overlay)
-  self:move_towards(overlay, "x", overlay.to.x)
-  self:move_towards(overlay, "y", overlay.to.y)
-  self:move_towards(overlay, "w", overlay.to.w)
-  self:move_towards(overlay, "h", overlay.to.h)
+  self:move_towards(overlay, "x", overlay.to.x, nil, "tab_drag")
+  self:move_towards(overlay, "y", overlay.to.y, nil, "tab_drag")
+  self:move_towards(overlay, "w", overlay.to.w, nil, "tab_drag")
+  self:move_towards(overlay, "h", overlay.to.h, nil, "tab_drag")
 
-  self:move_towards(overlay, "opacity", overlay.visible and 100 or 0)
+  self:move_towards(overlay, "opacity", overlay.visible and 100 or 0, nil, "tab_drag")
   overlay.color[4] = overlay.base_color[4] * overlay.opacity / 100
 end
 

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -1042,14 +1042,14 @@ function StatusView:update()
   if not self.visible and self.size.y <= 0 then
     return
   elseif not self.visible and self.size.y > 0 then
-    self:move_towards(self.size, "y", 0)
+    self:move_towards(self.size, "y", 0, nil, "statusbar")
     return
   end
 
   local height = style.font:get_height() + style.padding.y * 2;
 
   if self.size.y + 1 < height then
-    self:move_towards(self.size, "y", height)
+    self:move_towards(self.size, "y", height, nil, "statusbar")
   else
     self.size.y = height
   end

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -176,28 +176,28 @@ end
 function View:update_scrollbar()
     local x, y, w, h = self:get_scrollbar_rect()
     self.scrollbar.w.to.thumb = w
-    self:move_towards(self.scrollbar.w, "thumb", self.scrollbar.w.to.thumb, 0.3)
+    self:move_towards(self.scrollbar.w, "thumb", self.scrollbar.w.to.thumb, 0.3, "scroll")
     self.scrollbar.x.thumb = x + w - self.scrollbar.w.thumb
     self.scrollbar.y.thumb = y
     self.scrollbar.h.thumb = h
 
     local x, y, w, h = self:get_scrollbar_track_rect()
     self.scrollbar.w.to.track = w
-    self:move_towards(self.scrollbar.w, "track", self.scrollbar.w.to.track, 0.3)
+    self:move_towards(self.scrollbar.w, "track", self.scrollbar.w.to.track, 0.3, "scroll")
     self.scrollbar.x.track = x + w - self.scrollbar.w.track
     self.scrollbar.y.track = y
     self.scrollbar.h.track = h
 
     -- we use 100 for a smoother transition
     self.scrollbar_alpha.to = (self.hovered_scrollbar_track or self.dragging_scrollbar) and 100 or 0
-    self:move_towards(self.scrollbar_alpha, "value", self.scrollbar_alpha.to, 0.3)
+    self:move_towards(self.scrollbar_alpha, "value", self.scrollbar_alpha.to, 0.3, "scroll")
 end
 
 
 function View:update()
   self:clamp_scroll_position()
-  self:move_towards(self.scroll, "x", self.scroll.to.x, 0.3)
-  self:move_towards(self.scroll, "y", self.scroll.to.y, 0.3)
+  self:move_towards(self.scroll, "x", self.scroll.to.x, 0.3, "scroll")
+  self:move_towards(self.scroll, "y", self.scroll.to.y, 0.3, "scroll")
 
   self:update_scrollbar()
 end

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -27,13 +27,13 @@ function View:new()
   self.scrollbar_alpha = { value = 0, to = 0 }
 end
 
-function View:move_towards(t, k, dest, rate)
+function View:move_towards(t, k, dest, rate, name)
   if type(t) ~= "table" then
-    return self:move_towards(self, t, k, dest, rate)
+    return self:move_towards(self, t, k, dest, rate, name)
   end
   local val = t[k]
   local diff = math.abs(val - dest)
-  if not config.transitions or diff < 0.5 then
+  if not config.transitions or diff < 0.5 or config.disabled_transitions[name] then
     t[k] = dest
   else
     rate = rate or 0.5

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -284,14 +284,14 @@ function TreeView:update()
     self.size.x = dest
     self.init_size = false
   else
-    self:move_towards(self.size, "x", dest)
+    self:move_towards(self.size, "x", dest, nil, "treeview")
   end
 
   if not self.visible then return end
 
   local duration = system.get_time() - self.tooltip.begin
   if self.hovered_item and self.tooltip.x and duration > tooltip_delay then
-    self:move_towards(self.tooltip, "alpha", tooltip_alpha, tooltip_alpha_rate)
+    self:move_towards(self.tooltip, "alpha", tooltip_alpha, tooltip_alpha_rate, "treeview")
   else
     self.tooltip.alpha = 0
   end


### PR DESCRIPTION
### What this PR does
The following categories are implemented:
```lua
config.disabled_transitions = {
  scroll = false,
  commandview = false,
  contextmenu = false,
  logview = false,
  nagbar = false,
  tabs = false,
  tab_drag = false,
  statusbar = false,
}
```
Suggestions are welcome to rename them, add more or remove some.

To disable an animation, in the user module add:
```lua
config.disabled_transitions.commandview = true
config.disabled_transitions.contextmenu = true
```

To disable all the animations, the old method can still be used:
```lua
config.transitions = false
```

To enable al the animations:
```lua
config.transitions = true
config.disabled_transitions = { }
```

---

### Alternative proposed by @adamharrison
To disable an animation, in the user module add:
```lua
config.transitions.commandview = false
config.transitions.contextmenu = false
```

To disable all the animations, the old method can still be used:
```lua
config.transitions = false
```

To enable al the animations:
```lua
config.transitions = { }
```

---

Closes #893.