### PR TITLE
CommandView: do not change caret size with config.line_height

### DIFF
--- a/data/core/commandview.lua
+++ b/data/core/commandview.lua
@@ -226,6 +226,11 @@ function CommandView:exit(submitted, inexplicit)
 end
 
 
+function CommandView:get_line_height()
+  return math.floor(self:get_font():get_height() * 1.2)
+end
+
+
 function CommandView:get_gutter_width()
   return self.gutter_width
 end


### PR DESCRIPTION
Fixes issue as shown on image

![commandview-caret-size](https://user-images.githubusercontent.com/1702572/179255768-706fd5f2-fcfa-4778-a817-fcde7a3c03e0.png)
