### PR TITLE
Improve `lineguide` plugin

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -54,7 +54,6 @@ setmetatable(config.plugins, {
 
 -- Disable these plugins by default.
 config.plugins.trimwhitespace = false
-config.plugins.lineguide = false
 config.plugins.drawwhitespace = false
 
 return config

--- a/data/plugins/lineguide.lua
+++ b/data/plugins/lineguide.lua
@@ -1,21 +1,57 @@
 -- mod-version:3
+local command = require "core.command"
 local config = require "core.config"
 local style = require "core.style"
 local DocView = require "core.docview"
 local CommandView = require "core.commandview"
 
-local draw_overlay = DocView.draw_overlay
+config.plugins.lineguide = {
+  enabled = true,
+  width = 2,
+  rulers = {
+    -- 80,
+    -- 100,
+    120,
+  }
+}
 
-function DocView:draw_overlay(...)
-  if not self:is(CommandView) then
-    local offset = self:get_font():get_width("n") * config.line_limit
-    local x = self:get_line_screen_position(1) + offset
-    local y = self.position.y
-    local w = math.ceil(SCALE * 1)
-    local h = self.size.y
-
-    local color = style.guide or style.selection
-    renderer.draw_rect(x, y, w, h, color)
+local function get_ruler(v)
+  local result = nil
+  if type(v) == 'number' then
+    result = { columns = v }
+  elseif type(v) == 'table' then
+    result = v
   end
-  draw_overlay(self, ...)
+  return result
 end
+
+local draw_overlay = DocView.draw_overlay
+function DocView:draw_overlay(...)
+  draw_overlay(self, ...)
+
+  if config.plugins.lineguide.enabled and not self:is(CommandView) then
+    local line_x = self:get_line_screen_position(1)
+    local character_width = self:get_font():get_width("n")
+    local ruler_width = config.plugins.lineguide.width
+    local ruler_color = style.guide or style.selection
+
+    for k,v in ipairs(config.plugins.lineguide.rulers) do
+      local ruler = get_ruler(v)
+
+      if ruler then
+        local x = line_x + (character_width * ruler.columns)
+        local y = self.position.y
+        local w = ruler_width
+        local h = self.size.y
+
+        renderer.draw_rect(x, y, w, h, ruler.color or ruler_color)
+      end
+    end
+  end
+end
+
+command.add(nil, {
+  ["lineguide:toggle"] = function()
+    config.plugins.lineguide.enabled = not config.plugins.lineguide.enabled
+  end
+})

--- a/data/plugins/lineguide.lua
+++ b/data/plugins/lineguide.lua
@@ -1,19 +1,20 @@
 -- mod-version:3
+local common = require "core.common"
 local command = require "core.command"
 local config = require "core.config"
 local style = require "core.style"
 local DocView = require "core.docview"
 local CommandView = require "core.commandview"
 
-config.plugins.lineguide = {
-  enabled = true,
+config.plugins.lineguide = common.merge({
+  enabled = false,
   width = 2,
   rulers = {
     -- 80,
     -- 100,
     120,
   }
-}
+}, config.plugins.lineguide)
 
 local function get_ruler(v)
   local result = nil

--- a/data/plugins/lineguide.lua
+++ b/data/plugins/lineguide.lua
@@ -12,7 +12,8 @@ config.plugins.lineguide = common.merge({
   rulers = {
     -- 80,
     -- 100,
-    120,
+    -- 120,
+    config.line_limit
   }
 }, config.plugins.lineguide)
 


### PR DESCRIPTION
Feature changes:

- Add support for drawing multiple rulers
- Add config options to provide more customization
- Add toggle command to show/hide rulers

Example config:

```lua
config.plugins.lineguide.width = 2
config.plugins.lineguide.rulers = {
  { columns = 100, color = style.selection },
  120
}
```
