### PR TITLE
Steps to generalize toolbar, treeview and limit cursor splitting to only where it's relevant.

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -527,6 +527,23 @@ local commands = {
     doc():set_selection(line2, col2, line1, col1)
   end,
 
+  ["doc:create-cursor-previous-line"] = function()
+    split_cursor(-1)
+    doc():merge_cursors()
+  end,
+
+  ["doc:create-cursor-next-line"] = function()
+    split_cursor(1)
+    doc():merge_cursors()
+  end
+
+}
+
+command.add(function(x, y)
+  if x == nil or y == nil or not doc() then return false end
+  local x1,y1,x2,y2 = dv().position.x, dv().position.y, dv().position.x + dv().size.x, dv().position.y + dv().size.y
+  return x >= x1 + dv():get_gutter_width() and x < x2 and y >= y1 and y < y2
+end, {
   ["doc:set-cursor"] = function(x, y)
     set_cursor(x, y, "set")
   end,
@@ -553,20 +570,8 @@ local commands = {
       doc():add_selection(line, col, line, col)
     end
     dv().mouse_selecting = { line, col, "set" }
-  end,
-
-  ["doc:create-cursor-previous-line"] = function()
-    split_cursor(-1)
-    doc():merge_cursors()
-  end,
-
-  ["doc:create-cursor-next-line"] = function()
-    split_cursor(1)
-    doc():merge_cursors()
   end
-
-}
-
+})
 
 local translations = {
   ["previous-char"] = translate,

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -1109,9 +1109,10 @@ function StatusView:draw()
 
   if self.message and system.get_time() <= self.message_timeout then
     self:draw_items(self.message, false, 0, self.size.y)
-  elseif self.tooltip_mode then
-    self:draw_items(self.tooltip)
   else
+    if self.tooltip_mode then
+      self:draw_items(self.tooltip)
+    end
     if #self.active_items > 0 then
       --- draw left pane
       core.push_clip_rect(
@@ -1121,7 +1122,7 @@ function StatusView:draw()
       for _, item in ipairs(self.active_items) do
         local item_x = self.left_xoffset + item.x + style.padding.x
         local hovered, item_bg = get_item_bg_color(self, item)
-        if item.alignment == StatusView.Item.LEFT then
+        if item.alignment == StatusView.Item.LEFT and not self.tooltip_mode then
           if type(item_bg) == "table" then
             renderer.draw_rect(
               item_x, self.position.y,

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -458,7 +458,7 @@ end
 -- init
 local view = TreeView()
 local node = core.root_view:get_active_node()
-local treeview_node = node:split("left", view, {x = true}, true)
+view.node = node:split("left", view, {x = true}, true)
 
 -- The toolbarview plugin is special because it is plugged inside
 -- a treeview pane which is itelf provided in a plugin.
@@ -470,7 +470,7 @@ local toolbar_view = nil
 local toolbar_plugin, ToolbarView = core.try(require, "plugins.toolbarview")
 if config.plugins.toolbarview ~= false and toolbar_plugin then
   toolbar_view = ToolbarView()
-  treeview_node:split("down", toolbar_view, {y = true})
+  view.node:split("down", toolbar_view, {y = true})
   local min_toolbar_width = toolbar_view:get_min_width()
   view:set_target_size("x", math.max(config.plugins.treeview.size, min_toolbar_width))
   command.add(nil, {


### PR DESCRIPTION
Just a small amount of edits to make ToolbarView and TreeView more interactable in plugins; basically allowing you to re-use ToolbarView with a different set of commands, and made it so that you can latch onto the TreeView node, by making it publicly available. Also changed cursor splitting to have a proper predicate.