### PR TITLE
run GC between scale to prevent ram from exploding

### DIFF
--- a/data/plugins/scale.lua
+++ b/data/plugins/scale.lua
@@ -108,10 +108,12 @@ end
 
 local function inc_scale()
   set_scale(current_scale + scale_steps)
+  collectgarbage "step"
 end
 
 local function dec_scale()
   set_scale(current_scale - scale_steps)
+  collectgarbage "step"
 end
 
 


### PR DESCRIPTION
This is partly due to #1031, since creating a new Font and allocating resources for it doesn't go through Lua's GC, it doesn't generate enough pressure. This causes fast scaling (ctrl + scroll) to increase the RAM almost 4x before the GC kicked in. This PR decreases the speed slightly, but keeps the RAM constant.