### PR TITLE
Fixing minor bug relating to TreeView's cache.

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -50,20 +50,6 @@ function TreeView:new()
 
   self.item_icon_width = 0
   self.item_text_spacing = 0
-
-  self:add_core_hooks()
-end
-
-
-function TreeView:add_core_hooks()
-  -- When a file or directory is deleted we delete the corresponding cache entry
-  -- because if the entry is recreated we may use wrong information from cache.
-  local on_delete = core.on_dirmonitor_delete
-  core.on_dirmonitor_delete = function(dir, filepath)
-    local cache = self.cache[dir.name]
-    if cache then cache[filepath] = nil end
-    on_delete(dir, filepath)
-  end
 end
 
 

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -86,23 +86,23 @@ function TreeView:get_cached(dir, item, dirname)
   -- used only to identify the entry into the cache.
   local cache_name = item.filename .. (item.topdir and ":" or "")
   local t = dir_cache[cache_name]
-  if not t then
-    t = {}
+  if not t or t.type ~= item.type then
+    local n = {}
     local basename = common.basename(item.filename)
     if item.topdir then
-      t.filename = basename
-      t.expanded = true
-      t.depth = 0
-      t.abs_filename = dirname
+      n.filename = basename
+      n.expanded = true
+      n.depth = 0
+      n.abs_filename = dirname
     else
-      t.filename = item.filename
-      t.depth = get_depth(item.filename)
-      t.abs_filename = dirname .. PATHSEP .. item.filename
+      n.filename = item.filename
+      n.depth = get_depth(item.filename)
+      n.abs_filename = dirname .. PATHSEP .. item.filename
     end
-    t.name = basename
-    t.type = item.type
-    t.dir_name = dir.name -- points to top level "dir" item
-    dir_cache[cache_name] = t
+    n.name = basename
+    n.type = item.type
+    n.dir_name = dir.name -- points to top level "dir" item
+    dir_cache[cache_name], t = n, n
   end
   return t
 end

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -73,22 +73,22 @@ function TreeView:get_cached(dir, item, dirname)
   local cache_name = item.filename .. (item.topdir and ":" or "")
   local t = dir_cache[cache_name]
   if not t or t.type ~= item.type then
-    local n = {}
+    t = {}
     local basename = common.basename(item.filename)
     if item.topdir then
-      n.filename = basename
-      n.expanded = true
-      n.depth = 0
-      n.abs_filename = dirname
+      t.filename = basename
+      t.expanded = true
+      t.depth = 0
+      t.abs_filename = dirname
     else
-      n.filename = item.filename
-      n.depth = get_depth(item.filename)
-      n.abs_filename = dirname .. PATHSEP .. item.filename
+      t.filename = item.filename
+      t.depth = get_depth(item.filename)
+      t.abs_filename = dirname .. PATHSEP .. item.filename
     end
-    n.name = basename
-    n.type = item.type
-    n.dir_name = dir.name -- points to top level "dir" item
-    dir_cache[cache_name], t = n, n
+    t.name = basename
+    t.type = item.type
+    t.dir_name = dir.name -- points to top level "dir" item
+    dir_cache[cache_name] = t
   end
   return t
 end


### PR DESCRIPTION
Minor fix before we do a full passthrough and normalize how paths are handled, and who's exactly handling what in maintaining a file list.

EDIT: Sorry, the bug was that the treeview's cache wasn't getting invalidated when a directory had changes correctly, so if you 

```
mkdir test
rmdir test
touch test
```

It would show up as a directory, rather than a file. Fixed now.