### PR TITLE
c core: added renderer.font.get_metadata(font_path)

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -229,10 +229,9 @@ static int f_font_get_metadata(lua_State *L) {
   bool monospaced = false;
   int error = ren_font_get_metadata(filename, &data, &found, &monospaced);
 
-  if (error == 0 && found > 0){
+  if (error == 0 && found > 0) {
     lua_newtable(L);
-    for (int i=0; i<found; i++){
-
+    for (int i=0; i<found; i++) {
       switch(data[i].tag) {
         case FONT_FAMILY:
           lua_pushlstring(L, data[i].value, data[i].len);
@@ -282,11 +281,11 @@ static int f_font_get_metadata(lua_State *L) {
     free(data);
   } else if (error == 2) {
     lua_pushnil(L);
-    lua_pushstring(L, "could not retrieve the font properties");
+    lua_pushstring(L, "could not retrieve the font meta data");
     ret_count = 2;
   } else {
     lua_pushnil(L);
-    lua_pushstring(L, "no properties found");
+    lua_pushstring(L, "no meta data found");
     ret_count = 2;
   }
 

--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -221,6 +221,78 @@ static int f_font_set_size(lua_State *L) {
   return 0;
 }
 
+static int f_font_get_metadata(lua_State *L) {
+  const char *filename  = luaL_checkstring(L, 1);
+  int found = 0;
+  int ret_count = 1;
+  FontMetaData *data;
+  bool monospaced = false;
+  int error = ren_font_get_metadata(filename, &data, &found, &monospaced);
+
+  if (error == 0 && found > 0){
+    lua_newtable(L);
+    for (int i=0; i<found; i++){
+
+      switch(data[i].tag) {
+        case FONT_FAMILY:
+          lua_pushlstring(L, data[i].value, data[i].len);
+          lua_setfield(L, -2, "family");
+          break;
+        case FONT_SUBFAMILY:
+          lua_pushlstring(L, data[i].value, data[i].len);
+          lua_setfield(L, -2, "subfamily");
+          break;
+        case FONT_ID:
+          lua_pushlstring(L, data[i].value, data[i].len);
+          lua_setfield(L, -2, "id");
+          break;
+        case FONT_FULLNAME:
+          lua_pushlstring(L, data[i].value, data[i].len);
+          lua_setfield(L, -2, "fullname");
+          break;
+        case FONT_VERSION:
+          lua_pushlstring(L, data[i].value, data[i].len);
+          lua_setfield(L, -2, "version");
+          break;
+        case FONT_PSNAME:
+          lua_pushlstring(L, data[i].value, data[i].len);
+          lua_setfield(L, -2, "psname");
+          break;
+        case FONT_TFAMILY:
+          lua_pushlstring(L, data[i].value, data[i].len);
+          lua_setfield(L, -2, "tfamily");
+          break;
+        case FONT_TSUBFAMILY:
+          lua_pushlstring(L, data[i].value, data[i].len);
+          lua_setfield(L, -2, "tsubfamily");
+          break;
+        case FONT_WWSFAMILY:
+          lua_pushlstring(L, data[i].value, data[i].len);
+          lua_setfield(L, -2, "wwsfamily");
+          break;
+        case FONT_WWSSUBFAMILY:
+          lua_pushlstring(L, data[i].value, data[i].len);
+          lua_setfield(L, -2, "wwssubfamily");
+          break;
+      }
+      free(data[i].value);
+    }
+    lua_pushboolean(L, monospaced);
+    lua_setfield(L, -2, "monospace");
+    free(data);
+  } else if (error == 2) {
+    lua_pushnil(L);
+    lua_pushstring(L, "could not retrieve the font properties");
+    ret_count = 2;
+  } else {
+    lua_pushnil(L);
+    lua_pushstring(L, "no properties found");
+    ret_count = 2;
+  }
+
+  return ret_count;
+}
+
 static int color_value_error(lua_State *L, int idx, int table_idx) {
   const char *type, *msg;
   // generate an appropriate error message
@@ -375,6 +447,7 @@ static const luaL_Reg fontLib[] = {
   { "get_size",           f_font_get_size           },
   { "set_size",           f_font_set_size           },
   { "get_path",           f_font_get_path           },
+  { "get_metadata",       f_font_get_metadata       },
   { NULL, NULL }
 };
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -17,9 +17,11 @@ typedef struct RenFont RenFont;
 typedef enum { FONT_HINTING_NONE, FONT_HINTING_SLIGHT, FONT_HINTING_FULL } ERenFontHinting;
 typedef enum { FONT_ANTIALIASING_NONE, FONT_ANTIALIASING_GRAYSCALE, FONT_ANTIALIASING_SUBPIXEL } ERenFontAntialiasing;
 typedef enum { FONT_STYLE_BOLD = 1, FONT_STYLE_ITALIC = 2, FONT_STYLE_UNDERLINE = 4, FONT_STYLE_SMOOTH = 8, FONT_STYLE_STRIKETHROUGH = 16 } ERenFontStyle;
+typedef enum { FONT_FAMILY, FONT_SUBFAMILY, FONT_ID, FONT_FULLNAME, FONT_VERSION, FONT_PSNAME, FONT_TFAMILY, FONT_TSUBFAMILY, FONT_WWSFAMILY, FONT_WWSSUBFAMILY } EFontMetaTag;
 typedef struct { uint8_t b, g, r, a; } RenColor;
 typedef struct { int x, y, width, height; } RenRect;
 typedef struct { SDL_Surface *surface; int scale; } RenSurface;
+typedef struct { EFontMetaTag tag; char *value; size_t len; } FontMetaData;
 
 struct RenWindow;
 typedef struct RenWindow RenWindow;
@@ -29,6 +31,7 @@ RenFont* ren_font_load(RenWindow *window_renderer, const char *filename, float s
 RenFont* ren_font_copy(RenWindow *window_renderer, RenFont* font, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, int style);
 const char* ren_font_get_path(RenFont *font);
 void ren_font_free(RenFont *font);
+int ren_font_get_metadata(const char *path, FontMetaData **data, int *count, bool *monospaced);
 int ren_font_group_get_tab_size(RenFont **font);
 int ren_font_group_get_height(RenFont **font);
 float ren_font_group_get_size(RenFont **font);


### PR DESCRIPTION
This function accepts a path to a font and returns a table like the one below or nil with error message:

```lua
{
  ["family"] = "Open Sans",
  ["fullname"] = "Open Sans Regular",
  ["id"] = "Ascender - Open Sans Build 100",
  ["monospaced"] = false,
  ["psname"] = "OpenSans",
  ["subfamily"] = "Regular",
  ["version"] = "Version 1.10"
}
```

The idea of this function is to provide an easy interface to retrieve a font meta data directly from freetype for usage by any plugin that would need to deal with font selection or management, like for example a graphical dialog to select fonts. Example project: https://github.com/jgmdev/lite-xl-fontseek