### PR TITLE
treeview: restore ability to disable toolbarview

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -854,8 +854,10 @@ config.plugins.treeview.config_spec = {
     description = "Default treeview width.",
     path = "size",
     type = "number",
-    default = math.ceil(toolbar_view:get_min_width() / SCALE),
-    min = toolbar_view:get_min_width() / SCALE,
+    default = toolbar_view and math.ceil(toolbar_view:get_min_width() / SCALE)
+      or 200,
+    min = toolbar_view and toolbar_view:get_min_width() / SCALE
+      or 200,
     get_value = function(value)
       return value / SCALE
     end,
@@ -863,7 +865,9 @@ config.plugins.treeview.config_spec = {
       return value * SCALE
     end,
     on_apply = function(value)
-      view:set_target_size("x", math.max(value, toolbar_view:get_min_width()))
+      view:set_target_size("x", math.max(
+        value, toolbar_view and toolbar_view:get_min_width() or 200
+      ))
     end
   },
   {


### PR DESCRIPTION
This change fixes an issue introduced by config spec that made the toolbarview a hard requirement and caused an issue first reported by @Not-a-web-Developer and later by @AqilCont where the treeview is duplicated as shown on screenshot shared by Aqil when `config.plugins.toolbarview = false`:

![unknown](https://user-images.githubusercontent.com/1702572/174946166-a3ce1d96-3459-4701-8c50-71108a2b4b5b.png)