### PR TITLE
Use relative mouse position directly for drop event

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -158,7 +158,7 @@ static void push_win32_error(lua_State *L, DWORD rc) {
 
 static int f_poll_event(lua_State *L) {
   char buf[16];
-  int mx, my, wx, wy;
+  int mx, my;
   SDL_Event e;
 
 top:
@@ -209,12 +209,11 @@ top:
       goto top;
 
     case SDL_DROPFILE:
-      SDL_GetGlobalMouseState(&mx, &my);
-      SDL_GetWindowPosition(window, &wx, &wy);
+      SDL_GetMouseState(&mx, &my);
       lua_pushstring(L, "filedropped");
       lua_pushstring(L, e.drop.file);
-      lua_pushinteger(L, mx - wx);
-      lua_pushinteger(L, my - wy);
+      lua_pushinteger(L, mx);
+      lua_pushinteger(L, my);
       SDL_free(e.drop.file);
       return 4;
 


### PR DESCRIPTION
Previously the relative position was calculated using the window position and the global mouse coordinates. In some systems like wayland,  this operation returns incorrect values.