### PR TITLE
plugin scale: added option to set default scale

### DIFF
--- a/data/plugins/scale.lua
+++ b/data/plugins/scale.lua
@@ -5,47 +5,15 @@ local command = require "core.command"
 local config = require "core.config"
 local keymap = require "core.keymap"
 local style = require "core.style"
-local RootView = require "core.rootview"
 local CommandView = require "core.commandview"
 
 config.plugins.scale = common.merge({
   -- The method used to apply the scaling: "code", "ui"
   mode = "code",
+  -- Default scale applied at startup.
+  default_scale = "autodetect",
   -- Allow using CTRL + MouseWheel for changing the scale.
-  use_mousewheel = true,
-  -- The config specification used by gui generators
-  config_spec = {
-    name = "Scale",
-    {
-      label = "Mode",
-      description = "The method used to apply the scaling.",
-      path = "mode",
-      type = "selection",
-      default = "code",
-      values = {
-        {"Code Only", "code"},
-        {"Everything", "ui"}
-      }
-    },
-    {
-      label = "Use MouseWheel",
-      description = "Allow using CTRL + MouseWheel for changing the scale.",
-      path = "use_mousewheel",
-      type = "toggle",
-      default = true,
-      on_apply = function(enabled)
-        if enabled then
-          keymap.add {
-            ["ctrl+wheelup"] = "scale:increase",
-            ["ctrl+wheeldown"] = "scale:decrease"
-          }
-        else
-          keymap.unbind("ctrl+wheelup", "scale:increase")
-          keymap.unbind("ctrl+wheeldown", "scale:decrease")
-        end
-      end
-    }
-  }
+  use_mousewheel = true
 }, config.plugins.scale)
 
 local scale_steps = 0.05
@@ -113,6 +81,75 @@ end
 local function dec_scale()
   set_scale(current_scale - scale_steps)
 end
+
+if default_scale ~= config.plugins.scale.default_scale then
+  if type(config.plugins.scale.default_scale) == "number" then
+    set_scale(config.plugins.scale.default_scale)
+  end
+end
+
+-- The config specification used by gui generators
+config.plugins.scale.config_spec = {
+  name = "Scale",
+  {
+    label = "Mode",
+    description = "The method used to apply the scaling.",
+    path = "mode",
+    type = "selection",
+    default = "code",
+    values = {
+      {"Everything", "ui"},
+      {"Code Only", "code"}
+    }
+  },
+  {
+    label = "Default Scale",
+    description = "The scaling factor applied to lite-xl.",
+    path = "default_scale",
+    type = "selection",
+    default = "autodetect",
+    values = {
+      {"Autodetect", "autodetect"},
+      {"80%", 0.80},
+      {"90%", 0.90},
+      {"100%", 1.00},
+      {"110%", 1.10},
+      {"120%", 1.20},
+      {"125%", 1.25},
+      {"130%", 1.30},
+      {"140%", 1.40},
+      {"150%", 1.50},
+      {"175%", 1.75},
+      {"200%", 2.00},
+      {"250%", 2.50},
+      {"300%", 3.00}
+    },
+    on_apply = function(value)
+      if type(value) == "string" then value = default_scale end
+      if value ~= current_scale then
+        set_scale(value)
+      end
+    end
+  },
+  {
+    label = "Use MouseWheel",
+    description = "Allow using CTRL + MouseWheel for changing the scale.",
+    path = "use_mousewheel",
+    type = "toggle",
+    default = true,
+    on_apply = function(enabled)
+      if enabled then
+        keymap.add {
+          ["ctrl+wheelup"] = "scale:increase",
+          ["ctrl+wheeldown"] = "scale:decrease"
+        }
+      else
+        keymap.unbind("ctrl+wheelup", "scale:increase")
+        keymap.unbind("ctrl+wheeldown", "scale:decrease")
+      end
+    end
+  }
+}
 
 
 command.add(nil, {


### PR DESCRIPTION
As title says plus changed default mode to `ui` and added config spec option to allow settings gui modification:

![default-scale-option](https://user-images.githubusercontent.com/1702572/190007741-69ac406d-cd72-4f10-a3eb-6d34852a06a5.png)
