### PR TITLE
style: move default colors to its own style file

### DIFF
--- a/data/colors/default.lua
+++ b/data/colors/default.lua
@@ -1,0 +1,46 @@
+local style = require "core.style"
+local common = require "core.common"
+
+style.background = { common.color "#2e2e32" }  -- Docview
+style.background2 = { common.color "#252529" } -- Treeview
+style.background3 = { common.color "#252529" } -- Command view
+style.text = { common.color "#97979c" }
+style.caret = { common.color "#93DDFA" }
+style.accent = { common.color "#e1e1e6" }
+-- style.dim - text color for nonactive tabs, tabs divider, prefix in log and
+-- search result, hotkeys for context menu and command view
+style.dim = { common.color "#525257" }
+style.divider = { common.color "#202024" } -- Line between nodes
+style.selection = { common.color "#48484f" }
+style.line_number = { common.color "#525259" }
+style.line_number2 = { common.color "#83838f" } -- With cursor
+style.line_highlight = { common.color "#343438" }
+style.scrollbar = { common.color "#414146" }
+style.scrollbar2 = { common.color "#4b4b52" } -- Hovered
+style.scrollbar_track = { common.color "#252529" }
+style.nagbar = { common.color "#FF0000" }
+style.nagbar_text = { common.color "#FFFFFF" }
+style.nagbar_dim = { common.color "rgba(0, 0, 0, 0.45)" }
+style.drag_overlay = { common.color "rgba(255,255,255,0.1)" }
+style.drag_overlay_tab = { common.color "#93DDFA" }
+style.good = { common.color "#72b886" }
+style.warn = { common.color "#FFA94D" }
+style.error = { common.color "#FF3333" }
+style.modified = { common.color "#1c7c9c" }
+
+style.syntax["normal"] = { common.color "#e1e1e6" }
+style.syntax["symbol"] = { common.color "#e1e1e6" }
+style.syntax["comment"] = { common.color "#676b6f" }
+style.syntax["keyword"] = { common.color "#E58AC9" }  -- local function end if case
+style.syntax["keyword2"] = { common.color "#F77483" } -- self int float
+style.syntax["number"] = { common.color "#FFA94D" }
+style.syntax["literal"] = { common.color "#FFA94D" }  -- true false nil
+style.syntax["string"] = { common.color "#f7c95c" }
+style.syntax["operator"] = { common.color "#93DDFA" } -- = + - / < >
+style.syntax["function"] = { common.color "#93DDFA" }
+
+style.log["INFO"]  = { icon = "i", color = style.text }
+style.log["WARN"]  = { icon = "!", color = style.warn }
+style.log["ERROR"] = { icon = "!", color = style.error }
+
+return style

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -2,7 +2,7 @@ require "core.strict"
 require "core.regex"
 local common = require "core.common"
 local config = require "core.config"
-local style = require "core.style"
+local style = require "colors.default"
 local command
 local keymap
 local dirwatch

--- a/data/core/style.lua
+++ b/data/core/style.lua
@@ -28,44 +28,7 @@ style.icon_font = renderer.font.load(DATADIR .. "/fonts/icons.ttf", 16 * SCALE, 
 style.icon_big_font = style.icon_font:copy(23 * SCALE)
 style.code_font = renderer.font.load(DATADIR .. "/fonts/JetBrainsMono-Regular.ttf", 15 * SCALE)
 
-style.background = { common.color "#2e2e32" }  -- Docview
-style.background2 = { common.color "#252529" } -- Treeview
-style.background3 = { common.color "#252529" } -- Command view
-style.text = { common.color "#97979c" }
-style.caret = { common.color "#93DDFA" }
-style.accent = { common.color "#e1e1e6" }
--- style.dim - text color for nonactive tabs, tabs divider, prefix in log and
--- search result, hotkeys for context menu and command view
-style.dim = { common.color "#525257" }
-style.divider = { common.color "#202024" } -- Line between nodes
-style.selection = { common.color "#48484f" }
-style.line_number = { common.color "#525259" }
-style.line_number2 = { common.color "#83838f" } -- With cursor
-style.line_highlight = { common.color "#343438" }
-style.scrollbar = { common.color "#414146" }
-style.scrollbar2 = { common.color "#4b4b52" } -- Hovered
-style.scrollbar_track = { common.color "#252529" }
-style.nagbar = { common.color "#FF0000" }
-style.nagbar_text = { common.color "#FFFFFF" }
-style.nagbar_dim = { common.color "rgba(0, 0, 0, 0.45)" }
-style.drag_overlay = { common.color "rgba(255,255,255,0.1)" }
-style.drag_overlay_tab = { common.color "#93DDFA" }
-style.good = { common.color "#72b886" }
-style.warn = { common.color "#FFA94D" }
-style.error = { common.color "#FF3333" }
-style.modified = { common.color "#1c7c9c" }
-
 style.syntax = {}
-style.syntax["normal"] = { common.color "#e1e1e6" }
-style.syntax["symbol"] = { common.color "#e1e1e6" }
-style.syntax["comment"] = { common.color "#676b6f" }
-style.syntax["keyword"] = { common.color "#E58AC9" }  -- local function end if case
-style.syntax["keyword2"] = { common.color "#F77483" } -- self int float
-style.syntax["number"] = { common.color "#FFA94D" }
-style.syntax["literal"] = { common.color "#FFA94D" }  -- true false nil
-style.syntax["string"] = { common.color "#f7c95c" }
-style.syntax["operator"] = { common.color "#93DDFA" } -- = + - / < >
-style.syntax["function"] = { common.color "#93DDFA" }
 
 -- This can be used to override fonts per syntax group.
 -- The syntax highlighter will take existing values from this table and
@@ -74,10 +37,6 @@ style.syntax["function"] = { common.color "#93DDFA" }
 style.syntax_fonts = {}
 -- style.syntax_fonts["comment"] = renderer.font.load(path_to_font, size_of_font, rendering_options)
 
-style.log = {
-  INFO  = { icon = "i", color = style.text },
-  WARN  = { icon = "!", color = style.warn },
-  ERROR = { icon = "!", color = style.error }
-}
+style.log = {}
 
 return style


### PR DESCRIPTION
This allows to reapply default color style without destroying the style table, also allows other plugins like the select color scheme and settings to offer the option of selecting the default style:

![2022-06-02_19:16:06](https://user-images.githubusercontent.com/1702572/171753801-eb019647-3cec-4754-ada9-9bc9fc3a87ff.png)
