### PR TITLE
Add on_rescale event to View

### DIFF
--- a/data/core/titleview.lua
+++ b/data/core/titleview.lua
@@ -51,7 +51,7 @@ function TitleView:configure_hit_test(borderless)
   end
 end
 
-function TitleView:on_rescale()
+function TitleView:on_scale_change()
   self:configure_hit_test(self.visible)
 end
 

--- a/data/core/titleview.lua
+++ b/data/core/titleview.lua
@@ -51,6 +51,10 @@ function TitleView:configure_hit_test(borderless)
   end
 end
 
+function TitleView:on_rescale()
+  self:configure_hit_test(self.visible)
+end
+
 function TitleView:update()
   self.size.y = self.visible and title_view_height() or 0
   title_commands[2] = core.window_mode == "maximized" and restore_command or maximize_command

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -49,6 +49,7 @@ local Object = require "core.object"
 ---@field scrollable boolean
 ---@field scrollbar core.view.scrollbar
 ---@field scrollbar_alpha core.view.increment
+---@field current_scale number
 local View = Object:extend()
 
 -- context can be "application" or "session". The instance of objects
@@ -69,6 +70,7 @@ function View:new()
     h = { thumb = 0, track = 0 },
   }
   self.scrollbar_alpha = { value = 0, to = 0 }
+  self.current_scale = SCALE
 end
 
 function View:move_towards(t, k, dest, rate, name)
@@ -242,6 +244,12 @@ function View:on_mouse_wheel(y)
 
 end
 
+---Can be overriden to listen for scale change events to apply
+---any neccesary changes in sizes, padding, etc...
+---@param new_scale number
+---@param prev_scale number
+function View:on_rescale(new_scale, prev_scale) end
+
 function View:get_content_bounds()
   local x = self.scroll.x
   local y = self.scroll.y
@@ -286,6 +294,11 @@ end
 
 
 function View:update()
+  if self.current_scale ~= SCALE then
+    self:on_rescale(SCALE, self.current_scale)
+    self.current_scale = SCALE
+  end
+
   self:clamp_scroll_position()
   self:move_towards(self.scroll, "x", self.scroll.to.x, 0.3, "scroll")
   self:move_towards(self.scroll, "y", self.scroll.to.y, 0.3, "scroll")

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -248,7 +248,7 @@ end
 ---any neccesary changes in sizes, padding, etc...
 ---@param new_scale number
 ---@param prev_scale number
-function View:on_rescale(new_scale, prev_scale) end
+function View:on_scale_change(new_scale, prev_scale) end
 
 function View:get_content_bounds()
   local x = self.scroll.x
@@ -295,7 +295,7 @@ end
 
 function View:update()
   if self.current_scale ~= SCALE then
-    self:on_rescale(SCALE, self.current_scale)
+    self:on_scale_change(SCALE, self.current_scale)
     self.current_scale = SCALE
   end
 


### PR DESCRIPTION
This is a small but convenient change taken from https://github.com/lite-xl/lite-xl-widgets and applied directly into the View class so child views get notified of scale changes to perform any necessary calculations/updates. This PR also fixes #1144 by re-configuring the TitleView hit test on scale changes.