### PR TITLE
Manage return values from "replacer" function in `Doc:replace`

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -448,7 +448,7 @@ end
 
 function Doc:replace_cursor(idx, line1, col1, line2, col2, fn)
   local old_text = self:get_text(line1, col1, line2, col2)
-  local new_text, n = fn(old_text)
+  local new_text, res = fn(old_text)
   if old_text ~= new_text then
     self:insert(line2, col2, new_text)
     self:remove(line1, col1, line2, col2)
@@ -457,22 +457,22 @@ function Doc:replace_cursor(idx, line1, col1, line2, col2, fn)
       self:set_selections(idx, line1, col1, line2, col2)
     end
   end
-  return n
+  return res
 end
 
 function Doc:replace(fn)
-  local has_selection, n = false, 0
+  local has_selection, results = false, { }
   for idx, line1, col1, line2, col2 in self:get_selections(true) do
     if line1 ~= line2 or col1 ~= col2 then
-      n = n + self:replace_cursor(idx, line1, col1, line2, col2, fn)
+      results[idx] = self:replace_cursor(idx, line1, col1, line2, col2, fn)
       has_selection = true
     end
   end
   if not has_selection then
     self:set_selection(table.unpack(self.selections))
-    n = n + self:replace_cursor(1, 1, 1, #self.lines, #self.lines[#self.lines], fn)
+    results[1] = self:replace_cursor(1, 1, 1, #self.lines, #self.lines[#self.lines], fn)
   end
-  return n
+  return results
 end
 
 


### PR DESCRIPTION
Before the addition of multi-cursor support, we just returned the second return value of the "replacer" function to the caller.

With the introduction of multi-cursors, we naively summed the second return values for each selection.
In some cases the "replacer" function doesn't return any second value, which means that we tried to do math with `nil`, thus throwing errors.

To reproduce the problem, try running the `doc:upper-case` command.

With this PR, the second return value of each selection is added to a table which is then returned to the caller.