### PR TITLE
`language_md`: Add math delimiters

### DIFF
--- a/data/plugins/language_md.lua
+++ b/data/plugins/language_md.lua
@@ -110,6 +110,9 @@ syntax.add {
     { pattern = "&#?[a-zA-Z0-9]+;",         type = "keyword2" },
 
   ---- Markdown rules
+    -- math
+    { pattern = { "%$%$", "%$%$", "\\"  },  type = "string", syntax = ".tex"},
+    { pattern = { "%$", "%$", "\\" },       type = "string", syntax = ".tex"},
     -- code blocks
     { pattern = { "```c++", "```" },        type = "string", syntax = ".cpp" },
     { pattern = { "```cpp", "```" },        type = "string", syntax = ".cpp" },


### PR DESCRIPTION
Should the code blocks support escaping too?