### PR TITLE
Add font style options in user module

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -497,11 +497,14 @@ local style = require "core.style"
 --
 -- the function to load the font accept a 3rd optional argument like:
 --
--- {antialiasing="grayscale", hinting="full"}
+-- {antialiasing="grayscale", hinting="full", bold=true, italic=true, underline=true}
 --
 -- possible values are:
 -- antialiasing: grayscale, subpixel
 -- hinting: none, slight, full
+-- bold: true, false
+-- italic: true, false
+-- underline: true, false
 
 ------------------------------ Plugins ----------------------------------------
 


### PR DESCRIPTION
Hi!

It would be nice to let the user know about the bold/italic/underline options as font styles in the user module.

In my situation, the bold option is very convenient in order to have a thicker font like in Sublime Text and Atom. People might be interested about them too so we should let them know.

Feel free to suggest another presentation in the "possible values" section.