### PR TITLE
Improve initial scale calculation

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -3,6 +3,7 @@ require "core.regex"
 local common = require "core.common"
 local config = require "core.config"
 local style = require "colors.default"
+local scale
 local command
 local keymap
 local dirwatch
@@ -1306,6 +1307,20 @@ function core.step()
       did_keymap = false
     elseif type == "mousemoved" then
       core.try(core.on_event, type, a, b, c, d)
+    elseif type == "moved" and SCALE == DEFAULT_SCALE then
+      -- Change SCALE when lite-xl window is moved to a display
+      -- with a different resolution than previous one.
+      local new_scale = system.get_scale()
+      if SCALE ~= new_scale then
+        DEFAULT_SCALE = new_scale
+        local old_scale_mode = "ui"
+        if config.plugins.scale.mode ~= "ui" then
+          old_scale_mode = config.plugins.scale.mode
+          config.plugins.scale.mode = "ui"
+        end
+        scale.set(new_scale)
+        config.plugins.scale.mode = old_scale_mode
+      end
     else
       local _, res = core.try(core.on_event, type, a, b, c, d)
       did_keymap = res or did_keymap
@@ -1381,6 +1396,7 @@ end)
 
 
 function core.run()
+  scale = require "plugins.scale"
   local idle_iterations = 0
   while true do
     core.frame_start = system.get_time()

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1307,7 +1307,7 @@ function core.step()
       did_keymap = false
     elseif type == "mousemoved" then
       core.try(core.on_event, type, a, b, c, d)
-    elseif type == "moved" and SCALE == DEFAULT_SCALE then
+    elseif type == "displaychanged" and SCALE == DEFAULT_SCALE then
       -- Change SCALE when lite-xl window is moved to a display
       -- with a different resolution than previous one.
       local new_scale = system.get_scale()

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -2,7 +2,8 @@
 VERSION = "@PROJECT_VERSION@"
 MOD_VERSION = "3"
 
-SCALE = tonumber(os.getenv("LITE_SCALE") or os.getenv("GDK_SCALE") or os.getenv("QT_SCALE_FACTOR")) or SCALE
+DEFAULT_SCALE = system.get_scale()
+SCALE = tonumber(os.getenv("LITE_SCALE")) or DEFAULT_SCALE
 PATHSEP = package.config:sub(1, 1)
 
 EXEDIR = EXEFILE:match("^(.+)[/\\][^/\\]+$")

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -24,6 +24,7 @@ system = {}
 ---
 ---Window events:
 --- * "quit"
+--- * "moved" -> x, y
 --- * "resized" -> width, height (in points)
 --- * "exposed"
 --- * "minimized"
@@ -72,6 +73,12 @@ function system.wait_event(timeout) end
 ---
 ---@param type string | "arrow" | "ibeam" | "sizeh" | "sizev" | "hand"
 function system.set_cursor(type) end
+
+---
+---Retrieve a sane scale value using current desktop resolution.
+---
+---@return number scale
+function system.get_scale() end
 
 ---
 ---Change the window title.

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -24,6 +24,7 @@ system = {}
 ---
 ---Window events:
 --- * "quit"
+--- * "displaychanged" -> idx
 --- * "moved" -> x, y
 --- * "resized" -> width, height (in points)
 --- * "exposed"

--- a/meson.build
+++ b/meson.build
@@ -162,6 +162,15 @@ if not get_option('source-only')
 
     lite_deps = [lua_dep, sdl_dep, freetype_dep, pcre2_dep, libm, libdl]
 endif
+
+#===============================================================================
+# Link to X11 on linux to detect scale factor when video driver is x11
+#===============================================================================
+if host_machine.system() == 'linux'
+    x_dep = dependency('X11')
+    lite_deps += x_dep
+endif
+
 #===============================================================================
 # Install Configuration
 #===============================================================================

--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -346,7 +346,7 @@ static int f_draw_text(lua_State *L) {
   size_t len;
   const char *text = luaL_checklstring(L, 2, &len);
   float x = luaL_checknumber(L, 3);
-  int y = luaL_checknumber(L, 4);
+  float y = luaL_checknumber(L, 4);
   RenColor color = checkcolor(L, 5, 255);
   x = rencache_draw_text(fonts, text, len, x, y, color);
   lua_pushnumber(L, x);

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -433,7 +433,9 @@ static int f_get_scale(lua_State *L) {
   float scale = 1.0;
 #ifndef __APPLE__
   SDL_DisplayMode dm;
+#if _WIN32
   float dpi = 0;
+#endif
   char* env_scale = NULL;
   float system_scale = 0;
   int display_index = SDL_GetWindowDisplayIndex(window);

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -39,6 +39,8 @@
 #endif
 
 extern RenWindow window_renderer;
+extern float initial_scale;
+static bool got_initial_scale = false;
 
 static const char* button_name(int button) {
   switch (button) {
@@ -419,6 +421,15 @@ static int f_set_cursor(lua_State *L) {
 }
 
 static int f_get_scale(lua_State *L) {
+  /* returns the startup scale factor on first call if not 100% */
+  if (!got_initial_scale) {
+    got_initial_scale = true;
+    if (initial_scale != 1.0) {
+      lua_pushnumber(L, initial_scale);
+      return 1;
+    }
+  }
+
   float scale = 1.0;
 #ifndef __APPLE__
   SDL_DisplayMode dm;
@@ -438,7 +449,7 @@ static int f_get_scale(lua_State *L) {
     (system_scale = strtod(env_scale, NULL)) > 0
   ) {
     scale = system_scale;
-  } else if ((system_scale = ren_get_current_scale()) != 1.0) {
+  } else if ((system_scale = ren_get_scale_factor(window)) != 1.0) {
     scale = system_scale;
   } else if (SDL_GetCurrentDisplayMode(display_index, &dm) == 0) {
     float base_width = 1280, base_height = 720;

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -39,8 +39,6 @@
 #endif
 
 extern RenWindow window_renderer;
-extern float initial_scale;
-static bool got_initial_scale = false;
 
 static const char* button_name(int button) {
   switch (button) {
@@ -465,7 +463,7 @@ static float sdl_scale_factor() {
   */
 #ifndef LITE_USE_SDL_RENDERER
   SDL_DisplayMode dm;
-  SDL_GetCurrentDisplayMode(SDL_GetWindowDisplayIndex(window), &dm);
+  SDL_GetCurrentDisplayMode(SDL_GetWindowDisplayIndex(window_renderer.window), &dm);
 
   SDL_Window *windowHDPI = SDL_CreateWindow(
     "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
@@ -473,7 +471,7 @@ static float sdl_scale_factor() {
     SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_HIDDEN
   );
 #else
-  SDL_Window *windowHDPI = window;
+  SDL_Window *windowHDPI = window_renderer.window;
 #endif
 
   float scale = ren_get_scale_factor(windowHDPI);
@@ -503,7 +501,7 @@ static int f_get_scale(lua_State *L) {
   float system_scale = 0;
 #if _WIN32
   float dpi = 0;
-  int display_index = SDL_GetWindowDisplayIndex(window);
+  int display_index = SDL_GetWindowDisplayIndex(window_renderer.window);
 #endif
 
   if (

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -420,26 +420,27 @@ static int f_set_cursor(lua_State *L) {
 }
 
 static int f_get_scale(lua_State *L) {
+  float scale = 1.0;
 #ifndef __APPLE__
   SDL_DisplayMode dm;
   char* env_scale = NULL;
-  float scale = 1.0, parsed_scale = 0;
+  float system_scale = 0;
   int display_index = SDL_GetWindowDisplayIndex(window);
 
   if (
     (env_scale = getenv("GDK_SCALE")) != NULL
     &&
-    (parsed_scale = strtod(env_scale, NULL)) > 0
+    (system_scale = strtod(env_scale, NULL)) > 0
   ) {
-    scale = parsed_scale;
+    scale = system_scale;
   } else if (
     (env_scale = getenv("QT_SCALE_FACTOR")) != NULL
     &&
-    (parsed_scale = strtod(env_scale, NULL)) > 0
+    (system_scale = strtod(env_scale, NULL)) > 0
   ) {
-    scale = parsed_scale;
-  } else if ((parsed_scale = ren_get_current_scale()) != 1.0) {
-    scale = parsed_scale;
+    scale = system_scale;
+  } else if ((system_scale = ren_get_current_scale()) != 1.0) {
+    scale = system_scale;
   } else if (SDL_GetCurrentDisplayMode(display_index, &dm) == 0) {
     float base_width = 1280, base_height = 720;
     float dmw = (float) dm.w, dmh = (float) dm.h;

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -499,13 +499,12 @@ static int f_get_scale(lua_State *L) {
 
   float scale = 1.0;
 #ifndef __APPLE__
-  SDL_DisplayMode dm;
-#if _WIN32
-  float dpi = 0;
-#endif
   char* env_scale = NULL;
   float system_scale = 0;
+#if _WIN32
+  float dpi = 0;
   int display_index = SDL_GetWindowDisplayIndex(window);
+#endif
 
   if (
     (env_scale = getenv("GDK_SCALE")) != NULL
@@ -535,21 +534,6 @@ static int f_get_scale(lua_State *L) {
     got_initial_scale && (system_scale = sdl_scale_factor()) > 0
   ) {
     scale = system_scale;
-  /* if all other methods failed use a suggested scale factor */
-  } else if (SDL_GetCurrentDisplayMode(display_index, &dm) == 0) {
-    float base_width = 1280, base_height = 720;
-    float dmw = (float) dm.w, dmh = (float) dm.h;
-    if (dmw < dmh) {
-      base_width = 720;
-      base_height = 1280;
-    }
-    float current_aspect_ratio = dmw / dmh,
-      base_aspect_ratio = base_width / base_height;
-    if (current_aspect_ratio >= base_aspect_ratio) {
-      scale = dmw / base_width;
-    } else {
-      scale = dmh / base_height;
-    }
   }
 #endif /* __APPLE__ */
   got_initial_scale = true;

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -443,6 +443,10 @@ static int f_get_scale(lua_State *L) {
   } else if (SDL_GetCurrentDisplayMode(display_index, &dm) == 0) {
     float base_width = 1280, base_height = 720;
     float dmw = (float) dm.w, dmh = (float) dm.h;
+    if (dmw < dmh) {
+      base_width = 720;
+      base_height = 1280;
+    }
     float current_aspect_ratio = dmw / dmh,
       base_aspect_ratio = base_width / base_height;
     if (current_aspect_ratio >= base_aspect_ratio) {

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -433,6 +433,7 @@ static int f_get_scale(lua_State *L) {
   float scale = 1.0;
 #ifndef __APPLE__
   SDL_DisplayMode dm;
+  float dpi = 0;
   char* env_scale = NULL;
   float system_scale = 0;
   int display_index = SDL_GetWindowDisplayIndex(window);
@@ -451,6 +452,10 @@ static int f_get_scale(lua_State *L) {
     scale = system_scale;
   } else if ((system_scale = ren_get_scale_factor(window)) != 1.0) {
     scale = system_scale;
+#if _WIN32
+  } else if (SDL_GetDisplayDPI(display_index, NULL, &dpi, NULL) == 0) {
+    scale = dpi / 96.0;
+#endif
   } else if (SDL_GetCurrentDisplayMode(display_index, &dm) == 0) {
     float base_width = 1280, base_height = 720;
     float dmw = (float) dm.w, dmh = (float) dm.h;

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -195,12 +195,11 @@ top:
         lua_pushinteger(L, e.window.data1);
         lua_pushinteger(L, e.window.data2);
         return 3;
-      } else if (e.window.event == SDL_WINDOWEVENT_MOVED ) {
-        lua_pushstring(L, "moved");
-        /* The new position coordinates. */
+      } else if (e.window.event == SDL_WINDOWEVENT_DISPLAY_CHANGED ) {
+        lua_pushstring(L, "displaychanged");
+        /* The display index. */
         lua_pushinteger(L, e.window.data1);
-        lua_pushinteger(L, e.window.data2);
-        return 3;
+        return 2;
       } else if (e.window.event == SDL_WINDOWEVENT_EXPOSED) {
         rencache_invalidate();
         lua_pushstring(L, "exposed");

--- a/src/main.c
+++ b/src/main.c
@@ -159,6 +159,7 @@ int main(int argc, char **argv) {
     "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
     800, 450,
     SDL_WINDOW_RESIZABLE
+    | SDL_WINDOW_HIDDEN
 #if LITE_USE_SDL_RENDERER
     /* causes pixelated rendering when not using the sdl renderer */
     | SDL_WINDOW_ALLOW_HIGHDPI
@@ -178,7 +179,7 @@ int main(int argc, char **argv) {
   SDL_Window *windowHDPI = SDL_CreateWindow(
     "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
     dm.w * 0.8, dm.h * 0.8,
-    SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
+    SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_HIDDEN
   );
 #else
   SDL_Window *windowHDPI = window;

--- a/src/main.c
+++ b/src/main.c
@@ -20,29 +20,6 @@
 
 static SDL_Window *window;
 
-static double get_scale(void) {
-#ifndef __APPLE__
-  float dpi;
-  SDL_DisplayMode dm;
-  if (SDL_GetDesktopDisplayMode(0, &dm) == 0) {
-    int base_width = 1280, base_height = 720;
-    double scale, current_aspect_ratio = (double) dm.w / dm.h,
-      base_aspect_ratio = (double) base_width / base_height;
-    if (current_aspect_ratio >= base_aspect_ratio) {
-      scale = (double) dm.w / base_width;
-    } else {
-      scale = (double) dm.h / base_height;
-    }
-    return scale;
-  }
-  else if (SDL_GetDisplayDPI(0, NULL, &dpi, NULL) == 0) {
-    return dpi / 96.0;
-  }
-#endif
-  return 1.0;
-}
-
-
 static void get_exe_filename(char *buf, int sz) {
 #if _WIN32
   int len = GetModuleFileName(NULL, buf, sz - 1);
@@ -209,9 +186,6 @@ init_lua:
 
   lua_pushstring(L, LITE_ARCH_TUPLE);
   lua_setglobal(L, "ARCH");
-
-  lua_pushnumber(L, get_scale());
-  lua_setglobal(L, "SCALE");
 
   char exename[2048];
   get_exe_filename(exename, sizeof(exename));

--- a/src/main.c
+++ b/src/main.c
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
     SDL_WINDOW_RESIZABLE
     | SDL_WINDOW_HIDDEN
 #if LITE_USE_SDL_RENDERER
-    /* causes pixelated rendering when not using the sdl renderer */
+    /* causes pixelated rendering when not using the sdl renderer and scaled */
     | SDL_WINDOW_ALLOW_HIGHDPI
 #endif
   );
@@ -169,27 +169,6 @@ int main(int argc, char **argv) {
   SDL_DisplayMode dm;
   SDL_GetCurrentDisplayMode(SDL_GetWindowDisplayIndex(window), &dm);
   SDL_SetWindowSize(window, dm.w * 0.8, dm.h * 0.8);
-
-/* When not using the sdl renderer the SDL_WINDOW_ALLOW_HIGHDPI flag
-   causes the window to render the content pixelated, so we create
-   a separate window with the high dpi flag to retrieve the display
-   scale factor and then we destroy it.
-*/
-#ifndef LITE_USE_SDL_RENDERER
-  SDL_Window *windowHDPI = SDL_CreateWindow(
-    "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-    dm.w * 0.8, dm.h * 0.8,
-    SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_HIDDEN
-  );
-#else
-  SDL_Window *windowHDPI = window;
-#endif
-
-  /* Get the system scale factor. */
-  initial_scale = ren_get_scale_factor(windowHDPI);
-#ifndef LITE_USE_SDL_RENDERER
-  SDL_DestroyWindow(windowHDPI);
-#endif
 
   init_window_icon();
   if (!window) {

--- a/src/main.c
+++ b/src/main.c
@@ -23,8 +23,21 @@ static SDL_Window *window;
 static double get_scale(void) {
 #ifndef __APPLE__
   float dpi;
-  if (SDL_GetDisplayDPI(0, NULL, &dpi, NULL) == 0)
+  SDL_DisplayMode dm;
+  if (SDL_GetDesktopDisplayMode(0, &dm) == 0) {
+    int base_width = 1280, base_height = 720;
+    double scale, current_aspect_ratio = (double) dm.w / dm.h,
+      base_aspect_ratio = (double) base_width / base_height;
+    if (current_aspect_ratio >= base_aspect_ratio) {
+      scale = (double) dm.w / base_width;
+    } else {
+      scale = (double) dm.h / base_height;
+    }
+    return scale;
+  }
+  else if (SDL_GetDisplayDPI(0, NULL, &dpi, NULL) == 0) {
     return dpi / 96.0;
+  }
 #endif
   return 1.0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -158,8 +158,14 @@ int main(int argc, char **argv) {
   SDL_GetCurrentDisplayMode(0, &dm);
 
   window = SDL_CreateWindow(
-    "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, dm.w * 0.8, dm.h * 0.8,
-    SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_HIDDEN);
+    "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+    dm.w * 0.8, dm.h * 0.8,
+    SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIDDEN
+#if LITE_USE_SDL_RENDERER
+    | SDL_WINDOW_ALLOW_HIGHDPI
+#endif
+  );
+
   init_window_icon();
   if (!window) {
     fprintf(stderr, "Error creating lite-xl window: %s", SDL_GetError());

--- a/src/main.c
+++ b/src/main.c
@@ -165,6 +165,10 @@ int main(int argc, char **argv) {
 #endif
   );
 
+  SDL_DisplayMode dm;
+  SDL_GetCurrentDisplayMode(SDL_GetWindowDisplayIndex(window), &dm);
+  SDL_SetWindowSize(window, dm.w * 0.8, dm.h * 0.8);
+
 /* When not using the sdl renderer the SDL_WINDOW_ALLOW_HIGHDPI flag
    causes the window to render the content pixelated, so we create
    a separate window with the high dpi flag to retrieve the display
@@ -173,7 +177,7 @@ int main(int argc, char **argv) {
 #ifndef LITE_USE_SDL_RENDERER
   SDL_Window *windowHDPI = SDL_CreateWindow(
     "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-    800, 450,
+    dm.w * 0.8, dm.h * 0.8,
     SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
   );
 #else
@@ -185,10 +189,6 @@ int main(int argc, char **argv) {
 #ifndef LITE_USE_SDL_RENDERER
   SDL_DestroyWindow(windowHDPI);
 #endif
-
-  SDL_DisplayMode dm;
-  SDL_GetCurrentDisplayMode(SDL_GetWindowDisplayIndex(window), &dm);
-  SDL_SetWindowSize(window, dm.w * 0.8, dm.h * 0.8);
 
   init_window_icon();
   if (!window) {

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 
 
 static SDL_Window *window;
+float initial_scale = 1.0;
 
 static void get_exe_filename(char *buf, int sz) {
 #if _WIN32
@@ -154,17 +155,40 @@ int main(int argc, char **argv) {
   SDL_SetHint("SDL_MOUSE_DOUBLE_CLICK_RADIUS", "4");
 #endif
 
-  SDL_DisplayMode dm;
-  SDL_GetCurrentDisplayMode(0, &dm);
-
   window = SDL_CreateWindow(
     "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-    dm.w * 0.8, dm.h * 0.8,
-    SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIDDEN
+    800, 450,
+    SDL_WINDOW_RESIZABLE
 #if LITE_USE_SDL_RENDERER
+    /* causes pixelated rendering when not using the sdl renderer */
     | SDL_WINDOW_ALLOW_HIGHDPI
 #endif
   );
+
+/* When not using the sdl renderer the SDL_WINDOW_ALLOW_HIGHDPI flag
+   causes the window to render the content pixelated, so we create
+   a separate window with the high dpi flag to retrieve the display
+   scale factor and then we destroy it.
+*/
+#ifndef LITE_USE_SDL_RENDERER
+  SDL_Window *windowHDPI = SDL_CreateWindow(
+    "", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+    800, 450,
+    SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
+  );
+#else
+  SDL_Window *windowHDPI = window;
+#endif
+
+  /* Get the system scale factor. */
+  initial_scale = ren_get_scale_factor(windowHDPI);
+#ifndef LITE_USE_SDL_RENDERER
+  SDL_DestroyWindow(windowHDPI);
+#endif
+
+  SDL_DisplayMode dm;
+  SDL_GetCurrentDisplayMode(SDL_GetWindowDisplayIndex(window), &dm);
+  SDL_SetWindowSize(window, dm.w * 0.8, dm.h * 0.8);
 
   init_window_icon();
   if (!window) {

--- a/src/main.c
+++ b/src/main.c
@@ -19,7 +19,6 @@
 
 
 static SDL_Window *window;
-float initial_scale = 1.0;
 
 static void get_exe_filename(char *buf, int sz) {
 #if _WIN32

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -171,7 +171,7 @@ void rencache_draw_rect(RenRect rect, RenColor color) {
   }
 }
 
-float rencache_draw_text(RenFont **fonts, const char *text, size_t len, float x, int y, RenColor color)
+float rencache_draw_text(RenFont **fonts, const char *text, size_t len, float x, float y, RenColor color)
 {
   float width = ren_font_group_get_width(fonts, text, len);
   RenRect rect = { x, y, (int)width, ren_font_group_get_height(fonts) };
@@ -316,4 +316,3 @@ void rencache_end_frame() {
   cells_prev = tmp;
   command_buf_idx = 0;
 }
-

--- a/src/rencache.h
+++ b/src/rencache.h
@@ -8,7 +8,7 @@
 void  rencache_show_debug(bool enable);
 void  rencache_set_clip_rect(RenRect rect);
 void  rencache_draw_rect(RenRect rect, RenColor color);
-float rencache_draw_text(RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
+float rencache_draw_text(RenFont **font, const char *text, size_t len, float x, float y, RenColor color);
 void  rencache_invalidate(void);
 void  rencache_begin_frame();
 void  rencache_end_frame();

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -576,5 +576,5 @@ float ren_get_scale_factor(SDL_Window *win) {
   SDL_GL_GetDrawableSize(win, &w_pixels, &h_pixels);
   SDL_GetWindowSize(win, &w_points, &h_points);
   float scale = (float) w_pixels / (float) w_points;
-  return scale;
+  return roundf(scale * 100) / 100;
 }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -560,3 +560,14 @@ void ren_get_size(int *x, int *y) {
   *x = surface->w / scale;
   *y = surface->h / scale;
 }
+
+
+float ren_get_current_scale() {
+  RenWindow *ren = &window_renderer;
+  int w_pixels, h_pixels;
+  int w_points, h_points;
+  SDL_GL_GetDrawableSize(ren->window, &w_pixels, &h_pixels);
+  SDL_GetWindowSize(ren->window, &w_points, &h_points);
+  float scale = (float) w_pixels / (float) w_points;
+  return scale;
+}

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -562,12 +562,11 @@ void ren_get_size(int *x, int *y) {
 }
 
 
-float ren_get_current_scale() {
-  RenWindow *ren = &window_renderer;
+float ren_get_scale_factor(SDL_Window *win) {
   int w_pixels, h_pixels;
   int w_points, h_points;
-  SDL_GL_GetDrawableSize(ren->window, &w_pixels, &h_pixels);
-  SDL_GetWindowSize(ren->window, &w_points, &h_points);
+  SDL_GL_GetDrawableSize(win, &w_pixels, &h_pixels);
+  SDL_GetWindowSize(win, &w_points, &h_points);
   float scale = (float) w_pixels / (float) w_points;
   return scale;
 }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -257,7 +257,7 @@ RenFont* ren_font_load(const char* path, float size, ERenFontAntialiasing antial
 
 #endif
 
-  const int surface_scale = renwin_surface_scale(&window_renderer);
+  const float surface_scale = renwin_surface_scale(&window_renderer);
   if (FT_Set_Pixel_Sizes(face, 0, (int)(size*surface_scale)))
     goto failure;
   int len = strlen(path);
@@ -372,7 +372,7 @@ float ren_font_group_get_width(RenFont **fonts, const char *text, size_t len) {
       break;
     width += (!font || metric->xadvance) ? metric->xadvance : fonts[0]->space_advance;
   }
-  const int surface_scale = renwin_surface_scale(&window_renderer);
+  const float surface_scale = renwin_surface_scale(&window_renderer);
   return width / surface_scale;
 }
 
@@ -380,7 +380,7 @@ float ren_draw_text(RenFont **fonts, const char *text, size_t len, float x, int 
   SDL_Surface *surface = renwin_get_surface(&window_renderer);
   const RenRect clip = window_renderer.clip;
 
-  const int surface_scale = renwin_surface_scale(&window_renderer);
+  const float surface_scale = renwin_surface_scale(&window_renderer);
   float pen_x = x * surface_scale;
   y *= surface_scale;
   int bytes_per_pixel = surface->format->BytesPerPixel;
@@ -479,7 +479,7 @@ static inline RenColor blend_pixel(RenColor dst, RenColor src) {
 void ren_draw_rect(RenRect rect, RenColor color) {
   if (color.a == 0) { return; }
 
-  const int surface_scale = renwin_surface_scale(&window_renderer);
+  const float surface_scale = renwin_surface_scale(&window_renderer);
 
   /* transforms coordinates in pixels. */
   rect.x      *= surface_scale;
@@ -555,7 +555,7 @@ void ren_set_clip_rect(RenRect rect) {
 
 void ren_get_size(int *x, int *y) {
   RenWindow *ren = &window_renderer;
-  const int scale = renwin_surface_scale(ren);
+  const float scale = renwin_surface_scale(ren);
   SDL_Surface *surface = renwin_get_surface(ren);
   *x = surface->w / scale;
   *y = surface->h / scale;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -29,7 +29,7 @@ float ren_font_group_get_size(RenFont **font);
 void ren_font_group_set_size(RenFont **font, float size);
 void ren_font_group_set_tab_size(RenFont **font, int n);
 float ren_font_group_get_width(RenFont **font, const char *text, size_t len);
-float ren_draw_text(RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
+float ren_draw_text(RenFont **font, const char *text, size_t len, float x, float y, RenColor color);
 
 void ren_draw_rect(RenRect rect, RenColor color);
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -11,13 +11,19 @@
 #define UNUSED
 #endif
 
+#ifdef LITE_USE_SDL_RENDERER
+#define RECT_TYPE float
+#else
+#define RECT_TYPE int
+#endif
+
 #define FONT_FALLBACK_MAX 10
 typedef struct RenFont RenFont;
 typedef enum { FONT_HINTING_NONE, FONT_HINTING_SLIGHT, FONT_HINTING_FULL } ERenFontHinting;
 typedef enum { FONT_ANTIALIASING_NONE, FONT_ANTIALIASING_GRAYSCALE, FONT_ANTIALIASING_SUBPIXEL } ERenFontAntialiasing;
 typedef enum { FONT_STYLE_BOLD = 1, FONT_STYLE_ITALIC = 2, FONT_STYLE_UNDERLINE = 4, FONT_STYLE_SMOOTH = 8, FONT_STYLE_STRIKETHROUGH = 16 } ERenFontStyle;
 typedef struct { uint8_t b, g, r, a; } RenColor;
-typedef struct { float x, y, width, height; } RenRect;
+typedef struct { RECT_TYPE x, y, width, height; } RenRect;
 
 RenFont* ren_font_load(const char *filename, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, unsigned char style);
 RenFont* ren_font_copy(RenFont* font, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, int style);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -17,7 +17,7 @@ typedef enum { FONT_HINTING_NONE, FONT_HINTING_SLIGHT, FONT_HINTING_FULL } ERenF
 typedef enum { FONT_ANTIALIASING_NONE, FONT_ANTIALIASING_GRAYSCALE, FONT_ANTIALIASING_SUBPIXEL } ERenFontAntialiasing;
 typedef enum { FONT_STYLE_BOLD = 1, FONT_STYLE_ITALIC = 2, FONT_STYLE_UNDERLINE = 4, FONT_STYLE_SMOOTH = 8, FONT_STYLE_STRIKETHROUGH = 16 } ERenFontStyle;
 typedef struct { uint8_t b, g, r, a; } RenColor;
-typedef struct { int x, y, width, height; } RenRect;
+typedef struct { float x, y, width, height; } RenRect;
 
 RenFont* ren_font_load(const char *filename, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, unsigned char style);
 RenFont* ren_font_copy(RenFont* font, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, int style);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -39,6 +39,7 @@ void ren_update_rects(RenRect *rects, int count);
 void ren_set_clip_rect(RenRect rect);
 void ren_get_size(int *x, int *y); /* Reports the size in points. */
 void ren_free_window_resources();
+float ren_get_current_scale();
 
 
 #endif

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -39,7 +39,7 @@ void ren_update_rects(RenRect *rects, int count);
 void ren_set_clip_rect(RenRect rect);
 void ren_get_size(int *x, int *y); /* Reports the size in points. */
 void ren_free_window_resources();
-float ren_get_current_scale();
+float ren_get_scale_factor(SDL_Window *win);
 
 
 #endif

--- a/src/renwindow.c
+++ b/src/renwindow.c
@@ -138,11 +138,11 @@ void renwin_update_rects(RenWindow *ren, RenRect *rects, int count) {
 }
 
 void renwin_free(RenWindow *ren) {
-  SDL_DestroyWindow(ren->window);
-  ren->window = NULL;
 #ifdef LITE_USE_SDL_RENDERER
   SDL_DestroyTexture(ren->texture);
   SDL_DestroyRenderer(ren->renderer);
   SDL_FreeSurface(ren->surface);
 #endif
+  SDL_DestroyWindow(ren->window);
+  ren->window = NULL;
 }

--- a/src/renwindow.c
+++ b/src/renwindow.c
@@ -61,8 +61,13 @@ void renwin_surface_scale(UNUSED RenWindow *ren, float *scale_x, float *scale_y)
 
 
 static RenRect scaled_rect(const RenRect rect, RenWindow *ren) {
+#ifdef LITE_USE_SDL_RENDERER
   float scale_x = ren->surface_scale_x;
   float scale_y = ren->surface_scale_y;
+#else
+  float scale_x = 1;
+  float scale_y = 1;
+#endif
   return (RenRect) {
     rect.x * scale_x,
     rect.y * scale_y,

--- a/src/renwindow.c
+++ b/src/renwindow.c
@@ -3,15 +3,14 @@
 #include "renwindow.h"
 
 #ifdef LITE_USE_SDL_RENDERER
-static int query_surface_scale(RenWindow *ren) {
+static float query_surface_scale(RenWindow *ren) {
   int w_pixels, h_pixels;
   int w_points, h_points;
   SDL_GL_GetDrawableSize(ren->window, &w_pixels, &h_pixels);
   SDL_GetWindowSize(ren->window, &w_points, &h_points);
-  /* We consider that the ratio pixel/point will always be an integer and
-     it is the same along the x and the y axis. */
-  assert(w_pixels % w_points == 0 && h_pixels % h_points == 0 && w_pixels / w_points == h_pixels / h_points);
-  return w_pixels / w_points;
+  float scale = (float) w_pixels / (float) w_points;
+  scale = roundf(scale * 100) / 100;
+  return scale;
 }
 
 static void setup_renderer(RenWindow *ren, int w, int h) {
@@ -45,7 +44,7 @@ void renwin_init_surface(UNUSED RenWindow *ren) {
 #endif
 }
 
-int renwin_surface_scale(UNUSED RenWindow *ren) {
+float renwin_surface_scale(UNUSED RenWindow *ren) {
 #ifdef LITE_USE_SDL_RENDERER
   return ren->surface_scale;
 #else
@@ -54,7 +53,7 @@ int renwin_surface_scale(UNUSED RenWindow *ren) {
 }
 
 
-static RenRect scaled_rect(const RenRect rect, const int scale) {
+static RenRect scaled_rect(const RenRect rect, const float scale) {
   return (RenRect) {rect.x * scale, rect.y * scale, rect.width * scale, rect.height * scale};
 }
 
@@ -102,7 +101,7 @@ void renwin_show_window(RenWindow *ren) {
 
 void renwin_update_rects(RenWindow *ren, RenRect *rects, int count) {
 #ifdef LITE_USE_SDL_RENDERER
-  const int scale = ren->surface_scale;
+  const float scale = ren->surface_scale;
   for (int i = 0; i < count; i++) {
     const RenRect *r = &rects[i];
     const int x = scale * r->x, y = scale * r->y;

--- a/src/renwindow.c
+++ b/src/renwindow.c
@@ -9,7 +9,6 @@ static float query_surface_scale(RenWindow *ren) {
   SDL_GL_GetDrawableSize(ren->window, &w_pixels, &h_pixels);
   SDL_GetWindowSize(ren->window, &w_points, &h_points);
   float scale = (float) w_pixels / (float) w_points;
-  scale = roundf(scale * 100) / 100;
   return scale;
 }
 

--- a/src/renwindow.h
+++ b/src/renwindow.h
@@ -8,13 +8,13 @@ struct RenWindow {
   SDL_Renderer *renderer;
   SDL_Texture *texture;
   SDL_Surface *surface;
-  int surface_scale;
+  float surface_scale;
 #endif
 };
 typedef struct RenWindow RenWindow;
 
 void renwin_init_surface(RenWindow *ren);
-int  renwin_surface_scale(RenWindow *ren);
+float renwin_surface_scale(RenWindow *ren);
 void renwin_clip_to_surface(RenWindow *ren);
 void renwin_set_clip_rect(RenWindow *ren, RenRect rect);
 void renwin_resize_surface(RenWindow *ren);

--- a/src/renwindow.h
+++ b/src/renwindow.h
@@ -8,13 +8,14 @@ struct RenWindow {
   SDL_Renderer *renderer;
   SDL_Texture *texture;
   SDL_Surface *surface;
-  float surface_scale;
+  float surface_scale_x;
+  float surface_scale_y;
 #endif
 };
 typedef struct RenWindow RenWindow;
 
 void renwin_init_surface(RenWindow *ren);
-float renwin_surface_scale(RenWindow *ren);
+void renwin_surface_scale(RenWindow *ren, float *scale_x, float *scale_y);
 void renwin_clip_to_surface(RenWindow *ren);
 void renwin_set_clip_rect(RenWindow *ren, RenRect rect);
 void renwin_resize_surface(RenWindow *ren);


### PR DESCRIPTION
This PR modifies the get_scale() C function used on main to calculate the initical scale by using a base width and height which works better than current strategy based on the dpi value returned by sdl, 1280x720 was chosen as base because it is legible with the default font size of 15, here a comparison of before and after on differently tested resolutions:

1400x900 before
![1400x900-by-dpi](https://user-images.githubusercontent.com/1702572/170557447-ba740b92-b733-40bb-bbac-3533bd0f5d17.png)

1400x900 after
![1400x900-by-bw](https://user-images.githubusercontent.com/1702572/170557611-5c90e63f-9d4f-40f4-ba3c-61c5b66019ce.png)

1600x900 before
![1600x900-by-dpi](https://user-images.githubusercontent.com/1702572/170557673-f70e23ba-fc63-469d-af47-e3fa5ec056b7.png)

1600x900 after
![1600x900-by-bw](https://user-images.githubusercontent.com/1702572/170557776-0816e63f-bf37-4f62-aaa4-a39d0146fb9a.png)

1920x1080 before
![1920x1080-by-dpi](https://user-images.githubusercontent.com/1702572/170557844-884d90ff-364a-4400-a816-fa13f2d12e0e.png)

1920x1080 after
![1920x1080-by-bw](https://user-images.githubusercontent.com/1702572/170557887-ac353770-d1cd-4795-8e00-8e92bbdb1233.png)









