### PR TITLE
Improvements to multicursor copy/paste

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -157,6 +157,11 @@ function Doc:get_selection(sort)
   return line1, col1, line2, col2, swap
 end
 
+
+---Get the selection specified by `idx`
+---@param idx integer @the index of the selection to retrieve
+---@param sort? boolean @whether to sort the selection returned
+---@return integer,integer,integer,integer,boolean? @line1, col1, line2, col2, was the selection sorted
 function Doc:get_selection_idx(idx, sort)
   local line1, col1, line2, col2 = self.selections[idx*4-3], self.selections[idx*4-2], self.selections[idx*4-1], self.selections[idx*4]
   if sort then

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -154,7 +154,10 @@ end
 -- curors can never swap positions; only merge or split, or change their position in cursor
 -- order.
 function Doc:get_selection(sort)
-  local idx, line1, col1, line2, col2, swap = self:get_selections(sort)({ self.selections, sort }, 0)
+  local line1, col1, line2, col2, swap = self:get_selection_idx(self.last_selection, sort)
+  if not line1 then
+    line1, col1, line2, col2, swap = self:get_selection_idx(1, sort)
+  end
   return line1, col1, line2, col2, swap
 end
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -141,6 +141,13 @@ function Doc:get_change_id()
   return self.undo_stack.idx
 end
 
+local function sort_positions(line1, col1, line2, col2)
+  if line1 > line2 or line1 == line2 and col1 > col2 then
+    return line2, col2, line1, col1, true
+  end
+  return line1, col1, line2, col2, false
+end
+
 -- Cursor section. Cursor indices are *only* valid during a get_selections() call.
 -- Cursors will always be iterated in order from top to bottom. Through normal operation
 -- curors can never swap positions; only merge or split, or change their position in cursor
@@ -148,6 +155,15 @@ end
 function Doc:get_selection(sort)
   local idx, line1, col1, line2, col2, swap = self:get_selections(sort)({ self.selections, sort }, 0)
   return line1, col1, line2, col2, swap
+end
+
+function Doc:get_selection_idx(idx, sort)
+  local line1, col1, line2, col2 = self.selections[idx*4-3], self.selections[idx*4-2], self.selections[idx*4-1], self.selections[idx*4]
+  if sort then
+    return sort_positions(line1, col1, line2, col2)
+  else
+    return line1, col1, line2, col2
+  end
 end
 
 function Doc:get_selection_text(limit)
@@ -179,13 +195,6 @@ function Doc:sanitize_selection()
   for idx, line1, col1, line2, col2 in self:get_selections() do
     self:set_selections(idx, line1, col1, line2, col2)
   end
-end
-
-local function sort_positions(line1, col1, line2, col2)
-  if line1 > line2 or line1 == line2 and col1 > col2 then
-    return line2, col2, line1, col1, true
-  end
-  return line1, col1, line2, col2, false
 end
 
 function Doc:set_selections(idx, line1, col1, line2, col2, swap, rm)

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -33,6 +33,7 @@ end
 function Doc:reset()
   self.lines = { "\n" }
   self.selections = { 1, 1, 1, 1 }
+  self.last_selection = 1
   self.undo_stack = { idx = 1 }
   self.redo_stack = { idx = 1 }
   self.clean_change_id = 1
@@ -220,10 +221,14 @@ function Doc:add_selection(line1, col1, line2, col2, swap)
     end
   end
   self:set_selections(target, line1, col1, line2, col2, swap, 0)
+  self.last_selection = target
 end
 
 
 function Doc:remove_selection(idx)
+  if self.last_selection >= idx then
+    self.last_selection = self.last_selection - 1
+  end
   common.splice(self.selections, (idx - 1) * 4 + 1, 4)
 end
 
@@ -231,6 +236,7 @@ end
 function Doc:set_selection(line1, col1, line2, col2, swap)
   self.selections = {}
   self:set_selections(1, line1, col1, line2, col2, swap)
+  self.last_selection = 1
 end
 
 function Doc:merge_cursors(idx)
@@ -239,6 +245,9 @@ function Doc:merge_cursors(idx)
       if self.selections[i] == self.selections[j] and
         self.selections[i+1] == self.selections[j+1] then
           common.splice(self.selections, i, 4)
+          if self.last_selection >= (i+3)/4 then
+            self.last_selection = self.last_selection - 1
+          end
           break
       end
     end


### PR DESCRIPTION
This implements #1119 as the new default multicursor paste behavior. The old behavior can still be achieved by pressing `space`, then `escape`.
Mixed normal and full line paste is now treated as normal paste.

Added `Doc:get_selection_idx` to retrieve the selection at a specific index.


https://user-images.githubusercontent.com/2798487/191685609-e8f1d511-b56e-4506-9316-1aa58b0abd7c.mp4

This needs corner cases to be tested.