### PR TITLE
Added Release Workflow and Fixed some build script issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
     - '*'
+  workflow_dispatch:
 
 jobs:
   archive_source_code:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
-        echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-linux-$(uname -m)" >> "$GITHUB_ENV"
+        echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-linux-$(uname -m)-portable" >> "$GITHUB_ENV"
     - uses: actions/checkout@v2
     - name: Python Setup
       uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,8 +166,12 @@ jobs:
     - name: Set Environment Variables
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-$(uname -m)" >> "$GITHUB_ENV"
         echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
+        if [[ "${MSYSTEM}" == "MINGW64" ]]; then
+          echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-x86_64" >> "$GITHUB_ENV"
+        else
+          echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-i686" >> "$GITHUB_ENV"
+        fi
     - name: Install Dependencies
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
       run: bash scripts/install-dependencies.sh --debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,21 +65,16 @@ jobs:
     - name: Install Dependencies
       if: ${{ !startsWith(github.ref, 'refs/tags/') }}
       run: bash scripts/install-dependencies.sh --debug
-    - name: Install Release Dependencies
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      run: |
-        bash scripts/install-dependencies.sh --debug --lhelper
-        bash scripts/lhelper.sh --debug
     - name: Build
       run: |
         bash --version
-        bash scripts/build.sh --debug --forcefallback
+        bash scripts/build.sh --debug --forcefallback --portable
     - name: Package
       if: ${{ matrix.config.cc == 'gcc' }}
       run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary
     - name: AppImage
-      if: ${{ matrix.config.cc == 'gcc' && startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/appimage.sh --nobuild --version ${INSTALL_REF}
+      if: ${{ matrix.config.cc == 'gcc' }}
+      run: bash scripts/appimage.sh --debug --addons --static --version ${INSTALL_REF}
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       if: ${{ matrix.config.cc == 'gcc' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
     - name: Build
       run: |
         bash --version
-        bash scripts/build.sh --debug --forcefallback
+        bash scripts/build.sh -U --debug --forcefallback
     - name: Error Logs
       if: failure()
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   archive_source_code:
     name: Source Code Tarball
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     # Only on tags/releases
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -25,7 +25,7 @@ jobs:
     - name: Python Setup
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.9
     - name: Install Dependencies
       run: |
         sudo apt-get install -qq ninja-build
@@ -40,7 +40,7 @@ jobs:
 
   build_linux:
     name: Linux
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         config:
@@ -60,7 +60,7 @@ jobs:
     - name: Python Setup
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.9
     - name: Update Packages
       run: sudo apt-get update
     - name: Install Dependencies
@@ -87,7 +87,7 @@ jobs:
 
   build_macos:
     name: macOS (x86_64)
-    runs-on: macos-10.15
+    runs-on: macos-11
     env:
       CC: clang
       CXX: clang++
@@ -209,7 +209,7 @@ jobs:
 
   deploy:
     name: Deployment
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 #   if: startsWith(github.ref, 'refs/tags/')
     if: false
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,43 +1,17 @@
 name: CI
 
-# All builds use lhelper only for releases,
-# otherwise for normal builds dependencies are dynamically linked.
-
 on:
   push:
     branches:
-    - '*'
-#   tags:
-#   - 'v[0-9]*'
+      - '*'
+
   pull_request:
     branches:
-    - '*'
+      - '*'
+
   workflow_dispatch:
 
 jobs:
-  archive_source_code:
-    name: Source Code Tarball
-    runs-on: ubuntu-22.04
-    # Only on tags/releases
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-    - uses: actions/checkout@v2
-    - name: Python Setup
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install Dependencies
-      run: |
-        sudo apt-get install -qq ninja-build
-        pip3 install meson
-    - name: Package
-      shell: bash
-      run: bash scripts/package.sh --version ${GITHUB_REF##*/} --debug --source
-    - uses: actions/upload-artifact@v2
-      with:
-        name: Source Code Tarball
-        path: "lite-xl-*-src.tar.gz"
-
   build_linux:
     name: Linux
     runs-on: ubuntu-22.04
@@ -50,40 +24,34 @@ jobs:
       CC: ${{ matrix.config.cc }}
       CXX: ${{ matrix.config.cxx }}
     steps:
-    - name: Set Environment Variables
-      if: ${{ matrix.config.cc == 'gcc' }}
-      run: |
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
-        echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-linux-$(uname -m)-portable" >> "$GITHUB_ENV"
-    - uses: actions/checkout@v2
-    - name: Python Setup
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Update Packages
-      run: sudo apt-get update
-    - name: Install Dependencies
-      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/install-dependencies.sh --debug
-    - name: Build
-      run: |
-        bash --version
-        bash scripts/build.sh --debug --forcefallback --portable
-    - name: Package
-      if: ${{ matrix.config.cc == 'gcc' }}
-      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary
-    - name: AppImage
-      if: ${{ matrix.config.cc == 'gcc' }}
-      run: bash scripts/appimage.sh --debug --addons --static --version ${INSTALL_REF}
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
-      if: ${{ matrix.config.cc == 'gcc' }}
-      with:
-        name: Linux Artifacts
-        path: |
-          ${{ env.INSTALL_NAME }}.tar.gz
-          LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
+      - name: Set Environment Variables
+        if: ${{ matrix.config.cc == 'gcc' }}
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
+          echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-linux-$(uname -m)-portable" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v2
+      - name: Python Setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Update Packages
+        run: sudo apt-get update
+      - name: Install Dependencies
+        run: bash scripts/install-dependencies.sh --debug
+      - name: Build
+        run: |
+          bash --version
+          bash scripts/build.sh --debug --forcefallback --portable
+      - name: Package
+        if: ${{ matrix.config.cc == 'gcc' }}
+        run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ matrix.config.cc == 'gcc' }}
+        with:
+          name: Linux Artifacts
+          path: ${{ env.INSTALL_NAME }}.tar.gz
 
   build_macos:
     name: macOS (x86_64)
@@ -92,56 +60,35 @@ jobs:
       CC: clang
       CXX: clang++
     steps:
-    - name: System Information
-      run: |
-        system_profiler SPSoftwareDataType
-        bash --version
-        gcc -v
-        xcodebuild -version
-    - name: Set Environment Variables
-      run: |
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
-        echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-macos-$(uname -m)" >> "$GITHUB_ENV"
-    - uses: actions/checkout@v2
-    - name: Python Setup
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install Dependencies
-      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/install-dependencies.sh --debug
-    - name: Install Release Dependencies
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      run: |
-        bash scripts/install-dependencies.sh --debug --lhelper
-        bash scripts/lhelper.sh --debug
-    - name: Build
-      run: |
-        bash --version
-        bash scripts/build.sh --bundle --debug --forcefallback
-    - name: Error Logs
-      if: failure()
-      run: |
-        mkdir ${INSTALL_NAME}
-        cp /usr/var/lhenv/lite-xl/logs/* ${INSTALL_NAME}
-        tar czvf ${INSTALL_NAME}.tar.gz ${INSTALL_NAME}
-#   - name: Package
-#     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-#     run:  bash scripts/package.sh --version ${INSTALL_REF} --debug --addons
-    - name: Create DMG Image
-      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --dmg
-    - name: Upload DMG Image
-      uses: actions/upload-artifact@v2
-      with:
-        name: macOS DMG Image
-        path: ${{ env.INSTALL_NAME }}.dmg
-    - name: Upload Error Logs
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: Error Logs
-        path: ${{ env.INSTALL_NAME }}.tar.gz
+      - name: System Information
+        run: |
+          system_profiler SPSoftwareDataType
+          bash --version
+          gcc -v
+          xcodebuild -version
+      - name: Set Environment Variables
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
+          echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-macos-$(uname -m)" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v2
+      - name: Python Setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install Dependencies
+        run: bash scripts/install-dependencies.sh --debug
+      - name: Build
+        run: |
+          bash --version
+          bash scripts/build.sh --bundle --debug --forcefallback
+      - name: Create DMG Image
+        run: bash scripts/package.sh --version ${INSTALL_REF} --debug --dmg
+      - name: Upload DMG Image
+        uses: actions/upload-artifact@v2
+        with:
+          name: macOS DMG Image
+          path: ${{ env.INSTALL_NAME }}.dmg
 
   build_windows_msys2:
     name: Windows
@@ -156,7 +103,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: msys2/setup-msys2@v2
       with:
-        #msystem: MINGW64
         msystem: ${{ matrix.msystem }}
         update: true
         install: >-
@@ -173,80 +119,15 @@ jobs:
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-i686" >> "$GITHUB_ENV"
         fi
     - name: Install Dependencies
-      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
       run: bash scripts/install-dependencies.sh --debug
-    - name: Install Release Dependencies
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/install-dependencies.sh --debug --lhelper
     - name: Build
       run: |
         bash --version
         bash scripts/build.sh -U --debug --forcefallback
-    - name: Error Logs
-      if: failure()
-      run: |
-        mkdir ${INSTALL_NAME}
-        cp /usr/var/lhenv/lite-xl/logs/* ${INSTALL_NAME}
-        tar czvf ${INSTALL_NAME}.tar.gz ${INSTALL_NAME}
     - name: Package
-      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary
-    - name: Build Installer
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      run: bash scripts/innosetup/innosetup.sh --debug
+      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: Windows Artifacts
-        path: |
-          LiteXL*.exe
-          ${{ env.INSTALL_NAME }}.zip
-    - name: Upload Error Logs
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: Error Logs
-        path: ${{ env.INSTALL_NAME }}.tar.gz
-
-  deploy:
-    name: Deployment
-    runs-on: ubuntu-22.04
-#   if: startsWith(github.ref, 'refs/tags/')
-    if: false
-    needs:
-    - archive_source_code
-    - build_linux
-    - build_macos
-    - build_windows_msys2
-    steps:
-    - name: Set Environment Variables
-      run: echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
-    - uses: actions/download-artifact@v2
-      with:
-        name: Linux Artifacts
-    - uses: actions/download-artifact@v2
-      with:
-        name: macOS DMG Image
-    - uses: actions/download-artifact@v2
-      with:
-        name: Source Code Tarball
-    - uses: actions/download-artifact@v2
-      with:
-        name: Windows Artifacts
-    - name: Display File Information
-      shell: bash
-      run: ls -lR
-    # Note: not using `actions/create-release@v1`
-    #       because it cannot update an existing release
-    #       see https://github.com/actions/create-release/issues/29
-    - uses: softprops/action-gh-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ env.INSTALL_REF }}
-        name: Release ${{ env.INSTALL_REF }}
-        draft: false
-        prerelease: false
-        files: |
-          lite-xl-${{ env.INSTALL_REF }}-*
-          LiteXL*.AppImage
-          LiteXL*.exe
+        path: ${{ env.INSTALL_NAME }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
 
   archive_source_code:
     name: Source Code Tarball
+    # Disable this since github already provide source packages
+    if: false
     needs: release
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,12 +183,13 @@ jobs:
     - name: Set Environment Variables
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-$(uname -m)" >> "$GITHUB_ENV"
         echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
         if [[ "${MSYSTEM}" == "MINGW64" ]]; then
           echo "BUILD_ARCH=x86_64" >> "$GITHUB_ENV"
+          echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-x86_64" >> "$GITHUB_ENV"
         else
           echo "BUILD_ARCH=i686" >> "$GITHUB_ENV"
+          echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-i686" >> "$GITHUB_ENV"
         fi
     - name: Install Dependencies
       run: bash scripts/install-dependencies.sh --debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,224 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release Version
+        default: v2.1.0
+        required: true
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-18.04
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Fetch Version
+        id: tag
+        run: |
+          if [[ "${{ github.event.inputs.version }}" != "" ]]; then
+            echo ::set-output name=version::${{ github.event.inputs.version }}
+          else
+            echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+          fi
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.version }}
+          release_name: "Lite XL ${{ steps.tag.outputs.version }}"
+          draft: true
+          prerelease: false
+          body_path: changelog.md
+
+  archive_source_code:
+    name: Source Code Tarball
+    needs: release
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Python Setup
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install -qq ninja-build
+        pip3 install meson
+    - name: Package
+      shell: bash
+      run: bash scripts/package.sh --version ${{ needs.release.outputs.version }} --debug --source
+    - name: Upload Source Code Artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: lite-xl-${{ needs.release.outputs.version }}-src.tar.gz
+        asset_name: lite-xl-${{ needs.release.outputs.version }}-src.tar.gz
+        asset_content_type: application/gzip
+
+  build_linux:
+    name: Linux
+    needs: release
+    runs-on: ubuntu-18.04
+    env:
+      CC: gcc
+      CXX: g++
+    steps:
+    - name: Set Environment Variables
+      run: |
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
+        echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-linux-$(uname -m)-portable" >> "$GITHUB_ENV"
+    - uses: actions/checkout@v2
+    - name: Python Setup
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Update Packages
+      run: sudo apt-get update
+    - name: Install Dependencies
+      run: bash scripts/install-dependencies.sh --debug
+    - name: Build
+      run: |
+        bash --version
+        bash scripts/build.sh --debug --forcefallback --portable --release
+    - name: Package
+      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
+    - name: AppImage
+      run: bash scripts/appimage.sh --debug --addons --static --version ${INSTALL_REF} --release
+    - name: Upload Portable Artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ${{ env.INSTALL_NAME }}.tar.gz
+        asset_name: ${{ env.INSTALL_NAME }}.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload AppImage Artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
+        asset_name: LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
+        asset_content_type: application/x-executable
+
+  build_macos:
+    name: macOS (x86_64)
+    needs: release
+    runs-on: macos-10.15
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+    - name: System Information
+      run: |
+        system_profiler SPSoftwareDataType
+        bash --version
+        gcc -v
+        xcodebuild -version
+    - name: Set Environment Variables
+      run: |
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
+        echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-macos-$(uname -m)" >> "$GITHUB_ENV"
+    - uses: actions/checkout@v2
+    - name: Python Setup
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Dependencies
+      run: bash scripts/install-dependencies.sh --debug
+    - name: Build
+      run: |
+        bash --version
+        bash scripts/build.sh --bundle --debug --forcefallback --release
+    - name: Create DMG Image
+      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --dmg --release
+    - name: Upload DMG Image Artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ${{ env.INSTALL_NAME }}.dmg
+        asset_name: ${{ env.INSTALL_NAME }}.dmg
+        asset_content_type: application/x-bzip2
+
+  build_windows_msys2:
+    name: Windows
+    needs: release
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        msystem: [MINGW32, MINGW64]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msystem }}
+        update: true
+        install: >-
+          base-devel
+          git
+          zip
+    - name: Set Environment Variables
+      run: |
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-$(uname -m)" >> "$GITHUB_ENV"
+        echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
+        echo "BUILD_ARCH=$(uname -m)" >> "$GITHUB_ENV"
+    - name: Install Dependencies
+      run: bash scripts/install-dependencies.sh --debug
+    - name: Build
+      run: |
+        bash --version
+        bash scripts/build.sh --debug --forcefallback --release
+    - name: Package
+      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
+    - name: Get InnoSetup Version
+      run: |
+        echo "INNOVER=$(grep -E '#define\sMyAppVersion\s' build-windows-${BUILD_ARCH}/scripts/innosetup.iss | cut -d\" -f2)" >> "$GITHUB_ENV"
+        if [[ "${MSYSTEM}" == "MINGW64" ]]; then
+          echo "ARCHITECTURE=x86_64" >> "$GITHUB_ENV"
+        else
+          echo "ARCHITECTURE=i686" >> "$GITHUB_ENV"
+        fi
+    - name: Build Installer
+      run: bash scripts/innosetup/innosetup.sh --debug
+    - name: Upload Zip Artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ${{ env.INSTALL_NAME }}.zip
+        asset_name: ${{ env.INSTALL_NAME }}.zip
+        asset_content_type: application/zip
+    - name: Upload Setup Artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: LiteXL-${{ env.INNOVER }}-${{ env.ARCHITECTURE }}-setup.exe
+        asset_name: LiteXL-${{ env.INNOVER }}-${{ env.ARCHITECTURE }}-setup.exe
+        asset_content_type: application/x-dosexec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,11 @@ jobs:
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-$(uname -m)" >> "$GITHUB_ENV"
         echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-        echo "BUILD_ARCH=$(uname -m)" >> "$GITHUB_ENV"
+        if [[ "${MSYSTEM}" == "MINGW64" ]]; then
+          echo "BUILD_ARCH=x86_64" >> "$GITHUB_ENV"
+        else
+          echo "BUILD_ARCH=i686" >> "$GITHUB_ENV"
+        fi
     - name: Install Dependencies
       run: bash scripts/install-dependencies.sh --debug
     - name: Build
@@ -197,11 +201,6 @@ jobs:
     - name: Get InnoSetup Version
       run: |
         echo "INNOVER=$(grep -E '#define\sMyAppVersion\s' build-windows-${BUILD_ARCH}/scripts/innosetup.iss | cut -d\" -f2)" >> "$GITHUB_ENV"
-        if [[ "${MSYSTEM}" == "MINGW64" ]]; then
-          echo "ARCHITECTURE=x86_64" >> "$GITHUB_ENV"
-        else
-          echo "ARCHITECTURE=i686" >> "$GITHUB_ENV"
-        fi
     - name: Build Installer
       run: bash scripts/innosetup/innosetup.sh --debug
     - name: Upload Zip Artifact
@@ -219,6 +218,6 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       with:
         upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: LiteXL-${{ env.INNOVER }}-${{ env.ARCHITECTURE }}-setup.exe
-        asset_name: LiteXL-${{ env.INNOVER }}-${{ env.ARCHITECTURE }}-setup.exe
+        asset_path: LiteXL-${{ env.INNOVER }}-${{ env.BUILD_ARCH }}-setup.exe
+        asset_name: LiteXL-${{ env.INNOVER }}-${{ env.BUILD_ARCH }}-setup.exe
         asset_content_type: application/x-dosexec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,44 +32,14 @@ jobs:
           fi
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.tag.outputs.version }}
-          release_name: "Lite XL ${{ steps.tag.outputs.version }}"
+          name: Lite XL ${{ steps.tag.outputs.version }}
           draft: true
           prerelease: false
           body_path: changelog.md
-
-  archive_source_code:
-    name: Source Code Tarball
-    # Disable this since github already provide source packages
-    if: false
-    needs: release
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: Python Setup
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install Dependencies
-      run: |
-        sudo apt-get install -qq ninja-build
-        pip3 install meson
-    - name: Package
-      shell: bash
-      run: bash scripts/package.sh --version ${{ needs.release.outputs.version }} --debug --source
-    - name: Upload Source Code Artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: lite-xl-${{ needs.release.outputs.version }}-src.tar.gz
-        asset_name: lite-xl-${{ needs.release.outputs.version }}-src.tar.gz
-        asset_content_type: application/gzip
+          generate_release_notes: true
 
   build_linux:
     name: Linux
@@ -79,46 +49,42 @@ jobs:
       CC: gcc
       CXX: g++
     steps:
-    - name: Set Environment Variables
-      run: |
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-        echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-linux-$(uname -m)-portable" >> "$GITHUB_ENV"
-    - uses: actions/checkout@v2
-    - name: Python Setup
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Update Packages
-      run: sudo apt-get update
-    - name: Install Dependencies
-      run: bash scripts/install-dependencies.sh --debug
-    - name: Build
-      run: |
-        bash --version
-        bash scripts/build.sh --debug --forcefallback --portable --release
-    - name: Package
-      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
-    - name: AppImage
-      run: bash scripts/appimage.sh --debug --addons --static --version ${INSTALL_REF} --release
-    - name: Upload Portable Artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: ${{ env.INSTALL_NAME }}.tar.gz
-        asset_name: ${{ env.INSTALL_NAME }}.tar.gz
-        asset_content_type: application/gzip
-    - name: Upload AppImage Artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
-        asset_name: LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
-        asset_content_type: application/x-executable
+      - name: Set Environment Variables
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v2
+      - name: Python Setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Update Packages
+        run: sudo apt-get update
+      - name: Install Dependencies
+        run: |
+          bash scripts/install-dependencies.sh --debug
+          sudo apt-get install -y ccache
+      - name: Build Portable
+        run: |
+          bash --version
+          bash scripts/build.sh --debug --forcefallback --portable --release
+      - name: Package Portables
+        run: |
+          bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release
+          bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
+      - name: Build AppImages
+        run: |
+          bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release
+          bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}
+      - name: Upload Files
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.release.outputs.version }}
+          files: |
+            lite-xl-${{ env.INSTALL_REF }}-linux-x86_64-portable.tar.gz
+            lite-xl-${{ env.INSTALL_REF }}-addons-linux-x86_64-portable.tar.gz
+            LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
+            LiteXL-${{ env.INSTALL_REF }}-addons-x86_64.AppImage
 
   build_macos:
     name: macOS (x86_64)
@@ -128,39 +94,40 @@ jobs:
       CC: clang
       CXX: clang++
     steps:
-    - name: System Information
-      run: |
-        system_profiler SPSoftwareDataType
-        bash --version
-        gcc -v
-        xcodebuild -version
-    - name: Set Environment Variables
-      run: |
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-        echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-macos-$(uname -m)" >> "$GITHUB_ENV"
-    - uses: actions/checkout@v2
-    - name: Python Setup
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install Dependencies
-      run: bash scripts/install-dependencies.sh --debug
-    - name: Build
-      run: |
-        bash --version
-        bash scripts/build.sh --bundle --debug --forcefallback --release
-    - name: Create DMG Image
-      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --dmg --release
-    - name: Upload DMG Image Artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: ${{ env.INSTALL_NAME }}.dmg
-        asset_name: ${{ env.INSTALL_NAME }}.dmg
-        asset_content_type: application/x-bzip2
+      - name: System Information
+        run: |
+          system_profiler SPSoftwareDataType
+          bash --version
+          gcc -v
+          xcodebuild -version
+      - name: Set Environment Variables
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
+          echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-macos-$(uname -m)" >> "$GITHUB_ENV"
+          echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos-$(uname -m)" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v2
+      - name: Python Setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install Dependencies
+        run: bash scripts/install-dependencies.sh --debug
+      - name: Build
+        run: |
+          bash --version
+          bash scripts/build.sh --bundle --debug --forcefallback --release
+      - name: Create DMG Image
+        run: |
+          bash scripts/package.sh --version ${INSTALL_REF} --debug --dmg --release
+          bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --dmg --release
+      - name: Upload Files
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.release.outputs.version }}
+          files: |
+            ${{ env.INSTALL_NAME }}.dmg
+            ${{ env.INSTALL_NAME_ADDONS }}.dmg
 
   build_windows_msys2:
     name: Windows
@@ -173,54 +140,48 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: actions/checkout@v2
-    - uses: msys2/setup-msys2@v2
-      with:
-        msystem: ${{ matrix.msystem }}
-        update: true
-        install: >-
-          base-devel
-          git
-          zip
-    - name: Set Environment Variables
-      run: |
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-        if [[ "${MSYSTEM}" == "MINGW64" ]]; then
-          echo "BUILD_ARCH=x86_64" >> "$GITHUB_ENV"
-          echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-x86_64" >> "$GITHUB_ENV"
-        else
-          echo "BUILD_ARCH=i686" >> "$GITHUB_ENV"
-          echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-i686" >> "$GITHUB_ENV"
-        fi
-    - name: Install Dependencies
-      run: bash scripts/install-dependencies.sh --debug
-    - name: Build
-      run: |
-        bash --version
-        bash scripts/build.sh -U --debug --forcefallback --release
-    - name: Package
-      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
-    - name: Get InnoSetup Version
-      run: |
-        echo "INNOVER=$(grep -E '#define\sMyAppVersion\s' build-windows-${BUILD_ARCH}/scripts/innosetup.iss | cut -d\" -f2)" >> "$GITHUB_ENV"
-    - name: Build Installer
-      run: bash scripts/innosetup/innosetup.sh --debug
-    - name: Upload Zip Artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: ${{ env.INSTALL_NAME }}.zip
-        asset_name: ${{ env.INSTALL_NAME }}.zip
-        asset_content_type: application/zip
-    - name: Upload Setup Artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: LiteXL-${{ env.INNOVER }}-${{ env.BUILD_ARCH }}-setup.exe
-        asset_name: LiteXL-${{ env.INNOVER }}-${{ env.BUILD_ARCH }}-setup.exe
-        asset_content_type: application/x-dosexec
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: >-
+            base-devel
+            git
+            zip
+      - name: Set Environment Variables
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
+          if [[ "${MSYSTEM}" == "MINGW64" ]]; then
+            echo "BUILD_ARCH=x86_64" >> "$GITHUB_ENV"
+            echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-x86_64" >> "$GITHUB_ENV"
+            echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-windows-x86_64" >> "$GITHUB_ENV"
+          else
+            echo "BUILD_ARCH=i686" >> "$GITHUB_ENV"
+            echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-i686" >> "$GITHUB_ENV"
+            echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-windows-i686" >> "$GITHUB_ENV"
+          fi
+      - name: Install Dependencies
+        run: bash scripts/install-dependencies.sh --debug
+      - name: Build
+        run: |
+          bash --version
+          bash scripts/build.sh -U --debug --forcefallback --release
+      - name: Package
+        run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release
+      - name: Build Installer
+        run: bash scripts/innosetup/innosetup.sh --debug --version ${INSTALL_REF}
+      - name: Package With Addons
+        run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
+      - name: Build Installer With Addons
+        run: bash scripts/innosetup/innosetup.sh --debug --version ${INSTALL_REF} --addons
+      - name: Upload Files
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.release.outputs.version }}
+          files: |
+            ${{ env.INSTALL_NAME }}.zip
+            ${{ env.INSTALL_NAME_ADDONS }}.zip
+            LiteXL-${{ env.INSTALL_REF }}-${{ env.BUILD_ARCH }}-setup.exe
+            LiteXL-${{ env.INSTALL_REF }}-addons-${{ env.BUILD_ARCH }}-setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
     - name: Build
       run: |
         bash --version
-        bash scripts/build.sh --debug --forcefallback --release
+        bash scripts/build.sh -U --debug --forcefallback --release
     - name: Package
       run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
     - name: Get InnoSetup Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ steps.tag.outputs.version }}
@@ -47,13 +47,13 @@ jobs:
     # Disable this since github already provide source packages
     if: false
     needs: release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Python Setup
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.9
     - name: Install Dependencies
       run: |
         sudo apt-get install -qq ninja-build
@@ -74,7 +74,7 @@ jobs:
   build_linux:
     name: Linux
     needs: release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CC: gcc
       CXX: g++
@@ -88,7 +88,7 @@ jobs:
     - name: Python Setup
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.9
     - name: Update Packages
       run: sudo apt-get update
     - name: Install Dependencies
@@ -123,7 +123,7 @@ jobs:
   build_macos:
     name: macOS (x86_64)
     needs: release
-    runs-on: macos-10.15
+    runs-on: macos-11
     env:
       CC: clang
       CXX: clang++

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2021 Francesco Abbate
+Copyright (c) 2020-2021 Lite XL Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -37,6 +37,7 @@ show_help() {
   echo "-D --dmg                  Create a DMG disk image (macOS only)."
   echo "                          Requires NPM and AppDMG."
   echo "-I --innosetup            Create an InnoSetup installer (Windows only)."
+  echo "-r --release              Compile in release mode."
   echo "-S --source               Create a source code package,"
   echo "                          including subprojects dependencies."
   echo
@@ -58,6 +59,7 @@ main() {
   local innosetup
   local portable
   local pgo
+  local release
 
   for i in "$@"; do
     case $i in
@@ -109,6 +111,10 @@ main() {
         portable="--portable"
         shift
         ;;
+      -r|--release)
+        release="--release"
+        shift
+        ;;
       -S|--source)
         source="--source"
         shift
@@ -145,6 +151,7 @@ main() {
     $force_fallback \
     $bundle \
     $portable \
+    $release \
     $pgo
 
   source scripts/package.sh \
@@ -158,6 +165,7 @@ main() {
     $appimage \
     $dmg \
     $innosetup \
+    $release \
     $source
 }
 

--- a/meson.build
+++ b/meson.build
@@ -103,7 +103,6 @@ if not get_option('source-only')
     sdl_options = ['default_library=static']
 
     # we explicitly need these
-    sdl_options += 'test=false'
     sdl_options += 'use_loadso=enabled'
     sdl_options += 'prefer_dlopen=true'
     sdl_options += 'use_video=enabled'

--- a/meson.build
+++ b/meson.build
@@ -109,7 +109,6 @@ if not get_option('source-only')
     sdl_options += 'use_atomic=enabled'
     sdl_options += 'use_threads=enabled'
     sdl_options += 'use_timers=enabled'
-    sdl_options += 'use_render=enabled'
     # investigate if this is truly needed
     # Do not remove before https://github.com/libsdl-org/SDL/issues/5413 is released
     sdl_options += 'use_events=enabled'

--- a/meson.build
+++ b/meson.build
@@ -109,6 +109,7 @@ if not get_option('source-only')
     sdl_options += 'use_atomic=enabled'
     sdl_options += 'use_threads=enabled'
     sdl_options += 'use_timers=enabled'
+    sdl_options += 'use_render=enabled'
     # investigate if this is truly needed
     # Do not remove before https://github.com/libsdl-org/SDL/issues/5413 is released
     sdl_options += 'use_events=enabled'

--- a/meson.build
+++ b/meson.build
@@ -103,6 +103,7 @@ if not get_option('source-only')
     sdl_options = ['default_library=static']
 
     # we explicitly need these
+    sdl_options += 'test=false'
     sdl_options += 'use_loadso=enabled'
     sdl_options += 'prefer_dlopen=true'
     sdl_options += 'use_video=enabled'

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -13,6 +13,7 @@ BUILD_DIR="$(get_default_build_dir)"
 RUN_BUILD=true
 STATIC_BUILD=false
 ADDONS=false
+BUILD_TYPE="debug"
 
 show_help(){
   echo
@@ -28,6 +29,7 @@ show_help(){
   echo "-s --static               Specify if building using static libraries."
   echo "-v --version VERSION      Specify a version, non whitespace separated string."
   echo "-a --addons               Install 3rd party addons."
+  echo "-r --release              Compile in release mode."
   echo
 }
 
@@ -54,6 +56,10 @@ for i in "$@"; do
       ;;
     -n|--nobuild)
       RUN_BUILD=false
+      shift
+      ;;
+    -r|--release)
+      BUILD_TYPE="release"
       shift
       ;;
     -s|--static)
@@ -111,10 +117,10 @@ build_litexl() {
   echo "Build lite-xl..."
   sleep 1
   if [[ $STATIC_BUILD == false ]]; then
-    meson setup --buildtype=release --prefix=/usr ${BUILD_DIR}
+    meson setup --buildtype=$BUILD_TYPE --prefix=/usr ${BUILD_DIR}
   else
     meson setup --wrap-mode=forcefallback \
-      --buildtype=release \
+      --buildtype=$BUILD_TYPE \
       --prefix=/usr \
       ${BUILD_DIR}
   fi

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -177,6 +177,10 @@ generate_appimage() {
     version="-$VERSION"
   fi
 
+  if [[ $ADDONS == true ]]; then
+    version="${version}-addons"
+  fi
+
   ./appimagetool LiteXL.AppDir LiteXL${version}-${ARCH}.AppImage
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,12 +25,14 @@ show_help() {
   echo "-U --windows-lua-utf      Use the UTF8 patch for Lua."
   echo "                          macOS: disabled when used with --bundle,"
   echo "                          Windows: Implicit being the only option."
+  echo "-r --release              Compile in release mode."
   echo
 }
 
 main() {
   local platform="$(get_platform_name)"
   local build_dir="$(get_default_build_dir)"
+  local build_type="debug"
   local prefix=/
   local force_fallback
   local bundle
@@ -84,6 +86,10 @@ main() {
         patch_lua="true"
         shift
         ;;
+      -r|--release)
+        build_type="release"
+        shift
+        ;;
       *)
         # unknown option
         ;;
@@ -103,7 +109,7 @@ main() {
   rm -rf "${build_dir}"
 
   CFLAGS=$CFLAGS LDFLAGS=$LDFLAGS meson setup \
-    --buildtype=release \
+    --buildtype=$build_type \
     --prefix "$prefix" \
     $force_fallback \
     $bundle \

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -69,7 +69,7 @@ get_platform_name() {
   fi
 }
 
-get_default_build_dir() {
+get_platform_arch() {
   platform=$(get_platform_name)
   arch=$(uname -m)
   if [[ $MSYSTEM != "" ]]; then
@@ -79,6 +79,12 @@ get_default_build_dir() {
       arch=i686
     fi
   fi
+  echo "$arch"
+}
+
+get_default_build_dir() {
+  platform=$(get_platform_name)
+  arch=$(get_platform_arch)
   echo "build-$platform-$arch"
 }
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -71,7 +71,15 @@ get_platform_name() {
 
 get_default_build_dir() {
   platform=$(get_platform_name)
-  echo "build-$platform-$(uname -m)"
+  arch=$(uname -m)
+  if [[ $MSYSTEM != "" ]]; then
+    if [[ $MSYSTEM == "MINGW64" ]]; then
+      arch=x86_64
+    else
+      arch=i686
+    fi
+  fi
+  echo "build-$platform-$arch"
 }
 
 if [[ $(get_platform_name) == "UNSUPPORTED-OS" ]]; then

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -55,6 +55,11 @@ addons_install() {
     cp -r "${build_dir}/third/data/plugins/${plugin_name}.lua" \
       "${data_dir}/plugins/"
   done
+
+  rm "${build_dir}/third/data/plugins/language_cpp.lua"
+
+  cp "${build_dir}/third/data/plugins/"language_* \
+      "${data_dir}/plugins/"
 }
 
 get_platform_name() {

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -2,6 +2,61 @@
 
 set -e
 
+addons_download() {
+  local build_dir="$1"
+
+  if [[ -d "${build_dir}/third/data/colors" ]]; then
+    echo "Warning: found previous addons installation, skipping."
+    echo "  addons path: ${build_dir}/third/data/colors"
+    return 0
+  fi
+
+  # Download third party color themes
+  curl --insecure \
+    -L "https://github.com/lite-xl/lite-xl-colors/archive/master.zip" \
+    -o "${build_dir}/lite-xl-colors.zip"
+
+  mkdir -p "${build_dir}/third/data/colors"
+  unzip "${build_dir}/lite-xl-colors.zip" -d "${build_dir}"
+  mv "${build_dir}/lite-xl-colors-master/colors" "${build_dir}/third/data"
+  rm -rf "${build_dir}/lite-xl-colors-master"
+
+  # Download widgets library
+  curl --insecure \
+    -L "https://github.com/lite-xl/lite-xl-widgets/archive/master.zip" \
+    -o "${build_dir}/lite-xl-widgets.zip"
+
+  unzip "${build_dir}/lite-xl-widgets.zip" -d "${build_dir}"
+  mv "${build_dir}/lite-xl-widgets-master" "${build_dir}/third/data/widget"
+
+  # Downlaod thirdparty plugins
+  curl --insecure \
+    -L "https://github.com/lite-xl/lite-xl-plugins/archive/2.1.zip" \
+    -o "${build_dir}/lite-xl-plugins.zip"
+
+  unzip "${build_dir}/lite-xl-plugins.zip" -d "${build_dir}"
+  mv "${build_dir}/lite-xl-plugins-2.1/plugins" "${build_dir}/third/data"
+  rm -rf "${build_dir}/lite-xl-plugins-2.1"
+}
+
+# Addons installation: some distributions forbid external downloads
+# so make it as optional module.
+addons_install() {
+  local build_dir="$1"
+  local data_dir="$2"
+
+  for module_name in colors widget; do
+    cp -r "${build_dir}/third/data/$module_name" "${data_dir}"
+  done
+
+  mkdir -p "${data_dir}/plugins"
+
+  for plugin_name in settings; do
+    cp -r "${build_dir}/third/data/plugins/${plugin_name}.lua" \
+      "${data_dir}/plugins/"
+  done
+}
+
 get_platform_name() {
   if [[ "$OSTYPE" == "msys" ]]; then
     echo "windows"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -56,8 +56,6 @@ addons_install() {
       "${data_dir}/plugins/"
   done
 
-  rm "${build_dir}/third/data/plugins/language_cpp.lua"
-
   cp "${build_dir}/third/data/plugins/"language_* \
       "${data_dir}/plugins/"
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -51,7 +51,7 @@ addons_install() {
 
   mkdir -p "${data_dir}/plugins"
 
-  for plugin_name in settings; do
+  for plugin_name in settings open_ext; do
     cp -r "${build_dir}/third/data/plugins/${plugin_name}.lua" \
       "${data_dir}/plugins/"
   done

--- a/scripts/innosetup/innosetup.iss.in
+++ b/scripts/innosetup/innosetup.iss.in
@@ -69,9 +69,7 @@ Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescrip
 Name: "portablemode"; Description: "Portable Mode"; Flags: unchecked
 
 [Files]
-Source: "{#BuildDir}/src/lite-xl.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "{#BuildDir}/mingwLibs{#Arch}/*"; DestDir: "{app}"; Flags: ignoreversion ; Check: DirExists(ExpandConstant('{#BuildDir}/mingwLibs{#Arch}'))
-Source: "{#SourceDir}/data/*"; DestDir: "{app}/data"; Flags: ignoreversion recursesubdirs
+Source: "{#SourceDir}/lite-xl/*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/scripts/innosetup/innosetup.sh
+++ b/scripts/innosetup/innosetup.sh
@@ -56,7 +56,11 @@ main() {
   # see https://github.com/msys2/MINGW-packages/issues/4164
   local mingwLibsDir="${build_dir}/mingwLibs$arch"
   mkdir -p "$mingwLibsDir"
-  ntldd -R "${build_dir}/src/lite-xl.exe" | grep mingw | awk '{print $3}' | sed 's#\\#/#g' | xargs -I '{}' cp -v '{}' $mingwLibsDir
+  ntldd -R "${build_dir}/src/lite-xl.exe" \
+    | grep mingw \
+    | awk '{print $3}' \
+    | sed 's#\\#/#g' \
+    | xargs -I '{}' cp -v '{}' $mingwLibsDir
 
   "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" -dARCH=$arch "${build_dir}/scripts/innosetup.iss"
   pushd "${build_dir}/scripts"; mv LiteXL*.exe "./../../"; popd

--- a/scripts/innosetup/innosetup.sh
+++ b/scripts/innosetup/innosetup.sh
@@ -57,6 +57,7 @@ main() {
   echo "Linked libraries:"
   ntldd -R "${build_dir}/src/lite-xl.exe"
 
+  echo "Copy dll's:"
   local mingwLibsDir="${build_dir}/mingwLibs$arch"
   mkdir -p "$mingwLibsDir"
   ntldd -R "${build_dir}/src/lite-xl.exe" \

--- a/scripts/innosetup/innosetup.sh
+++ b/scripts/innosetup/innosetup.sh
@@ -54,6 +54,9 @@ main() {
   # Copy MinGW libraries dependencies.
   # MSYS2 ldd command seems to be only 64bit, so use ntldd
   # see https://github.com/msys2/MINGW-packages/issues/4164
+  echo "Linked libraries:"
+  ntldd -R "${build_dir}/src/lite-xl.exe"
+
   local mingwLibsDir="${build_dir}/mingwLibs$arch"
   mkdir -p "$mingwLibsDir"
   ntldd -R "${build_dir}/src/lite-xl.exe" \

--- a/scripts/innosetup/innosetup.sh
+++ b/scripts/innosetup/innosetup.sh
@@ -51,21 +51,6 @@ main() {
     exit 1
   fi
 
-  # Copy MinGW libraries dependencies.
-  # MSYS2 ldd command seems to be only 64bit, so use ntldd
-  # see https://github.com/msys2/MINGW-packages/issues/4164
-  echo "Linked libraries:"
-  ntldd -R "${build_dir}/src/lite-xl.exe"
-
-  echo "Copy dll's:"
-  local mingwLibsDir="${build_dir}/mingwLibs$arch"
-  mkdir -p "$mingwLibsDir"
-  ntldd -R "${build_dir}/src/lite-xl.exe" \
-    | grep mingw \
-    | awk '{print $3}' \
-    | sed 's#\\#/#g' \
-    | xargs -I '{}' cp -v '{}' $mingwLibsDir
-
   "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" -dARCH=$arch "${build_dir}/scripts/innosetup.iss"
   pushd "${build_dir}/scripts"; mv LiteXL*.exe "./../../"; popd
 }

--- a/scripts/innosetup/innosetup.sh
+++ b/scripts/innosetup/innosetup.sh
@@ -15,15 +15,29 @@ show_help() {
   echo
   echo "-b --builddir DIRNAME     Sets the name of the build directory (not path)."
   echo "                          Default: '$(get_default_build_dir)'."
+  echo "-v --version VERSION      Sets the version on the package name."
+  echo "-a --addons               Tell the script we are packaging an install with addons."
   echo "   --debug                Debug this script."
   echo
 }
 
 main() {
   local build_dir=$(get_default_build_dir)
+  local addons=false
   local arch
+  local arch_file
+  local version
+  local output
 
-  if [[ $MSYSTEM == "MINGW64" ]]; then arch=x64; else arch=Win32; fi
+  if [[ $MSYSTEM == "MINGW64" ]]; then
+    arch=x64
+    arch_file=x86_64
+  else
+    arch=i686;
+    arch_file=i686
+  fi
+
+  initial_arg_count=$#
 
   for i in "$@"; do
     case $i in
@@ -31,8 +45,17 @@ main() {
         show_help
         exit 0
         ;;
+      -a|--addons)
+        addons=true
+        shift
+        ;;
       -b|--builddir)
         build_dir="$2"
+        shift
+        shift
+        ;;
+      -v|--version)
+        if [[ -n $2 ]]; then version="-$2"; fi
         shift
         shift
         ;;
@@ -46,12 +69,19 @@ main() {
     esac
   done
 
-  if [[ -n $1 ]]; then
+  # show help if no valid argument was found
+  if [ $initial_arg_count -eq $# ]; then
     show_help
     exit 1
   fi
 
-  "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" -dARCH=$arch "${build_dir}/scripts/innosetup.iss"
+  if [[ $addons == true ]]; then
+    version="${version}-addons"
+  fi
+
+  output="LiteXL${version}-${arch_file}-setup"
+
+  "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" -dARCH=$arch //F"${output}" "${build_dir}/scripts/innosetup.iss"
   pushd "${build_dir}/scripts"; mv LiteXL*.exe "./../../"; popd
 }
 

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -48,7 +48,7 @@ main() {
     if [[ $lhelper == true ]]; then
       sudo apt-get install -qq ninja-build
     else
-      sudo apt-get install -qq ninja-build libsdl2-dev libfreetype6
+      sudo apt-get install -qq ninja-build wayland-protocols libsdl2-dev libfreetype6
     fi
     pip3 install meson
   elif [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -48,7 +48,7 @@ main() {
     if [[ $lhelper == true ]]; then
       sudo apt-get install -qq ninja-build
     else
-      sudo apt-get install -qq ninja-build wayland-protocols libsdl2-dev libfreetype6
+      sudo apt-get install -qq libfuse2 ninja-build wayland-protocols libsdl2-dev libfreetype6
     fi
     pip3 install meson
   elif [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -186,6 +186,14 @@ main() {
     if [[ $platform == "windows" ]]; then
       exe_file="${exe_file}.exe"
       stripcmd="strip --strip-all"
+      # Copy MinGW libraries dependencies.
+      # MSYS2 ldd command seems to be only 64bit, so use ntldd
+      # see https://github.com/msys2/MINGW-packages/issues/4164
+      ntldd -R "${exe_file}" \
+        | grep mingw \
+        | awk '{print $3}' \
+        | sed 's#\\#/#g' \
+        | xargs -I '{}' cp -v '{}' "$(pwd)/${dest_dir}/"
     else
       # Windows archive is always portable
       package_name+="-portable"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -60,7 +60,7 @@ source_package() {
 }
 
 main() {
-  local arch="$(uname -m)"
+  local arch="$(get_platform_arch)"
   local platform="$(get_platform_name)"
   local build_dir="$(get_default_build_dir)"
   local dest_dir=lite-xl

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -27,6 +27,7 @@ show_help() {
   echo "                          depending on how the build was configured. (Default.)"
   echo "-D --dmg                  Create a DMG disk image with AppDMG (macOS only)."
   echo "-I --innosetup            Create a InnoSetup package (Windows only)."
+  echo "-r --release              Strip debugging symbols."
   echo "-S --source               Create a source code package,"
   echo "                          including subprojects dependencies."
   echo
@@ -70,8 +71,10 @@ main() {
   local binary=false
   local dmg=false
   local innosetup=false
+  local release=false
   local source=false
 
+  # store the current flags to easily pass them to appimage script
   local flags="$@"
 
   for i in "$@"; do
@@ -126,6 +129,10 @@ main() {
         else
           innosetup=true
         fi
+        shift
+        ;;
+      -r|--release)
+        release=true
         shift
         ;;
       -S|--source)
@@ -218,7 +225,9 @@ main() {
   find . -type d -empty -delete
   popd
 
-  $stripcmd "${exe_file}"
+  if [[ $release == true ]]; then
+    $stripcmd "${exe_file}"
+  fi
 
   echo "Creating a compressed archive ${package_name}"
   if [[ $binary == true ]]; then

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -153,6 +153,10 @@ main() {
     esac
   done
 
+  if [[ $addons == true ]]; then
+    version="$version-addons"
+  fi
+
   if [[ -n $1 ]]; then show_help; exit 1; fi
 
   # The source package doesn't require a previous build,
@@ -256,7 +260,7 @@ main() {
     source scripts/appdmg.sh "${package_name}"
   fi
   if [[ $innosetup == true ]]; then
-    source scripts/innosetup/innosetup.sh -b "${build_dir}"
+    source scripts/innosetup/innosetup.sh $flags
   fi
 }
 


### PR DESCRIPTION
Ok, so this PR includes various changes regarding the build scripts and a new `release.yml` workflow in order to finally be able to hit the button and make a release that builds working packages for each platform.

The release workflow can be manually triggered and  it lets you enter a version so one can trigger a build and make a draft release which can then be adjusted:

![2022-06-01_14:41:54](https://user-images.githubusercontent.com/1702572/171478823-4a78eb8c-eb21-4ea4-af6d-d8523009c03b.png)

Should also work on pushed tags but haven't tested that, but if it doesn't works we can adjust later.

## Some of the Changes 

* make builds properly static by forcing the meson fallback
* we now only depend on meson and forcefallback to generate the release static builds
* install wayland protocols on linux target for proper wayland support
* disabled x11 and wayland under mac which resulted on additional dependencies
* CI builds are now debug builds so they include debug symbols and git commit on version
* enabled some video subsystems for linux so the appimage and portable build launch properly
* enabled use_timers which is required for proper sdl time calculation which we rely on (fixes statusview neve hiding messages)
* fixed msys detected platform to properly report i686 on mingw32 build run and not only x86_64
* copy missing dll's to portable windows zip file
* fixed inno setup copying from the bare bone data dir instead of the one generated by meson
* changed license which is used on innosetup to reflect the entire litexl team
* added settings gui as addon
* added language plugins as addon
* other changes and fixes...