### PR TITLE
Add `warn` log level and backtraces

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1056,7 +1056,7 @@ function core.get_views_referencing_doc(doc)
 end
 
 
-function log(level, show, backtrace, fmt, ...)
+function core.custom_log(level, show, backtrace, fmt, ...)
   local text = string.format(fmt, ...)
   if show then
     local s = style.log[level]
@@ -1081,20 +1081,20 @@ end
 
 
 function core.log(...)
-  return log("INFO", true, false, ...)
+  return core.custom_log("INFO", true, false, ...)
 end
 
 
 function core.log_quiet(...)
-  return log("INFO", false, false, ...)
+  return core.custom_log("INFO", false, false, ...)
 end
 
 function core.warn(...)
-  return log("WARN", true, true, ...)
+  return core.custom_log("WARN", true, true, ...)
 end
 
 function core.error(...)
-  return log("ERROR", true, true, ...)
+  return core.custom_log("ERROR", true, true, ...)
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1056,7 +1056,7 @@ function core.get_views_referencing_doc(doc)
 end
 
 
-local function log(level, show, fmt, ...)
+function log(level, show, backtrace, fmt, ...)
   local text = string.format(fmt, ...)
   if show then
     local s = style.log[level]
@@ -1069,7 +1069,8 @@ local function log(level, show, fmt, ...)
     level = level,
     text = text,
     time = os.time(),
-    at = at
+    at = at,
+    info = backtrace and debug.traceback(nil, 2):gsub("\t", "")
   }
   table.insert(core.log_items, item)
   if #core.log_items > config.max_log_items then
@@ -1080,17 +1081,17 @@ end
 
 
 function core.log(...)
-  return log("INFO", true, ...)
+  return log("INFO", true, false, ...)
 end
 
 
 function core.log_quiet(...)
-  return log("INFO", false, ...)
+  return log("INFO", false, false, ...)
 end
 
 
 function core.error(...)
-  return log("ERROR", true, ...)
+  return log("ERROR", true, true, ...)
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1089,6 +1089,9 @@ function core.log_quiet(...)
   return log("INFO", false, false, ...)
 end
 
+function core.warn(...)
+  return log("WARN", true, true, ...)
+end
 
 function core.error(...)
   return log("ERROR", true, true, ...)

--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -76,6 +76,7 @@ style.syntax_fonts = {}
 
 style.log = {
   INFO  = { icon = "i", color = style.text },
+  WARN  = { icon = "!", color = style.warn },
   ERROR = { icon = "!", color = style.error }
 }
 


### PR DESCRIPTION
This PR:
* adds the `core.warn` log function,
* exposes the `core.custom_log` function to create custom log entries,
* makes the `warn` and `error` log entries acquire the backtrace.