### PR TITLE
Make mod-version follow semver

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -937,21 +937,17 @@ local function get_plugin_details(filename)
 
   for line in f:lines() do
     if not version_match then
-      local _, _,
-        major_a, major_b,
-        minor_a, minor_b,
-        patch_a, patch_b = mod_version_regex:match(line)
-      local major, minor, patch
-      if major_a then
-        major = tonumber(line:sub(major_a, major_b))
+      local major, minor, patch = mod_version_regex:match(line)
+      if major then
+        major = tonumber(major)
         version_match = major == MOD_VERSION_MAJOR
       end
-      if version_match and minor_a then
-        minor = tonumber(line:sub(minor_a, minor_b))
+      if version_match and minor then
+        minor = tonumber(minor)
         version_match = (minor or 0) <= MOD_VERSION_MINOR
       end
-      if version_match and patch_a then
-        patch = tonumber(line:sub(patch_a, patch_b))
+      if version_match and patch then
+        patch = tonumber(patch)
         version_match = (patch or 0) <= MOD_VERSION_PATCH
       end
     end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -673,6 +673,9 @@ end
 
 
 function core.init()
+  core.log_items = {}
+  core.log_quiet("Lite XL version %s - mod-version %s", VERSION, MOD_VERSION_STRING)
+
   command = require "core.command"
   keymap = require "core.keymap"
   dirwatch = require "core.dirwatch"
@@ -726,7 +729,6 @@ function core.init()
 
   core.frame_start = 0
   core.clip_rect_stack = {{ 0,0,0,0 }}
-  core.log_items = {}
   core.docs = {}
   core.cursor_clipboard = {}
   core.cursor_clipboard_whole_line = {}
@@ -824,15 +826,19 @@ function core.init()
     local msg = {}
     for _, entry in pairs(plugins_refuse_list) do
       if #entry.plugins > 0 then
-        msg[#msg + 1] = string.format("Plugins from directory \"%s\":\n%s", common.home_encode(entry.dir), table.concat(entry.plugins, "\n"))
+        local msg_list = {}
+        for _, p in pairs(entry.plugins) do
+          table.insert(msg_list, string.format("%s[%s]", p.file, p.version_string))
+        end
+        msg[#msg + 1] = string.format("Plugins from directory \"%s\":\n%s", common.home_encode(entry.dir), table.concat(msg_list, "\n"))
       end
     end
     core.nag_view:show(
       "Refused Plugins",
       string.format(
-        "Some plugins are not loaded due to version mismatch.\n\n%s.\n\n" ..
+        "Some plugins are not loaded due to version mismatch. Expected version %s.\n\n%s.\n\n" ..
         "Please download a recent version from https://github.com/lite-xl/lite-xl-plugins.",
-        table.concat(msg, ".\n\n")),
+        MOD_VERSION_STRING, table.concat(msg, ".\n\n")),
       opt, function(item)
         if item.text == "Exit" then os.exit(1) end
       end)
@@ -934,21 +940,24 @@ local function get_plugin_details(filename)
   if not f then return false end
   local priority = false
   local version_match = false
+  local major, minor, patch
 
   for line in f:lines() do
     if not version_match then
-      local major, minor, patch = mod_version_regex:match(line)
-      if major then
-        major = tonumber(major)
+      local _major, _minor, _patch = mod_version_regex:match(line)
+      if _major then
+        _major = tonumber(_major) or 0
+        _minor = tonumber(_minor) or 0
+        _patch = tonumber(_patch) or 0
+        major, minor, patch = _major, _minor, _patch
+
         version_match = major == MOD_VERSION_MAJOR
-      end
-      if version_match and minor then
-        minor = tonumber(minor)
-        version_match = (minor or 0) <= MOD_VERSION_MINOR
-      end
-      if version_match and patch then
-        patch = tonumber(patch)
-        version_match = (patch or 0) <= MOD_VERSION_PATCH
+        if version_match then
+          version_match = minor <= MOD_VERSION_MINOR
+        end
+        if version_match then
+          version_match = patch <= MOD_VERSION_PATCH
+        end
       end
     end
 
@@ -964,6 +973,7 @@ local function get_plugin_details(filename)
   f:close()
   return true, {
     version_match = version_match,
+    version = major and {major, minor, patch} or {},
     priority = priority or 100
   }
 end
@@ -999,6 +1009,8 @@ function core.load_plugins()
     plugin.dir = dir
     plugin.priority = details and details.priority or 100
     plugin.version_match = details and details.version_match or false
+    plugin.version = details and details.version or {}
+    plugin.version_string = #plugin.version > 0 and table.concat(plugin.version, ".") or "unknown"
   end
 
   -- sort by priority or name for plugins that have same priority
@@ -1014,21 +1026,27 @@ function core.load_plugins()
     if plugin.valid then
       if not config.skip_plugins_version and not plugin.version_match then
         core.log_quiet(
-          "Version mismatch for plugin %q from %s",
+          "Version mismatch for plugin %q[%s] from %s",
           plugin.name,
+          plugin.version_string,
           plugin.dir
         )
         local rlist = plugin.dir:find(USERDIR, 1, true) == 1
           and 'userdir' or 'datadir'
         local list = refused_list[rlist].plugins
-        table.insert(list, plugin.file)
+        table.insert(list, plugin)
       elseif config.plugins[plugin.name] ~= false then
         local start = system.get_time()
         local ok, loaded_plugin = core.try(require, "plugins." .. plugin.name)
         if ok then
+          local plugin_version = ""
+          if plugin.version_string ~= MOD_VERSION_STRING then
+            plugin_version = "["..plugin.version_string.."]"
+          end
           core.log_quiet(
-            "Loaded plugin %q from %s in %.1fms",
+            "Loaded plugin %q%s from %s in %.1fms",
             plugin.name,
+            plugin_version,
             plugin.dir,
             (system.get_time() - start) * 1000
           )

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -3,6 +3,7 @@ VERSION = "@PROJECT_VERSION@"
 MOD_VERSION_MAJOR = 3
 MOD_VERSION_MINOR = 0
 MOD_VERSION_PATCH = 0
+MOD_VERSION_STRING = string.format("%d.%d.%d", MOD_VERSION_MAJOR, MOD_VERSION_MINOR, MOD_VERSION_PATCH)
 
 SCALE = tonumber(os.getenv("LITE_SCALE") or os.getenv("GDK_SCALE") or os.getenv("QT_SCALE_FACTOR")) or SCALE
 PATHSEP = package.config:sub(1, 1)

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -1,6 +1,8 @@
 -- this file is used by lite-xl to setup the Lua environment when starting
 VERSION = "@PROJECT_VERSION@"
-MOD_VERSION = "3"
+MOD_VERSION_MAJOR = 3
+MOD_VERSION_MINOR = 0
+MOD_VERSION_PATCH = 0
 
 SCALE = tonumber(os.getenv("LITE_SCALE") or os.getenv("GDK_SCALE") or os.getenv("QT_SCALE_FACTOR")) or SCALE
 PATHSEP = package.config:sub(1, 1)


### PR DESCRIPTION
Now plugins can optionally specify the minor and patch mod-version they support.
If no minor or patch version is specified, it's considered 0.

Plugins are only loaded if they have the same major version and a smaller or equal minor+patch version.

When we make an API bugfix we will bump our patch mod-version.
When we change the API we will bump the minor mod-version.

We'll have to keep compatibility with older minor+patch versions. If the compatibility can't be ensured, the major version needs to be bumped.