### PR TITLE
Allowed for font overrides of toolbar items

### DIFF
--- a/data/plugins/toolbarview.lua
+++ b/data/plugins/toolbarview.lua
@@ -43,7 +43,7 @@ end
 
 function ToolbarView:get_icon_width()
   local max_width = 0
-  for i,v in ipairs(self.toolbar_commands) do max_width = math.max(max_width, self.toolbar_font:get_width(v.symbol)) end
+  for i,v in ipairs(self.toolbar_commands) do max_width = math.max(max_width, (v.font or self.toolbar_font):get_width(v.symbol)) end
   return max_width
 end
 
@@ -77,7 +77,7 @@ function ToolbarView:draw()
 
   for item, x, y, w, h in self:each_item() do
     local color = item == self.hovered_item and command.is_valid(item.command) and style.text or style.dim
-    common.draw_text(self.toolbar_font, color, item.symbol, nil, x, y, 0, h)
+    common.draw_text(item.font or self.toolbar_font, color, item.symbol, nil, x, y, 0, h)
   end
 end
 


### PR DESCRIPTION
So plugins can access the toolbar, and add new items with different fonts, if they want to.