### PR TITLE
omit filename when printing error for library load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ lhelper/
 submodules/
 subprojects/*/
 /appimage*
+.cache
 .ccls-cache
 .lite-debug.log
 .run*

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -769,7 +769,7 @@ static int f_load_native_plugin(lua_State *L) {
   const char *path = luaL_checkstring(L, 2);
   void *library = SDL_LoadObject(path);
   if (!library)
-    return luaL_error(L, "Unable to load %s: %s", name, SDL_GetError());
+    return (lua_pushstring(L, SDL_GetError()), lua_error(L));
 
   lua_getglobal(L, "package");
   lua_getfield(L, -1, "native_plugins");


### PR DESCRIPTION
SDL already does this.