### PR TITLE
dirmonitor: added missing mutex initialization

### DIFF
--- a/src/api/dirmonitor.c
+++ b/src/api/dirmonitor.c
@@ -63,6 +63,7 @@ static int f_dirmonitor_new(lua_State* L) {
   struct dirmonitor* monitor = lua_newuserdata(L, sizeof(struct dirmonitor));
   luaL_setmetatable(L, API_TYPE_DIRMONITOR);
   memset(monitor, 0, sizeof(struct dirmonitor));
+  monitor->mutex = SDL_CreateMutex();
   monitor->internal = init_dirmonitor();
   return 1;
 }

--- a/src/api/dirmonitor/fsevents.c
+++ b/src/api/dirmonitor/fsevents.c
@@ -22,6 +22,7 @@ struct dirmonitor_internal* init_dirmonitor() {
   monitor->stream = NULL;
   monitor->changes = NULL;
   monitor->count = 0;
+  monitor->lock = NULL;
 
   return monitor;
 }
@@ -135,6 +136,8 @@ int translate_changes_dirmonitor(
 
 int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
   stop_monitor_stream(monitor);
+
+  monitor->lock = SDL_CreateMutex();
 
   FSEventStreamContext context = {
     .info = monitor,


### PR DESCRIPTION
As mentioned on #1149 it seems that on newer SDL versions locking an uninitialized mutex automatically creates a mutex for you which causes a crash on older SDL versions. This PR fixes #1149 and also adds the missing initialization on `dirmonitor.c`