### PR TITLE
On `doc:newline` remove line content if it contains only whitespace

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -233,6 +233,10 @@ local commands = {
       if col <= #indent then
         indent = indent:sub(#indent + 2 - col)
       end
+      -- Remove current line if it contains only whitespace
+      if doc().lines[line]:match("^%s+$") then
+        doc():remove(line, 1, line, math.huge)
+      end
       doc():text_input("\n" .. indent, idx)
     end
   end,
@@ -475,7 +479,7 @@ local commands = {
       command.perform("doc:save-as")
     end
   end,
-  
+
   ["doc:reload"] = function()
     doc():reload()
   end,


### PR DESCRIPTION
This results in what looks like the whitespace moving to the new line.

https://user-images.githubusercontent.com/2798487/175754237-d5ade3f0-e89e-4af5-bd54-dced2bd207bd.mp4

EDIT: Should this be an option?