### PR TITLE
Added in ability to have `init.so` as a require for cpath.

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -29,7 +29,7 @@ package.cpath =
   USERDIR .. '/?/init.' .. suffix .. ";" .. 
   DATADIR .. '/?.' .. ARCH .. "." .. suffix .. 
   DATADIR .. '/?/init.' .. ARCH .. "." .. suffix .. 
-  DATADIR .. '/?.' .. suffix
+  DATADIR .. '/?.' .. suffix ..
   DATADIR .. '/?/init.' .. suffix
   
 package.native_plugins = {}

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -22,9 +22,16 @@ package.path = USERDIR .. '/?.lua;' .. package.path
 package.path = USERDIR .. '/?/init.lua;' .. package.path
 
 local suffix = PLATFORM == "Mac OS X" and 'lib' or (PLATFORM == "Windows" and 'dll' or 'so')
-
-package.cpath = USERDIR .. '/?.' .. ARCH .. "." .. suffix .. ";" .. DATADIR .. '/?.' .. ARCH .. "." .. suffix .. 
-  USERDIR .. '/?.' .. suffix .. ";" .. DATADIR .. '/?.' .. suffix
+package.cpath =
+  USERDIR .. '/?.' .. ARCH .. "." .. suffix .. ";" .. 
+  USERDIR .. '/?/init.' .. ARCH .. "." .. suffix .. ";" .. 
+  USERDIR .. '/?.' .. suffix .. ";" .. 
+  USERDIR .. '/?/init.' .. suffix .. ";" .. 
+  DATADIR .. '/?.' .. ARCH .. "." .. suffix .. 
+  DATADIR .. '/?/init.' .. ARCH .. "." .. suffix .. 
+  DATADIR .. '/?.' .. suffix
+  DATADIR .. '/?/init.' .. suffix
+  
 package.native_plugins = {}
 package.searchers = { package.searchers[1], package.searchers[2], function(modname)
   local path = package.searchpath(modname, package.cpath)


### PR DESCRIPTION
As per discussion on discord, to enable `complex` libraries whose entrypoints are in C, we require this minor change.