### PR TITLE
command predicates: added support for strict matching

### DIFF
--- a/data/core/command.lua
+++ b/data/core/command.lua
@@ -11,21 +11,32 @@ local always_true = function() return true end
 ---evaluation.
 ---
 ---If a string predicate is given it is treated as a require import that should
----return a valid object which is checked against the current active view, the
----sames applies if a table is given. A function that returns a boolean can be
----used instead to perform a custom evaluation, setting to nil means always
----evaluates to true.
+---return a valid object which is checked against the current active view,
+---eg: "core.docview" will match any view that inherits from DocView. Appending
+---a `!` at the end of the string means we want to match the given object
+---from the import strcitly eg: "core.docview!" only DocView is matched.
+---A function that returns a boolean can be used instead to perform a custom
+---evaluation, setting to nil means always evaluates to true.
 ---
 ---@param predicate string | table | function
 ---@return function
 function command.generate_predicate(predicate)
   predicate = predicate or always_true
+  local strict = false
   if type(predicate) == "string" then
+    if predicate:match("!$") then
+      strict = true
+      predicate = predicate:gsub("!$", "")
+    end
     predicate = require(predicate)
   end
   if type(predicate) == "table" then
     local class = predicate
-    predicate = function() return core.active_view:extends(class) end
+    if not strict then
+      predicate = function() return core.active_view:extends(class) end
+    else
+      predicate = function() return core.active_view:is(class) end
+    end
   end
   return predicate
 end

--- a/data/core/object.lua
+++ b/data/core/object.lua
@@ -21,10 +21,7 @@ end
 
 
 function Object:is(T)
-  if getmetatable(self) == T then
-    return true
-  end
-  return false
+  return getmetatable(self) == T
 end
 
 


### PR DESCRIPTION
Appending `!` on a string predicate will allow strict matching of the current view.

Example: "core.docview!" will strictly match an active view that is explicitly a DocView and not other views like the CommandView which also inherits from DocView.