### PR TITLE
plugin linewrapping: added priority

### DIFF
--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -1,4 +1,4 @@
--- mod-version:3
+-- mod-version:3 --priority:10
 local core = require "core"
 local common = require "core.common"
 local DocView = require "core.docview"


### PR DESCRIPTION
This is a small change but opened a PR as a record so others don't pull their hairs trying to figure out why their plugins aren't working with linewrapping and why the priority for this plugin is needed:

Since the linewrapping plugin modifies some of the DocView line calculation and positioning functions we need to make sure of loading it before other plugins. This way we make sure that plugins that also overwrite and depend on DocView functionality aren't using the original methods without
the linewrapping changes, which leads to wrong line and column calculations.