### PR TITLE
`language_python`:  Add new patterns

### DIFF
--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -10,7 +10,7 @@ syntax.add {
   patterns = {
     { pattern = { "#", "\n" },                 type = "comment"  },
     { pattern = { '^%s*"""', '"""' },         type = "comment"  },
-    { regex   = '[uUrR](?=")',                 type = "keyword"  },
+    { pattern = '[uUrR]%f["]',                 type = "keyword"  },
     { pattern = "class%s+()[%a_][%w_]*",       type = {"keyword", "keyword2"} },
     { pattern = { '[ruU]?"""', '"""'; '\\' },  type = "string"   },
     { pattern = { "[ruU]?'''", "'''", '\\' },  type = "string"   },

--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -6,8 +6,12 @@ syntax.add {
   files = { "%.py$", "%.pyw$", "%.rpy$" },
   headers = "^#!.*[ /]python",
   comment = "#",
+  block_comment = '"""',
   patterns = {
     { pattern = { "#", "\n" },                 type = "comment"  },
+    { regex   = { '^\\s*"""', '"""' },         type = "comment"  },
+    { regex   = '[uUrR](?=")',                 type = "keyword"  },
+    { pattern = "class%s+()[%a_][%w_]*",       type = {"keyword", "keyword2"} },
     { pattern = { '[ruU]?"""', '"""'; '\\' },  type = "string"   },
     { pattern = { "[ruU]?'''", "'''", '\\' },  type = "string"   },
     { pattern = { '[ruU]?"', '"', '\\' },      type = "string"   },

--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -9,7 +9,7 @@ syntax.add {
   block_comment = { '"""', '"""' },
   patterns = {
     { pattern = { "#", "\n" },                 type = "comment"  },
-    { pattern = { '^%s*"""', '"""' },         type = "comment"  },
+    { pattern = { '^%s*"""', '"""' },          type = "comment"  },
     { pattern = '[uUrR]%f["]',                 type = "keyword"  },
     { pattern = "class%s+()[%a_][%w_]*",       type = {"keyword", "keyword2"} },
     { pattern = { '[ruU]?"""', '"""'; '\\' },  type = "string"   },

--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -9,7 +9,7 @@ syntax.add {
   block_comment = { '"""', '"""' },
   patterns = {
     { pattern = { "#", "\n" },                 type = "comment"  },
-    { regex   = { '^\\s*"""', '"""' },         type = "comment"  },
+    { pattern = { '^%s*"""', '"""' },         type = "comment"  },
     { regex   = '[uUrR](?=")',                 type = "keyword"  },
     { pattern = "class%s+()[%a_][%w_]*",       type = {"keyword", "keyword2"} },
     { pattern = { '[ruU]?"""', '"""'; '\\' },  type = "string"   },

--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -6,7 +6,7 @@ syntax.add {
   files = { "%.py$", "%.pyw$", "%.rpy$" },
   headers = "^#!.*[ /]python",
   comment = "#",
-  block_comment = '"""',
+  block_comment = { '"""', '"""' },
   patterns = {
     { pattern = { "#", "\n" },                 type = "comment"  },
     { regex   = { '^\\s*"""', '"""' },         type = "comment"  },


### PR DESCRIPTION
Hello!

This commit provides improvements for the Python syntax coloring:
 - multiline comments support;
 - unicode string symbol highlighting;
 - class names highlighting.

I am not completely sure if my patterns are optimal but some required using pure regex to work properly. Let me know if there is a better way.

On a personal note, it would be nice to have a "class" or "keyword3" syntax color so we could use it to distinguish even more keywords (especially class names, special variables like `__name__`, or pseudo-const variables in uppercases, as Sublime Text does it).