### PR TITLE
Make `common.merge` work with invalid arguments

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -18,9 +18,16 @@ end
 
 
 function common.merge(a, b)
+  a = type(a) == "table" and a or {}
   local t = {}
-  for k, v in pairs(a) do t[k] = v end
-  if b then for k, v in pairs(b) do t[k] = v end end
+  for k, v in pairs(a) do
+    t[k] = v
+  end
+  if b and type(b) == "table" then
+    for k, v in pairs(b) do
+      t[k] = v
+    end
+  end
   return t
 end
 


### PR DESCRIPTION
This is needed because users could try to enable plugins with `config.plugins.plugin_name = true`.
Before, this would result in `common.merge` throwing an error; now it just returns a copy of the "base" table.