### PR TITLE
Clear default Lua `require` search path

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -16,7 +16,7 @@ USERDIR = (system.get_file_info(EXEDIR .. '/user') and (EXEDIR .. '/user'))
        or ((os.getenv("XDG_CONFIG_HOME") and os.getenv("XDG_CONFIG_HOME") .. "/lite-xl"))
        or (HOME and (HOME .. '/.config/lite-xl'))
 
-package.path = DATADIR .. '/?.lua;' .. package.path
+package.path = DATADIR .. '/?.lua;'
 package.path = DATADIR .. '/?/init.lua;' .. package.path
 package.path = USERDIR .. '/?.lua;' .. package.path
 package.path = USERDIR .. '/?/init.lua;' .. package.path


### PR DESCRIPTION
This is mainly done to avoid requiring from the current working directory of the editor.

This also avoids requiring from system paths, as it was already the case for the native modules search path.

This is needed because the editor's working directory is moved to the opened project path, so `require`s after that use the project path to look for modules.
Also consider that we don't reset the cwd on editor restart.

This is problematic mostly for plugins that use "optional" requires for modules that can not be found in our custom search paths, as those are then looked up in the system paths, then the current working directory.