### PR TITLE
language_md: don't require space at end on '_', '__', '___'

### DIFF
--- a/data/plugins/language_md.lua
+++ b/data/plugins/language_md.lua
@@ -42,9 +42,9 @@ syntax.add {
     -- blockquote
     { pattern = "^%s*>+%s",                 type = "string" },
     -- alternative bold italic formats
-    { pattern = { "%s___", "___%f[%s]" },   type = "markdown_bold_italic" },
-    { pattern = { "%s__", "__%f[%s]" },     type = "markdown_bold" },
-    { pattern = { "%s_[%S]", "_%f[%s]" },   type = "markdown_italic" },
+    { pattern = { "%s___", "___" },         type = "markdown_bold_italic" },
+    { pattern = { "%s__", "__" },           type = "markdown_bold" },
+    { pattern = { "%s_[%S]", "_" },         type = "markdown_italic" },
     -- reference links
     {
       pattern = "^%s*%[%^()["..in_squares_match.."]+()%]: ",
@@ -166,9 +166,9 @@ syntax.add {
       type = "markdown_italic"
     },
     -- alternative bold italic formats
-    { pattern = "^___[%s%p%w]+___%s" ,      type = "markdown_bold_italic" },
-    { pattern = "^__[%s%p%w]+__%s" ,        type = "markdown_bold" },
-    { pattern = "^_[%s%p%w]+_%s" ,          type = "markdown_italic" },
+    { pattern = "^___[%s%p%w]+___" ,        type = "markdown_bold_italic" },
+    { pattern = "^__[%s%p%w]+__" ,          type = "markdown_bold" },
+    { pattern = "^_[%s%p%w]+_" ,            type = "markdown_italic" },
     -- heading with custom id
     {
       pattern = "^#+%s[%w%s%p]+(){()#[%w%-]+()}",


### PR DESCRIPTION
After some testing it seems that the alternative bold, italic and italic+bold _ expressions do not require a space at the end so disabled that requirement which fixes issues like this one:

![md-issue](https://user-images.githubusercontent.com/1702572/192569084-0c4b7459-63f3-464e-a061-bf8e4567b44f.png)

which should look like:

![md-fixed](https://user-images.githubusercontent.com/1702572/192569585-6761548d-f01e-49fe-841f-58f8921189bf.png)
