### PR TITLE
redraw window on resizing on Windows

### DIFF
--- a/data/core/titleview.lua
+++ b/data/core/titleview.lua
@@ -37,8 +37,10 @@ function TitleView:configure_hit_test(borderless)
     local icon_spacing = icon_w
     local controls_width = (icon_w + icon_spacing) * #title_commands + icon_spacing
     system.set_window_hit_test(title_height, controls_width, icon_spacing)
+    system.set_window_on_resize(core.step)
     -- core.hit_test_title_height = title_height
   else
+    system.set_window_on_resize()
     system.set_window_hit_test()
   end
 end


### PR DESCRIPTION
This PR fixes a very longstanding issue with SDL (and a wontfix by SDL authors). 

Before:
https://user-images.githubusercontent.com/20792268/174504934-38cfe074-2897-42ac-a403-f182f5b8caf9.mp4

After:
https://user-images.githubusercontent.com/20792268/174504938-539c8a30-9ff7-4f2f-9684-d224f551bb26.mp4

The performance impact is okay-ish, but I might not be aware of bugs that might break it.

Another consideration is that core.step() may run other threads which might lag the windows "modal loop", the loop handling resizes and moves (which causes this issue anyway). 


