### PR TITLE
`TreeView` improvements for multi-project

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -140,9 +140,25 @@ function common.fuzzy_match_with_recents(haystack, recents, needle)
 end
 
 
-function common.path_suggest(text)
+function common.path_suggest(text, root)
+  if root and root:sub(-1) ~= PATHSEP then
+    root = root .. PATHSEP
+  end
   local path, name = text:match("^(.-)([^/\\]*)$")
-  local files = system.list_dir(path == "" and "." or path) or {}
+  -- ignore root if path is absolute
+  local is_absolute = common.is_absolute_path(text)
+  if not is_absolute then
+    if path == "" then
+      path = root or "."
+    else
+      path = (root or "") .. path
+    end
+  end
+
+  local files = system.list_dir(path) or {}
+  if path:sub(-1) ~= PATHSEP then
+    path = path .. PATHSEP
+  end
   local res = {}
   for _, file in ipairs(files) do
     file = path .. file
@@ -150,6 +166,13 @@ function common.path_suggest(text)
     if info then
       if info.type == "dir" then
         file = file .. PATHSEP
+      end
+      if root then
+        -- remove root part from file path
+        local s, e = file:find(root, nil, true)
+        if s == 1 then
+          file = file:sub(e + 1)
+        end
       end
       if file:lower():find(text:lower(), nil, true) == 1 then
         table.insert(res, file)

--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -385,6 +385,11 @@ function common.normalize_path(filename)
 end
 
 
+function common.is_absolute_path(path)
+  return path:sub(1, 1) == PATHSEP or path:match("^(%a):\\")
+end
+
+
 function common.path_belongs_to(filename, path)
   return string.find(filename, path .. PATHSEP, 1, true) == 1
 end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -605,7 +605,7 @@ end
 -- This function should get only filenames normalized using
 -- common.normalize_path function.
 function core.project_absolute_path(filename)
-  if filename:match('^%a:\\') or filename:find('/', 1, true) == 1 then
+  if common.is_absolute_path(filename) then
     return common.normalize_path(filename)
   elseif not core.project_dir then
     local cwd = system.absolute_path(".")


### PR DESCRIPTION
This PR fixes #1006 and other issues found while testing `TreeView` with multiple top directories. 

* `common.path_suggest` now accepts a 'root' parameter for relative paths to start from.
* Added `common.is_absolute_path`.
* Added `TreeView:get_item`, `TreeView:get_next` and `TreeView:get_previous` helper functions.
* Added `is_primary_project_folder`; `is_project_folder` now applies to any top directory.
* Added `treeview:remove-project-directory` command and relative `Remove directory` context menu item.
* `treeview:expand` now goes to the first child if called on an expanded directory.
* `treeview:new-file`, `treeview:new-folder`, `treeview:delete` and `treeview:rename` now work with multi-project-dirs.

#### TODO:
- [ ] add documentation for new methods 