### PR TITLE
Make `Doc:get_selection[s]` return if the selection was actually sorted

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -146,8 +146,8 @@ end
 -- curors can never swap positions; only merge or split, or change their position in cursor
 -- order.
 function Doc:get_selection(sort)
-  local idx, line1, col1, line2, col2 = self:get_selections(sort)({ self.selections, sort }, 0)
-  return line1, col1, line2, col2, sort
+  local idx, line1, col1, line2, col2, swap = self:get_selections(sort)({ self.selections, sort }, 0)
+  return line1, col1, line2, col2, swap
 end
 
 function Doc:get_selection_text(limit)
@@ -183,9 +183,9 @@ end
 
 local function sort_positions(line1, col1, line2, col2)
   if line1 > line2 or line1 == line2 and col1 > col2 then
-    return line2, col2, line1, col1
+    return line2, col2, line1, col1, true
   end
-  return line1, col1, line2, col2
+  return line1, col1, line2, col2, false
 end
 
 function Doc:set_selections(idx, line1, col1, line2, col2, swap, rm)


### PR DESCRIPTION
This is useful when a sorted selection is needed, but the original selection direction needs to be preserved.

As it can be seen here https://github.com/lite-xl/lite-xl-plugins/blob/714d0cea7f75572320ee91dcb2b6c0f89e12e802/plugins/autoinsert.lua#L50 the `autoinsert` plugin used the last parameter returned by `Doc:get_selection` as the `swap` parameter of `Doc:set_selection` even if, before this PR, the returned value was whether the `sort` parameter was set or not.