### PR TITLE
Autoreload Nagview

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -466,6 +466,10 @@ local commands = {
       command.perform("doc:save-as")
     end
   end,
+  
+  ["doc:reload"] = function()
+    doc():reload()
+  end,
 
   ["file:rename"] = function()
     local old_filename = doc().filename

--- a/data/core/dirwatch.lua
+++ b/data/core/dirwatch.lua
@@ -31,10 +31,13 @@ end
 -- In windows, this is a no-op for anything underneath a top-level directory,
 -- but code should be called anyway, so we can ensure that we have a proper
 -- experience across all platforms. Should be an absolute path.
+-- Can also be called on individual files, though this should be used sparingly,
+-- so as not to run into system limits (like in the autoreload plugin).
 function dirwatch:watch(directory, bool)
   if bool == false then return self:unwatch(directory) end
   if not self.watched[directory] and not self.scanned[directory] then
     if PLATFORM == "Windows" then
+      if system.get_file_info(directory).type ~= "dir" then return self:scan(directory) end
       if not self.windows_watch_top or directory:find(self.windows_watch_top, 1, true) ~= 1 then
         -- Get the highest level of directory that is common to this directory, and the original.
         local target = directory

--- a/data/core/dirwatch.lua
+++ b/data/core/dirwatch.lua
@@ -35,9 +35,11 @@ end
 -- so as not to run into system limits (like in the autoreload plugin).
 function dirwatch:watch(directory, bool)
   if bool == false then return self:unwatch(directory) end
+  local info = system.get_file_info(directory)
+  if not info then return end
   if not self.watched[directory] and not self.scanned[directory] then
     if PLATFORM == "Windows" then
-      if system.get_file_info(directory).type ~= "dir" then return self:scan(directory) end
+      if info.type ~= "dir" then return self:scan(directory) end
       if not self.windows_watch_top or directory:find(self.windows_watch_top, 1, true) ~= 1 then
         -- Get the highest level of directory that is common to this directory, and the original.
         local target = directory

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -80,6 +80,16 @@ function Doc:load(filename)
 end
 
 
+function Doc:reload()
+  if self.filename then
+    local sel = { self:get_selection() }
+    self:load(self.filename)
+    self:clean()
+    self:set_selection(table.unpack(sel))
+  end
+end
+
+
 function Doc:save(filename, abs_filename)
   if not filename then
     assert(self.filename, "no filename set to default to")

--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -10,7 +10,16 @@ config.plugins.autoreload = common.merge({
   always_show_nagview = false
 }, config.plugins.autoreload)
 
+local function get_project_doc(doc)
+  for i, v in ipairs(core.project_directories) do
+    if doc.abs_filename:find(v.abs_filename, 1, true) == 1 then return v end
+  end
+  return nil
+end
+
+local watch = dirwatch.new()
 local times = setmetatable({}, { __mode = "k" })
+local visible = setmetatable({}, { __mode = "k" })
 
 local function update_time(doc)
   local info = system.get_file_info(doc.filename)
@@ -23,9 +32,9 @@ local function reload_doc(doc)
   core.log_quiet("Auto-reloaded doc \"%s\"", doc.filename)
 end
 
-local function check_prompt_reload()
-  if core.active_view.doc and core.active_view.doc.deferred_reload then
-    local doc = core.active_view.doc
+local function check_prompt_reload(doc)
+  if doc or (core.active_view.doc and core.active_view.doc.deferred_reload) then
+    doc = doc or core.active_view.doc
     core.nag_view:show("File Changed", doc.filename .. " has changed. Reload this file?", {
       { font = style.font, text = "Yes", default_yes = true },
       { font = style.font, text = "No" , default_no = true }
@@ -36,6 +45,24 @@ local function check_prompt_reload()
   end
 end
 
+local function doc_becomes_visible(doc)
+  if doc and not visible[doc] and doc.abs_filename then
+    visible[doc] = true
+    check_prompt_reload(doc)
+    local dir = get_project_doc(doc)
+    (dir and dir.watch or watch):watch(doc.abs_filename)
+  end
+end
+
+local function doc_becomes_invisible(doc)
+  if doc and visible[doc] then
+    visible[doc] = false
+    local dir = get_project_doc(doc)
+    (dir and dir.watch or watch):unwatch(doc.abs_filename)
+  end
+end
+
+>>>>>>> Stashed changes
 local function check_if_modified(doc)
   local info = system.get_file_info(doc.filename or "")
   if info and times[doc] ~= info.modified then
@@ -51,7 +78,7 @@ local on_check = dirwatch.check
 function dirwatch:check(change_callback, ...)
   on_check(self, function(dir)
     for _, doc in ipairs(core.docs) do
-      if dir == common.dirname(doc.abs_filename) then
+      if dir == common.dirname(doc.abs_filename) or dir == doc.abs_filename then
         check_if_modified(doc)
       end
     end
@@ -60,29 +87,27 @@ function dirwatch:check(change_callback, ...)
   check_prompt_reload()
 end
 
-
-local set_active_view = core.set_active_view
+local core_set_active_view = core.set_active_view
 function core.set_active_view(view)
-  set_active_view(view)
-  check_prompt_reload()
-  if view.doc and view.doc.abs_filename then
-    local should_poll = true
-    for i,v in ipairs(core.project_directories) do
-      if view.doc.abs_filename:find(v.name, 1, true) == 1 and not v.files_limit then
-        should_poll = false
-      end
-    end
-    if should_poll then
-      local doc = core.active_view.doc
-      core.add_thread(function()
-        while core.active_view.doc == doc do
-          check_if_modified(doc)
-          coroutine.yield(0.25)
-        end
-      end)
-    end
-  end
+  core_set_active_view(view)
+  doc_becomes_visible(view.doc)
 end
+
+local node_set_active_view = Node.set_active_view
+function Node:set_active_view(view)
+  doc_becomes_invisible(self.active_view.doc)
+  node_set_active_view(self, view)
+  doc_becomes_visible(self.active_view.doc)
+end
+
+core.add_thread(function()
+  while true do
+    -- because we already hook this function above; we only
+    -- need to check the file.
+    watch:check(function() end)
+    coroutine.yield(0.05)
+  end
+end)
 
 -- patch `Doc.save|load` to store modified time
 local load = Doc.load

--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -3,6 +3,7 @@ local core = require "core"
 local config = require "core.config"
 local style = require "core.style"
 local Doc = require "core.doc"
+local Node = require "core.node"
 local common = require "core.common"
 local dirwatch = require "core.dirwatch"
 
@@ -10,31 +11,30 @@ config.plugins.autoreload = common.merge({
   always_show_nagview = false
 }, config.plugins.autoreload)
 
-local function get_project_doc(doc)
-  for i, v in ipairs(core.project_directories) do
-    if doc.abs_filename:find(v.abs_filename, 1, true) == 1 then return v end
-  end
-  return nil
-end
-
 local watch = dirwatch.new()
 local times = setmetatable({}, { __mode = "k" })
 local visible = setmetatable({}, { __mode = "k" })
 
+local function get_project_doc_watch(doc)
+  for i, v in ipairs(core.project_directories) do
+    if doc.abs_filename:find(v.name, 1, true) == 1 then return v.watch end
+  end
+  return watch
+end
+
 local function update_time(doc)
-  local info = system.get_file_info(doc.filename)
-  times[doc] = info.modified
+  times[doc] = system.get_file_info(doc.filename).modified
 end
 
 local function reload_doc(doc)
   doc:reload()
   update_time(doc)
+  core.redraw = true
   core.log_quiet("Auto-reloaded doc \"%s\"", doc.filename)
 end
 
 local function check_prompt_reload(doc)
-  if doc or (core.active_view.doc and core.active_view.doc.deferred_reload) then
-    doc = doc or core.active_view.doc
+  if doc and doc.deferred_reload then
     core.nag_view:show("File Changed", doc.filename .. " has changed. Reload this file?", {
       { font = style.font, text = "Yes", default_yes = true },
       { font = style.font, text = "No" , default_no = true }
@@ -45,32 +45,11 @@ local function check_prompt_reload(doc)
   end
 end
 
-local function doc_becomes_visible(doc)
-  if doc and not visible[doc] and doc.abs_filename then
-    visible[doc] = true
-    check_prompt_reload(doc)
-    local dir = get_project_doc(doc)
-    (dir and dir.watch or watch):watch(doc.abs_filename)
-  end
-end
-
-local function doc_becomes_invisible(doc)
-  if doc and visible[doc] then
-    visible[doc] = false
-    local dir = get_project_doc(doc)
-    (dir and dir.watch or watch):unwatch(doc.abs_filename)
-  end
-end
-
->>>>>>> Stashed changes
-local function check_if_modified(doc)
-  local info = system.get_file_info(doc.filename or "")
-  if info and times[doc] ~= info.modified then
-    if not doc:is_dirty() and not config.plugins.autoreload.always_show_nagview then
-      reload_doc(doc)
-    else
-      doc.deferred_reload = true
-    end
+local function doc_changes_visiblity(doc, visibility)
+  if doc and visible[doc] ~= visibility and doc.abs_filename then
+    visible[doc] = visibility
+    if visibility then check_prompt_reload(doc) end
+    get_project_doc_watch(doc):watch(doc.abs_filename, visibility)
   end
 end
 
@@ -79,25 +58,32 @@ function dirwatch:check(change_callback, ...)
   on_check(self, function(dir)
     for _, doc in ipairs(core.docs) do
       if dir == common.dirname(doc.abs_filename) or dir == doc.abs_filename then
-        check_if_modified(doc)
+        local info = system.get_file_info(doc.filename or "")
+        if info and times[doc] ~= info.modified then
+          if not doc:is_dirty() and not config.plugins.autoreload.always_show_nagview then
+            reload_doc(doc)
+          else
+            doc.deferred_reload = true
+            if doc == core.active_view.doc then check_prompt_reload(doc) end
+          end
+        end
       end
     end
     change_callback(dir)
   end, ...)
-  check_prompt_reload()
 end
 
 local core_set_active_view = core.set_active_view
 function core.set_active_view(view)
   core_set_active_view(view)
-  doc_becomes_visible(view.doc)
+  doc_changes_visiblity(view.doc, true)
 end
 
 local node_set_active_view = Node.set_active_view
 function Node:set_active_view(view)
-  doc_becomes_invisible(self.active_view.doc)
+  if self.active_view then doc_changes_visiblity(self.active_view.doc, false) end
   node_set_active_view(self, view)
-  doc_becomes_visible(self.active_view.doc)
+  doc_changes_visiblity(self.active_view.doc, true)
 end
 
 core.add_thread(function()
@@ -121,6 +107,8 @@ end
 
 Doc.save = function(self, ...)
   local res = save(self, ...)
+  -- if starting with an unsaved document with a filename.
+  if not times[self] then get_project_doc_watch(self):watch(self.abs_filename, true) end
   update_time(self)
   return res
 end

--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -6,6 +6,10 @@ local Doc = require "core.doc"
 local common = require "core.common"
 local dirwatch = require "core.dirwatch"
 
+config.plugins.autoreload = common.merge({
+  always_show_nagview = false
+}, config.plugins.autoreload)
+
 local times = setmetatable({}, { __mode = "k" })
 
 local function update_time(doc)
@@ -35,7 +39,7 @@ end
 local function check_if_modified(doc)
   local info = system.get_file_info(doc.filename or "")
   if info and times[doc] ~= info.modified then
-    if not doc:is_dirty() then
+    if not doc:is_dirty() and not config.plugins.autoreload.always_show_nagview then
       reload_doc(doc)
     else
       doc.deferred_reload = true

--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -14,17 +14,8 @@ local function update_time(doc)
 end
 
 local function reload_doc(doc)
-  local fp = io.open(doc.filename, "r")
-  local text = fp:read("*a")
-  fp:close()
-
-  local sel = { doc:get_selection() }
-  doc:remove(1, 1, math.huge, math.huge)
-  doc:insert(1, 1, text:gsub("\r", ""):gsub("\n$", ""))
-  doc:set_selection(table.unpack(sel))
-
+  doc:reload()
   update_time(doc)
-  doc:clean()
   core.log_quiet("Auto-reloaded doc \"%s\"", doc.filename)
 end
 
@@ -41,20 +32,23 @@ local function check_prompt_reload()
   end
 end
 
+local function check_if_modified(doc)
+  local info = system.get_file_info(doc.filename or "")
+  if info and times[doc] ~= info.modified then
+    if not doc:is_dirty() then
+      reload_doc(doc)
+    else
+      doc.deferred_reload = true
+    end
+  end
+end
+
 local on_check = dirwatch.check
 function dirwatch:check(change_callback, ...)
   on_check(self, function(dir)
     for _, doc in ipairs(core.docs) do
       if dir == common.dirname(doc.abs_filename) then
-        local info = system.get_file_info(doc.filename or "")
-        if info and times[doc] ~= info.modified then
-          if not doc:is_dirty() then
-            reload_doc(doc)
-          else
-            doc.deferred_reload = true
-          end
-          break
-        end
+        check_if_modified(doc)
       end
     end
     change_callback(dir)
@@ -62,10 +56,28 @@ function dirwatch:check(change_callback, ...)
   check_prompt_reload()
 end
 
+
 local set_active_view = core.set_active_view
 function core.set_active_view(view)
   set_active_view(view)
   check_prompt_reload()
+  if view.doc and view.doc.abs_filename then
+    local should_poll = true
+    for i,v in ipairs(core.project_directories) do
+      if view.doc.abs_filename:find(v.name, 1, true) == 1 and not v.files_limit then
+        should_poll = false
+      end
+    end
+    if should_poll then
+      local doc = core.active_view.doc
+      core.add_thread(function()
+        while core.active_view.doc == doc do
+          check_if_modified(doc)
+          coroutine.yield(0.25)
+        end
+      end)
+    end
+  end
 end
 
 -- patch `Doc.save|load` to store modified time

--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -1,7 +1,10 @@
 -- mod-version:3 -- lite-xl 2.1
 local core = require "core"
 local config = require "core.config"
+local style = require "core.style"
 local Doc = require "core.doc"
+local common = require "core.common"
+local dirwatch = require "core.dirwatch"
 
 local times = setmetatable({}, { __mode = "k" })
 
@@ -25,18 +28,44 @@ local function reload_doc(doc)
   core.log_quiet("Auto-reloaded doc \"%s\"", doc.filename)
 end
 
-local on_modify = core.on_dirmonitor_modify
-
-core.on_dirmonitor_modify = function(dir, filepath)
-  local abs_filename = dir.name .. PATHSEP .. filepath
-  for _, doc in ipairs(core.docs) do
-    local info = system.get_file_info(doc.filename or "")
-    if doc.abs_filename == abs_filename and info and times[doc] ~= info.modified then
-      reload_doc(doc)
-      break
-    end
+local function check_prompt_reload()
+  if core.active_view.doc and core.active_view.doc.deferred_reload then
+    local doc = core.active_view.doc
+    core.nag_view:show("File Changed", doc.filename .. " has changed. Reload this file?", {
+      { font = style.font, text = "Yes", default_yes = true },
+      { font = style.font, text = "No" , default_no = true }
+    }, function(item)
+      if item.text == "Yes" then reload_doc(doc) end
+      doc.deferred_reload = false
+    end)
   end
-  on_modify(dir, filepath)
+end
+
+local on_check = dirwatch.check
+function dirwatch:check(change_callback, ...)
+  on_check(self, function(dir)
+    for _, doc in ipairs(core.docs) do
+      if dir == common.dirname(doc.abs_filename) then
+        local info = system.get_file_info(doc.filename or "")
+        if info and times[doc] ~= info.modified then
+          if not doc:is_dirty() then
+            reload_doc(doc)
+          else
+            doc.deferred_reload = true
+          end
+          break
+        end
+      end
+    end
+    change_callback(dir)
+  end, ...)
+  check_prompt_reload()
+end
+
+local set_active_view = core.set_active_view
+function core.set_active_view(view)
+  set_active_view(view)
+  check_prompt_reload()
 end
 
 -- patch `Doc.save|load` to store modified time

--- a/src/api/dirmonitor/inotify.c
+++ b/src/api/dirmonitor/inotify.c
@@ -47,7 +47,7 @@ int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buff
 
 
 int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
-  return inotify_add_watch(monitor->fd, path, IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
+  return inotify_add_watch(monitor->fd, path, IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MODIFY | IN_MOVED_TO);
 }
 
 


### PR DESCRIPTION
In addition to changing the plugin from the special core hook to a normal overload for detecting file changes, I've also done the following, based on some suggestions on discord:

1. If a file has changed, and we have it open, and clean, automatically reload it. (current behaviour)
2. If a file has changed, and we have it open, and dirty, and is the active view, show nagbar to ask if you want to reload the file or not.
3. If a file has changed, and we have it open, and dirty, and it's not the active view, flag the file, but don't show nagbar yet.
4. When the active view is changed, check to see if the view we're changing to is flagged, and if so, activate nagbar to ask if a reload is desirable.

This covers most of the cases; and should get rid of the issue where `autoreload.lua` will just stomp on changes you have if you're actively editing the file.

This is not the end-behaviour; as there is some discussion about exactly how a file should be reloaded (should it go directly into the undo stack, so you can easily undo it?), but this is an incremental step in the right direction.