### PR TITLE
language_python: add syntax support for the match-case statement

### DIFF
--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -41,6 +41,8 @@ syntax.add {
     ["if"]       = "keyword",
     ["or"]       = "keyword",
     ["else"]     = "keyword",
+    ["match"]    = "keyword",
+    ["case"]     = "keyword",
     ["import"]   = "keyword",
     ["pass"]     = "keyword",
     ["break"]    = "keyword",


### PR DESCRIPTION
This PR adds syntax support for the *match-case* statement introduced in Python 3.10.

source: https://peps.python.org/pep-0636