### PR TITLE
Make `StatusView:add_item` accept a table

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -168,17 +168,17 @@
   ```lua
   ------@return StatusView.Item
   function StatusView:add_item(
-    predicate, name, alignment, getitem, command, pos, tooltip
+    { predicate, name, alignment, get_item, command, position, tooltip, separator }
   ) end
   ```
 
   **Example:**
   ```lua
-  core.status_view:add_item(
-    nil,
-    "status:memory-usage",
-    StatusView.Item.RIGHT,
-    function()
+  core.status_view:add_item({
+    predicate = nil,
+    name = "status:memory-usage",
+    alignment = StatusView.Item.RIGHT,
+    get_item = function()
       return {
         style.text,
         string.format(
@@ -187,10 +187,11 @@
         )
       }
     end,
-    nil,
-    1,
-    "lua memory usage"
-  ).separator = core.status_view.separator2
+    command = nil,
+    position = 1,
+    tooltip = "lua memory usage",
+    separator = core.status_view.separator2
+  })
   ```
 
 * [CommandView:enter](https://github.com/lite-xl/lite-xl/pull/1004) now accepts


### PR DESCRIPTION
Now both `StatusView:add_item` and `StatusViewItem:new` accept a `StatusViewItemOptions` table.

This is done to avoid having to specify the 7 parameters `StatusView:add_item` needed, and will make it more flexible by, for example, allowing to specify additional fields like `separator`.

What other fields should be added?

**Note**: as this PR doesn't keep compatibility with the old way (as no version with the old way was ever released), some plugins require changes that can be found in https://github.com/Guldoman/lite-xl-plugins/tree/PR_StatusView_add_item_table. Other plugins like LSP and lintplus need changes too.

When this plugin is merged I'll PR the needed plugin changes.