### PR TITLE
language_python: add syntax support for async/await

### DIFF
--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -33,6 +33,8 @@ syntax.add {
     ["lambda"]   = "keyword",
     ["try"]      = "keyword",
     ["def"]      = "keyword",
+    ["async"]    = "keyword",
+    ["await"]    = "keyword",
     ["from"]     = "keyword",
     ["nonlocal"] = "keyword",
     ["while"]    = "keyword",


### PR DESCRIPTION
This PR adds syntax support for the `async` keyword and  `await` keyword in Python.

source: https://docs.python.org/3/library/asyncio-task.html