### PR TITLE
Add options table to `CommandView:enter`

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -423,21 +423,23 @@ local commands = {
       end
     end
 
-    core.command_view:enter("Go To Line", function(text, item)
-      local line = item and item.line or tonumber(text)
-      if not line then
-        core.error("Invalid line number or unmatched string")
-        return
+    core.command_view:enter("Go To Line", {
+      submit = function(text, item)
+        local line = item and item.line or tonumber(text)
+        if not line then
+          core.error("Invalid line number or unmatched string")
+          return
+        end
+        dv.doc:set_selection(line, 1  )
+        dv:scroll_to_line(line, true)
+      end,
+      suggest = function(text)
+        if not text:find("^%d*$") then
+          init_items()
+          return common.fuzzy_match(items, text)
+        end
       end
-      dv.doc:set_selection(line, 1  )
-      dv:scroll_to_line(line, true)
-
-    end, function(text)
-      if not text:find("^%d*$") then
-        init_items()
-        return common.fuzzy_match(items, text)
-      end
-    end)
+    })
   end,
 
   ["doc:toggle-line-ending"] = function()
@@ -452,11 +454,14 @@ local commands = {
       local dirname, filename = core.last_active_view.doc.abs_filename:match("(.*)[/\\](.+)$")
       core.command_view:set_text(core.normalize_to_project_dir(dirname) .. PATHSEP)
     end
-    core.command_view:enter("Save As", function(filename)
-      save(common.home_expand(filename))
-    end, function (text)
-      return common.home_encode_list(common.path_suggest(common.home_expand(text)))
-    end)
+    core.command_view:enter("Save As", {
+      submit = function(filename)
+        save(common.home_expand(filename))
+      end,
+      suggest = function (text)
+        return common.home_encode_list(common.path_suggest(common.home_expand(text)))
+      end
+    })
   end,
 
   ["doc:save"] = function()
@@ -478,15 +483,18 @@ local commands = {
       return
     end
     core.command_view:set_text(old_filename)
-    core.command_view:enter("Rename", function(filename)
-      save(common.home_expand(filename))
-      core.log("Renamed \"%s\" to \"%s\"", old_filename, filename)
-      if filename ~= old_filename then
-        os.remove(old_filename)
+    core.command_view:enter("Rename", {
+      submit = function(filename)
+        save(common.home_expand(filename))
+        core.log("Renamed \"%s\" to \"%s\"", old_filename, filename)
+        if filename ~= old_filename then
+          os.remove(old_filename)
+        end
+      end,
+      suggest = function (text)
+        return common.home_encode_list(common.path_suggest(common.home_expand(text)))
       end
-    end, function (text)
-      return common.home_encode_list(common.path_suggest(common.home_expand(text)))
-    end)
+    })
   end,
 
 

--- a/data/core/commands/files.lua
+++ b/data/core/commands/files.lua
@@ -4,11 +4,13 @@ local common = require "core.common"
 
 command.add(nil, {
   ["files:create-directory"] = function()
-    core.command_view:enter("New directory name", function(text)
-      local success, err, path = common.mkdirp(text)
-      if not success then
-        core.error("cannot create directory %q: %s", path, err)
+    core.command_view:enter("New directory name", {
+      submit = function(text)
+        local success, err, path = common.mkdirp(text)
+        if not success then
+          core.error("cannot create directory %q: %s", path, err)
+        end
       end
-    end)
+    })
   end,
 })

--- a/data/core/commands/statusbar.lua
+++ b/data/core/commands/statusbar.lua
@@ -50,20 +50,20 @@ command.add(nil, {
     core.status_view:display_messages(true)
   end,
   ["status-bar:hide-item"] = function()
-    core.command_view:enter("Status bar item to hide",
-      function(text, item)
+    core.command_view:enter("Status bar item to hide", {
+      submit = function(text, item)
         core.status_view:hide_items(item.name)
       end,
-      status_view_get_items
-    )
+      suggest = status_view_get_items
+    })
   end,
   ["status-bar:show-item"] = function()
-    core.command_view:enter("Status bar item to show",
-      function(text, item)
+    core.command_view:enter("Status bar item to show", {
+      submit = function(text, item)
         core.status_view:show_items(item.name)
       end,
-      status_view_get_items
-    )
+      suggest = status_view_get_items
+    })
   end,
   ["status-bar:reset-items"] = function()
     core.status_view:show_items()

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -65,19 +65,22 @@ end
 function DocView:try_close(do_close)
   if self.doc:is_dirty()
   and #core.get_views_referencing_doc(self.doc) == 1 then
-    core.command_view:enter("Unsaved Changes; Confirm Close", function(_, item)
-      if item.text:match("^[cC]") then
-        do_close()
-      elseif item.text:match("^[sS]") then
-        self.doc:save()
-        do_close()
+    core.command_view:enter("Unsaved Changes; Confirm Close", {
+      submit = function(_, item)
+        if item.text:match("^[cC]") then
+          do_close()
+        elseif item.text:match("^[sS]") then
+          self.doc:save()
+          do_close()
+        end
+      end,
+      suggest = function(text)
+        local items = {}
+        if not text:find("^[^cC]") then table.insert(items, "Close Without Saving") end
+        if not text:find("^[^sS]") then table.insert(items, "Save And Close") end
+        return items
       end
-    end, function(text)
-      local items = {}
-      if not text:find("^[^cC]") then table.insert(items, "Close Without Saving") end
-      if not text:find("^[^sS]") then table.insert(items, "Save And Close") end
-      return items
-    end)
+    })
   else
     do_close()
   end

--- a/data/plugins/detectindent.lua
+++ b/data/plugins/detectindent.lua
@@ -300,22 +300,20 @@ local function set_indent_type(doc, type)
 end
 
 local function set_indent_type_command()
-  core.command_view:enter(
-    "Specify indent style for this file",
-    function(value) -- submit
+  core.command_view:enter("Specify indent style for this file", {
+    submit = function(value)
       local doc = core.active_view.doc
       value = value:lower()
       set_indent_type(doc, value == "tabs" and "hard" or "soft")
     end,
-    function(text) -- suggest
+    suggest = function(text)
       return common.fuzzy_match({"tabs", "spaces"}, text)
     end,
-    nil, -- cancel
-    function(text) -- validate
+    validate = function(text)
       local t = text:lower()
       return t == "tabs" or t == "spaces"
     end
-  )
+  })
 end
 
 
@@ -330,20 +328,17 @@ local function set_indent_size(doc, size)
 end
 
 local function set_indent_size_command()
-  core.command_view:enter(
-    "Specify indent size for current file",
-    function(value) -- submit
+  core.command_view:enter("Specify indent size for current file", {
+    submit = function(value)
       value = math.floor(tonumber(value))
       local doc = core.active_view.doc
       set_indent_size(doc, value)
     end,
-    nil, -- suggest
-    nil, -- cancel
-    function(value) -- validate
+    validate = function(value)
       value = tonumber(value)
       return value ~= nil and value >= 1
     end
-  )
+  })
 end
 
 

--- a/data/plugins/projectsearch.lua
+++ b/data/plugins/projectsearch.lua
@@ -244,30 +244,36 @@ end
 command.add(nil, {
   ["project-search:find"] = function()
     set_command_view_text()
-    core.command_view:enter("Find Text In Project", function(text)
-      text = text:lower()
-      begin_search(text, function(line_text)
-        return line_text:lower():find(text, nil, true)
-      end)
-    end)
+    core.command_view:enter("Find Text In Project", {
+      submit = function(text)
+        text = text:lower()
+        begin_search(text, function(line_text)
+          return line_text:lower():find(text, nil, true)
+        end)
+      end
+    })
   end,
 
   ["project-search:find-regex"] = function()
-    core.command_view:enter("Find Regex In Project", function(text)
-      local re = regex.compile(text, "i")
-      begin_search(text, function(line_text)
-        return regex.cmatch(re, line_text)
-      end)
-    end)
+    core.command_view:enter("Find Regex In Project", {
+      submit = function(text)
+        local re = regex.compile(text, "i")
+        begin_search(text, function(line_text)
+          return regex.cmatch(re, line_text)
+        end)
+      end
+    })
   end,
 
   ["project-search:fuzzy-find"] = function()
     set_command_view_text()
-    core.command_view:enter("Fuzzy Find Text In Project", function(text)
-      begin_search(text, function(line_text)
-        return common.fuzzy_match(line_text, text) and 1
-      end)
-    end)
+    core.command_view:enter("Fuzzy Find Text In Project", {
+      submit = function(text)
+        begin_search(text, function(line_text)
+          return common.fuzzy_match(line_text, text) and 1
+        end)
+      end
+    })
   end,
 })
 

--- a/data/plugins/tabularize.lua
+++ b/data/plugins/tabularize.lua
@@ -42,20 +42,22 @@ end
 
 command.add("core.docview", {
   ["tabularize:tabularize"] = function()
-    core.command_view:enter("Tabularize On Delimiter", function(delim)
-      if delim == "" then delim = " " end
+    core.command_view:enter("Tabularize On Delimiter", {
+      submit = function(delim)
+        if delim == "" then delim = " " end
 
-      local doc = core.active_view.doc
-      local line1, col1, line2, col2, swap = doc:get_selection(true)
-      line1, col1 = doc:position_offset(line1, col1, translate.start_of_line)
-      line2, col2 = doc:position_offset(line2, col2, translate.end_of_line)
-      doc:set_selection(line1, col1, line2, col2, swap)
-
-      doc:replace(function(text)
-        local lines = gmatch_to_array(text, "[^\n]*\n?")
-        tabularize_lines(lines, delim)
-        return table.concat(lines)
-      end)
-    end)
+        local doc = core.active_view.doc
+        local line1, col1, line2, col2, swap = doc:get_selection(true)
+        line1, col1 = doc:position_offset(line1, col1, translate.start_of_line)
+        line2, col2 = doc:position_offset(line2, col2, translate.end_of_line)
+        doc:set_selection(line1, col1, line2, col2, swap)
+  
+        doc:replace(function(text)
+          local lines = gmatch_to_array(text, "[^\n]*\n?")
+          tabularize_lines(lines, delim)
+          return table.concat(lines)
+        end)
+      end
+    })
   end,
 })


### PR DESCRIPTION
With this PR we can now more easily add options to the `CommandView` `state`.
This also allows for a simpler way to provide behavior functions.

The options that are available now are:
```lua
{
  submit = noop,
  suggest = noop,
  cancel = noop,
  validate = function() return true end,
  typeahead = true,
  wrap = true,
}
```

The old behavior is kept for compatibility, but a warning is shown if used.