### PR TITLE
Strictly limit find/replace commands to `core.docview`

### DIFF
--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -200,7 +200,7 @@ command.add(has_unique_selection, {
   ["find-replace:select-add-all"] = function() select_add_next(true) end
 })
 
-command.add("core.docview", {
+command.add("core.docview!", {
   ["find-replace:find"] = function()
     find("Find Text", function(doc, line, col, text, case_sensitive, find_regex, find_reverse)
       local opt = { wrap = true, no_case = not case_sensitive, regex = find_regex, reverse = find_reverse }


### PR DESCRIPTION
Without this, find/replace commands apply to the `CommandView` too, with buggy results.

Maybe in the future we could also select the whole input if the command is repeated, like other editors do.

Fixes #1107.