### PR TITLE
dirwatch: exit coroutine if project not open anymore

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -295,7 +295,19 @@ function core.add_project_directory(path)
         end
         return refresh_directory(topdir, dirpath)
       end, 0.01, 0.01)
-      coroutine.yield(changed and 0.05 or 0)
+      -- properly exit coroutine if project not open anymore to clear dir watch
+      local project_dir_open = false
+      for _, prj in ipairs(core.project_directories) do
+        if topdir == prj then
+          project_dir_open = true
+          break
+        end
+      end
+      if project_dir_open then
+        coroutine.yield(changed and 0.05 or 0)
+      else
+        return
+      end
     end
   end)
 


### PR DESCRIPTION
This fixes an issue where lite-xl would keep receiving file system events when the main project directory was changed or additional directory removed since the garbage collector of dirmonitor was never reached.