### PR TITLE
Improvements to borderless mode on Windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -103,6 +103,18 @@ int main(int argc, char **argv) {
   SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
 #endif
 
+#if SDL_VERSION_ATLEAST(2, 0, 8)
+  /* This hint tells SDL to respect borderless window as a normal window.
+  ** For example, the window will sit right on top of the taskbar instead
+  ** of obscuring it. */
+  SDL_SetHint("SDL_BORDERLESS_WINDOWED_STYLE", "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 12)
+  /* This hint tells SDL to allow the user to resize a borderless windoow.
+  ** It also enables aero-snap on Windows apparently. */
+  SDL_SetHint("SDL_BORDERLESS_RESIZABLE_STYLE", "1");
+#endif
+
   SDL_DisplayMode dm;
   SDL_GetCurrentDisplayMode(0, &dm);
 


### PR DESCRIPTION
Here are some long awaited improvements for Windows' borderless mode:

- Aero snap now works (finally)
- Borderless mode no longer obscures taskbar when maximized
- Double click to maximize works

As far as I'm concerned this is about as close as we can get to the default title bar's behavior.

Before:

https://user-images.githubusercontent.com/20792268/169748565-42507b56-0293-4940-884e-875e37c7fd99.mp4

After:

https://user-images.githubusercontent.com/20792268/169748580-7afa3404-2398-422e-868a-9104d00e2b67.mp4


I think the redraw when window is moving issue is getting worse because Aero snap changes the window size more rapidly than actually resizing the window, so there's that. Otherwise, pretty good.
