### PR TITLE
meson: install docs/api to datadir for lsp support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -174,6 +174,7 @@ endif
 
 install_data('licenses/licenses.md', install_dir : lite_docdir)
 
+install_subdir('docs/api' , install_dir : lite_datadir, strip_directory: true)
 install_subdir('data/core' , install_dir : lite_datadir, exclude_files : 'start.lua')
 foreach data_module : ['fonts', 'plugins', 'colors']
     install_subdir(join_paths('data', data_module), install_dir : lite_datadir)


### PR DESCRIPTION
Currently the LSP plugin declares the lite-xl data dir as a library:

```lua
workspace = {
    library = {
      [DATADIR] = true
    }
}
```
This PR adds the installation of docs/api meta files to the DATADIR on the meson.build script so lua-language-server can pick them for autocompletion/intellisense support of the LUA api hidden away on the C implementation.