### PR TITLE
Add utf8 support on doc lower and upper commands

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -180,7 +180,7 @@ local commands = {
     local line, col = doc():get_selection()
     doc():set_selection(line, col)
   end,
-  
+
   ["doc:cut"] = function()
     cut_or_copy(true)
   end,
@@ -402,11 +402,11 @@ local commands = {
   end,
 
   ["doc:upper-case"] = function()
-    doc():replace(string.upper)
+    doc():replace(string.uupper)
   end,
 
   ["doc:lower-case"] = function()
-    doc():replace(string.lower)
+    doc():replace(string.ulower)
   end,
 
   ["doc:go-to-line"] = function()


### PR DESCRIPTION
~~Also fixed related lua arithmetic error when trying to make a sum against a nil value on doc replace.~~ #961 implements a proper fix