### PR TITLE
dirmonitor: add watch to subdirs on file limit mode

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -373,6 +373,11 @@ end
 function core.update_project_subdir(dir, filename, expanded)
   assert(dir.files_limit, "function should be called only when directory is in files limit mode")
   dir.shown_subdir[filename] = expanded
+  if expanded then
+    dir.watch:watch(dir.name .. PATHSEP .. filename)
+  else
+    dir.watch:unwatch(dir.name .. PATHSEP .. filename)
+  end
   return refresh_directory(dir, filename)
 end
 


### PR DESCRIPTION
As discussed on discord with @adamdharrison exceeding the `config.max_project_files` limit wasn't properly adding sub-directory watches when expanding them on the treeview. With his guidance this PR adds the necessary change to add the watches on demand and have proper subdir monitoring.