### PR TITLE
Fix opening `LogView` when reloading customizations

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -68,15 +68,19 @@ local function reload_customizations()
   local user_error = not core.load_user_directory()
   local project_error = not core.load_project_module()
   if user_error or project_error then
-    local LogView = require "core.logview"
-    local rn = core.root_view.root_node
-    for _,v in pairs(core.root_view.root_node:get_children()) do
-      if v:is(LogView) then
-        rn:get_node_for_view(v):set_active_view(v)
-        return
+    -- Use core.add_thread to delay opening the LogView, as opening
+    -- it directly here disturbs the normal save operations.
+    core.add_thread(function()
+      local LogView = require "core.logview"
+      local rn = core.root_view.root_node
+      for _,v in pairs(core.root_view.root_node:get_children()) do
+        if v:is(LogView) then
+          rn:get_node_for_view(v):set_active_view(v)
+          return
+        end
       end
-    end
-    command.perform("core:open-log")
+      command.perform("core:open-log")
+    end)
   end
 end
 


### PR DESCRIPTION
As `reload_customizations` was called during save operations, opening the `LogView` changed `core.active_view` which caused some errors to be thrown.

For now the solution is to delay opening the `LogView` with `core.add_thread`, but in the future a better way to do this could be implemented.

This problem was introduced in 237f0c91cb4cf50ccc3c31439ead24aeda7ae510.