### PR TITLE
renderer fonts: additions and improvements

### DIFF
--- a/data/plugins/language_md.lua
+++ b/data/plugins/language_md.lua
@@ -14,9 +14,7 @@ for _, attr in pairs({"bold", "italic", "bold_italic"}) do
     attributes["bold"] = true
     attributes["italic"] = true
   end
-  -- no way to copy user custom font with additional attributes :(
-  style.syntax_fonts["markdown_"..attr] = renderer.font.load(
-    DATADIR .. "/fonts/JetBrainsMono-Regular.ttf",
+  style.syntax_fonts["markdown_"..attr] = style.code_font:copy(
     style.code_font:get_size(),
     attributes
   )

--- a/data/plugins/scale.lua
+++ b/data/plugins/scale.lua
@@ -79,14 +79,14 @@ local function set_scale(scale)
     style.tab_width      = style.tab_width      * s
 
     for _, name in ipairs {"font", "big_font", "icon_font", "icon_big_font", "code_font"} do
-      style[name] = renderer.font.copy(style[name], s * style[name]:get_size())
+      style[name]:set_size(s * style[name]:get_size())
     end
   else
-    style.code_font = renderer.font.copy(style.code_font, s * style.code_font:get_size())
+    style.code_font:set_size(s * style.code_font:get_size())
   end
 
   for name, font in pairs(style.syntax_fonts) do
-    style.syntax_fonts[name] = renderer.font.copy(font, s * font:get_size())
+    style.syntax_fonts[name]:set_size(s * font:get_size())
   end
 
   -- restore scroll positions
@@ -108,12 +108,10 @@ end
 
 local function inc_scale()
   set_scale(current_scale + scale_steps)
-  collectgarbage "step"
 end
 
 local function dec_scale()
   set_scale(current_scale - scale_steps)
-  collectgarbage "step"
 end
 
 

--- a/docs/api/renderer.lua
+++ b/docs/api/renderer.lua
@@ -35,7 +35,7 @@ renderer.font = {}
 ---
 ---@param path string
 ---@param size number
----@param options renderer.fontoptions
+---@param options? renderer.fontoptions
 ---
 ---@return renderer.font
 function renderer.font.load(path, size, options) end
@@ -54,9 +54,10 @@ function renderer.font.group(fonts) end
 ---Clones a font object into a new one.
 ---
 ---@param size? number Optional new size for cloned font.
+---@param options? renderer.fontoptions
 ---
 ---@return renderer.font
-function renderer.font:copy(size) end
+function renderer.font:copy(size, options) end
 
 ---
 ---Set the amount of characters that represent a tab.
@@ -91,6 +92,13 @@ function renderer.font:get_size() end
 ---
 ---@param size number
 function renderer.font:set_size(size) end
+
+---
+---Get the current path of the font as a string if a single font or as an
+---array of strings if a group font.
+---
+---@return string | table<integer, string>
+function renderer.font:get_path() end
 
 ---
 ---Toggles drawing debugging rectangles on the currently rendered sections

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -20,11 +20,13 @@ typedef struct { uint8_t b, g, r, a; } RenColor;
 typedef struct { int x, y, width, height; } RenRect;
 
 RenFont* ren_font_load(const char *filename, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, unsigned char style);
-RenFont* ren_font_copy(RenFont* font, float size);
+RenFont* ren_font_copy(RenFont* font, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, int style);
+const char* ren_font_get_path(RenFont *font);
 void ren_font_free(RenFont *font);
 int ren_font_group_get_tab_size(RenFont **font);
 int ren_font_group_get_height(RenFont **font);
 float ren_font_group_get_size(RenFont **font);
+void ren_font_group_set_size(RenFont **font, float size);
 void ren_font_group_set_tab_size(RenFont **font, int n);
 float ren_font_group_get_width(RenFont **font, const char *text);
 float ren_draw_text(RenFont **font, const char *text, float x, int y, RenColor color);


### PR DESCRIPTION
### Changes

* Allow passing font options to renderer.font:copy().
* Added renderer.font:get_path() which has various useful uses like checking in the settings plugin if the user is using a default font or not or preventing reloading a font if the path is already the same.
* Reintroduced set_size() for more faster font size changes on scale and prevent breaking references to fonts that get overridden with new one when using copy()
* Swapped copy with set_size on scale plugin for better performance and not breaking references
* Use code_font:copy() instead of renderer.font.load() on language_md to properly match user font now that font options are supported on copy.
* Added new changes to renderer docs