### PR TITLE
`language_md`: Limit inline math mode to the current line

### DIFF
--- a/data/plugins/language_md.lua
+++ b/data/plugins/language_md.lua
@@ -110,7 +110,7 @@ syntax.add {
   ---- Markdown rules
     -- math
     { pattern = { "%$%$", "%$%$", "\\"  },  type = "string", syntax = ".tex"},
-    { pattern = { "%$", "%$", "\\" },       type = "string", syntax = ".tex"},
+    { regex   = { "\\$", [[\$|(?=\\*\n)]], "\\" },  type = "string", syntax = ".tex"},
     -- code blocks
     { pattern = { "```c++", "```" },        type = "string", syntax = ".cpp" },
     { pattern = { "```cpp", "```" },        type = "string", syntax = ".cpp" },


### PR DESCRIPTION
For the moment this is the best solution.

Next week I'll implement a tokenizer mode that allows to match a syntax to a single pattern.
With that mode this would become:
```lua
{ pattern   = "%$().*()%$",  type = "string", syntax = ".tex"}
```
The main problem will be specifying escapes.