### PR TITLE
Allow regexes in `tokenizer` to split tokens with groups

### DIFF
--- a/data/core/regex.lua
+++ b/data/core/regex.lua
@@ -5,8 +5,9 @@ regex.__index = function(table, key) return regex[key]; end
 regex.match = function(pattern_string, string, offset, options)
   local pattern = type(pattern_string) == "table" and
     pattern_string or regex.compile(pattern_string)
-  local s, e = regex.cmatch(pattern, string, offset or 1, options or 0)
-  return s, e and e - 1
+  local res = { regex.cmatch(pattern, string, offset or 1, options or 0) }
+  res[2] = res[2] and res[2] - 1
+  return table.unpack(res)
 end
 
 -- Will iterate back through any UTF-8 bytes so that we don't replace bits

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -174,6 +174,17 @@ function tokenizer.tokenize(incoming_syntax, text, state)
       if p.regex and #res > 0 then -- set correct utf8 len for regex result
         res[2] = res[1] + string.ulen(text:sub(res[1], res[2])) - 1
         res[1] = next
+        -- `regex.match` returns group results as a series of `begin, end`
+        -- we only want `begin`s
+        for i=1,(#res-3) do
+          local curr = i + 3
+          local from = i * 2 + 3
+          if from < #res then
+            res[curr] = string.uoffset(text, res[from])
+          else
+            res[curr] = nil
+          end
+        end
       end
       if res[1] and close and target[3] then
         local count = 0

--- a/src/api/regex.c
+++ b/src/api/regex.c
@@ -88,7 +88,7 @@ static int f_pcre_match(lua_State *L) {
     return 0;
   }
   for (int i = 0; i < rc*2; i++)
-    lua_pushnumber(L, ovector[i]+offset+1);
+    lua_pushinteger(L, ovector[i]+offset+1);
   pcre2_match_data_free(md);
   return rc*2;
 }


### PR DESCRIPTION
This implements the same syntax used for tokenizer patterns. That is, splitting the token using empty groups.

This needs a good dose of UTF-8 testing.