### PR TITLE
core: initial encoding conversion support

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -2,6 +2,7 @@ local core = require "core"
 local command = require "core.command"
 local common = require "core.common"
 local config = require "core.config"
+local encodings = require "core.doc.encodings"
 local translate = require "core.doc.translate"
 local style = require "core.style"
 local DocView = require "core.docview"
@@ -544,6 +545,30 @@ local commands = {
     dv.doc.crlf = not dv.doc.crlf
   end,
 
+  ["doc:change-encoding"] = function(dv)
+    encodings.select_encoding("Select Output Encoding", function(charset)
+      dv.doc.encoding = charset
+      if charset ~= "UTF-8" and charset ~= "ASCII" then
+        dv.doc.convert = true
+      else
+        dv.doc.convert = false
+      end
+      dv.doc:save()
+    end)
+  end,
+
+  ["doc:reload-with-encoding"] = function(dv)
+    encodings.select_encoding("Reload With Encoding", function(charset)
+      dv.doc.encoding = charset
+      if charset ~= "UTF-8" and charset ~= "ASCII" then
+        dv.doc.convert = true
+      else
+        dv.doc.convert = false
+      end
+      dv.doc:reload()
+    end)
+  end,
+
   ["doc:save-as"] = function(dv)
     local last_doc = core.last_active_view and core.last_active_view.doc
     local text
@@ -597,7 +622,6 @@ local commands = {
     })
   end,
 
-
   ["file:delete"] = function(dv)
     local filename = dv.doc.abs_filename
     if not filename then
@@ -628,7 +652,6 @@ local commands = {
     split_cursor(1)
     dv.doc:merge_cursors()
   end
-
 }
 
 command.add(function(x, y)

--- a/data/core/doc/encodings.lua
+++ b/data/core/doc/encodings.lua
@@ -1,0 +1,159 @@
+local core = require "core"
+local common = require "core.common"
+
+local encodings = {}
+
+---@class encodings.encoding
+---@field charset string
+---@field name string
+
+---List of encoding regions.
+---@type table<integer,string>
+encodings.groups = {
+  "West European",
+  "East European",
+  "East Asian",
+  "SE & SW Asian",
+  "Middle Eastern",
+  "Unicode"
+}
+
+---Supported iconv encodings grouped by region.
+---@type table<integer,encodings.encoding[]>
+encodings.list = {
+  -- West European
+  {
+    { charset = "ISO-8859-14",  name = "Celtic"         },
+    { charset = "ISO-8859-7",   name = "Greek"          },
+    { charset = "WINDOWS-1253", name = "Greek"          },
+    { charset = "ISO-8859-10",  name = "Nordic"         },
+    { charset = "ISO-8859-3",   name = "South European" },
+    { charset = "IBM850",       name = "Western"        },
+    { charset = "ISO-8859-1",   name = "Western"        },
+    { charset = "ISO-8859-15",  name = "Western"        },
+    { charset = "WINDOWS-1252", name = "Western"        }
+  },
+  -- East European
+  {
+    { charset = "ISO-8859-4",   name = "Baltic"             },
+    { charset = "ISO-8859-13",  name = "Baltic"             },
+    { charset = "WINDOWS-1257", name = "Baltic"             },
+    { charset = "IBM852",       name = "Central European"   },
+    { charset = "ISO-8859-2",   name = "Central European"   },
+    { charset = "WINDOWS-1250", name = "Central European"   },
+    { charset = "IBM855",       name = "Cyrillic"           },
+    { charset = "ISO-8859-5",   name = "Cyrillic"           },
+    { charset = "ISO-IR-111",   name = "Cyrillic"           },
+    { charset = "KOI8-R",       name = "Cyrillic"           },
+    { charset = "WINDOWS-1251", name = "Cyrillic"           },
+    { charset = "CP866",        name = "Cyrillic/Russian"   },
+    { charset = "KOI8-U",       name = "Cyrillic/Ukrainian" },
+    { charset = "ISO-8859-16",  name = "Romanian"           }
+  },
+  -- East Asian
+  {
+    { charset = "GB18030",     name = "Chinese Simplified" },
+    { charset = "GB2312",      name = "Chinese Simplified" },
+    { charset = "GBK",         name = "Chinese Simplified" },
+    { charset = "HZ",          name = "Chinese Simplified" },
+    { charset = "BIG5",        name = "Chinese Traditional" },
+    { charset = "BIG5-HKSCS",  name = "Chinese Traditional" },
+    { charset = "EUC-TW",      name = "Chinese Traditional" },
+    { charset = "EUC-JP",      name = "Japanese" },
+    { charset = "ISO-2022-JP", name = "Japanese" },
+    { charset = "SHIFT_JIS",   name = "Japanese" },
+    { charset = "CP932",       name = "Japanese" },
+    { charset = "EUC-KR",      name = "Korean" },
+    { charset = "ISO-2022-KR", name = "Korean" },
+    { charset = "JOHAB",       name = "Korean" },
+    { charset = "UHC",         name = "Korean" }
+  },
+  -- SE & SW Asian
+  {
+    { charset = "ARMSCII-8",        name = "Armenian"   },
+    { charset = "GEORGIAN-ACADEMY", name = "Georgian"   },
+    { charset = "TIS-620",          name = "Thai"       },
+    { charset = "IBM857",           name = "Turkish"    },
+    { charset = "WINDOWS-1254",     name = "Turkish"    },
+    { charset = "ISO-8859-9",       name = "Turkish"    },
+    { charset = "TCVN",             name = "Vietnamese" },
+    { charset = "VISCII",           name = "Vietnamese" },
+    { charset = "WINDOWS-1258",     name = "Vietnamese" }
+  },
+  -- Middle Eastern
+  {
+    { charset = "IBM864",       name = "Arabic"        },
+    { charset = "ISO-8859-6",   name = "Arabic"        },
+    { charset = "WINDOWS-1256", name = "Arabic"        },
+    { charset = "IBM862",       name = "Hebrew"        },
+    { charset = "ISO-8859-8-I", name = "Hebrew"        },
+    { charset = "WINDOWS-1255", name = "Hebrew"        },
+    { charset = "ISO-8859-8",   name = "Hebrew Visual" }
+  },
+  -- Unicode
+  {
+    { charset = "UTF-7",    name = "Unicode" },
+    { charset = "UTF-8",    name = "Unicode" },
+    { charset = "UTF-16LE", name = "Unicode" },
+    { charset = "UTF-16BE", name = "Unicode" },
+    { charset = "UCS-2LE",  name = "Unicode" },
+    { charset = "UCS-2BE",  name = "Unicode" },
+    { charset = "UTF-32LE", name = "Unicode" },
+    { charset = "UTF-32BE", name = "Unicode" }
+  }
+};
+
+---Get the list of encodings associated to a region.
+---@param label string
+---@return encodings.encoding[] | nil
+function encodings.get_group(label)
+  for idx, name in ipairs(encodings.groups) do
+    if name == label then
+      return encodings.list[idx]
+    end
+  end
+end
+
+---Get the list of encodings associated to a region.
+---@return encodings.encoding[] | nil
+function encodings.get_all()
+  local all = {}
+  for idx, _ in ipairs(encodings.groups) do
+      for _, item in ipairs(encodings.list[idx]) do
+        table.insert(all, item)
+      end
+  end
+  return all
+end
+
+---Open a commandview to select a charset and executes the given callback,
+---@param title_label string Title displayed on the commandview
+---@param callback fun(charset: string)
+function encodings.select_encoding(title_label, callback)
+  core.command_view:enter(title_label, {
+    submit = function(_, item)
+      callback(item.charset)
+    end,
+    suggest = function(text)
+      local charsets = encodings.get_all()
+      local list_labels = {}
+      local list_charset = {}
+      for _, element in ipairs(charsets) do
+        local label = element.name .. " (" .. element.charset .. ")"
+        table.insert(list_labels, label)
+        list_charset[label] = element.charset
+      end
+      local res = common.fuzzy_match(list_labels, text)
+      for i, name in ipairs(res) do
+        res[i] = {
+          text = name,
+          charset = list_charset[name]
+        }
+      end
+      return res
+    end
+  })
+end
+
+
+return encodings;

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -297,6 +297,26 @@ function StatusView:register_docview_items()
 
   self:add_item({
     predicate = predicate_docview,
+    name = "doc:encoding",
+    alignment = StatusView.Item.RIGHT,
+    get_item = function()
+      local dv = core.active_view
+      return {
+        style.text, dv.doc.encoding or "none"
+      }
+    end,
+    command = function(button)
+      if button == "left" then
+        command.perform "doc:change-encoding"
+      elseif button == "right" then
+        command.perform "doc:reload-with-encoding"
+      end
+    end,
+    tooltip = "encoding"
+  })
+
+  self:add_item({
+    predicate = predicate_docview,
     name = "doc:line-ending",
     alignment = StatusView.Item.RIGHT,
     get_item = function()

--- a/docs/api/encoding.lua
+++ b/docs/api/encoding.lua
@@ -1,0 +1,113 @@
+---@meta
+
+---
+---Utilites for encoding detection and conversion.
+---@class encoding
+encoding = {}
+
+---@alias encoding.charset
+---|>'"ARMSCII-8"'
+---| '"BIG5"'
+---| '"BIG5-HKSCS"'
+---| '"CP866"'
+---| '"CP932"'
+---| '"EUC-JP"'
+---| '"EUC-KR"'
+---| '"EUC-TW"'
+---| '"GB18030"'
+---| '"GB2312"'
+---| '"GBK"'
+---| '"GEORGIAN-ACADEMY"'
+---| '"HZ"'
+---| '"IBM850"'
+---| '"IBM852"'
+---| '"IBM855"'
+---| '"IBM857"'
+---| '"IBM862"'
+---| '"IBM864"'
+---| '"ISO-2022-JP"'
+---| '"ISO-2022-KR"'
+---| '"ISO-8859-1"'
+---| '"ISO-8859-2"'
+---| '"ISO-8859-3"'
+---| '"ISO-8859-4"'
+---| '"ISO-8859-5"'
+---| '"ISO-8859-6"'
+---| '"ISO-8859-7"'
+---| '"ISO-8859-8"'
+---| '"ISO-8859-8-I"'
+---| '"ISO-8859-9"'
+---| '"ISO-8859-10"'
+---| '"ISO-8859-13"'
+---| '"ISO-8859-14"'
+---| '"ISO-8859-15"'
+---| '"ISO-8859-16"'
+---| '"ISO-IR-111"'
+---| '"JOHAB"'
+---| '"KOI8-R"'
+---| '"KOI8-U"'
+---| '"SHIFT_JIS"'
+---| '"TCVN"'
+---| '"TIS-620"'
+---| '"UCS-2BE"'
+---| '"UCS-2LE"'
+---| '"UHC"'
+---| '"UTF-16BE"'
+---| '"UTF-16LE"'
+---| '"UTF-32BE"'
+---| '"UTF-32LE"'
+---| '"UTF-7"'
+---| '"UTF-8"'
+---| '"VISCII"'
+---| '"WINDOWS-1250"'
+---| '"WINDOWS-1251"'
+---| '"WINDOWS-1252"'
+---| '"WINDOWS-1253"'
+---| '"WINDOWS-1254"'
+---| '"WINDOWS-1255"'
+---| '"WINDOWS-1256"'
+---| '"WINDOWS-1257"'
+---| '"WINDOWS-1258"'
+
+---
+---Try and detect the encoding to best of capabilities for given file given or
+---returns nil and error message on failure.
+---@param filename string
+---@return string | nil charset
+---@return string errmsg
+function encoding.detect(filename) end
+
+---
+---Same as encoding.detect() but for strings.
+---@param text string
+---@return string | nil charset
+---@return string errmsg
+function encoding.detect_string(text) end
+
+---@class encoding.convert_options
+---@field handle_to_bom boolean @If applicable adds the byte order marks.
+---@field handle_from_bom boolean @If applicable strips the byte order marks.
+---@field strict boolean @When true fail if errors found.
+
+---
+---Converts the given text from one encoding into another.
+---@param tocharset encoding.charset
+---@param fromcharset encoding.charset
+---@param text string
+---@param options? encoding.convert_options
+---@return string | nil converted_text
+---@return string errmsg
+function encoding.convert(tocharset, fromcharset, text, options) end
+
+---
+---Get the byte order marks for the given charset if applicable.
+---@param charset encoding.charset
+---@return string bom
+function encoding.get_charset_bom(charset) end
+
+---
+---Remove the byte order marks from the given text.
+---@param text string A string that may contain a byte order marks.
+---@param charset? encoding.charset Charset to scan, if nil scan all charsets with bom.
+---@return string cleaned_text
+function encoding.strip_bom(text, charset) end

--- a/meson.build
+++ b/meson.build
@@ -110,6 +110,7 @@ if not get_option('source-only')
         default_options: default_fallback_options + ['default_library=static', 'zlib=disabled', 'bzip2=disabled', 'png=disabled', 'harfbuzz=disabled', 'brotli=disabled']
     )
 
+    uchardet_dep = dependency('uchardet')
 
     sdl_options = ['default_library=static']
 
@@ -157,7 +158,7 @@ if not get_option('source-only')
         default_options: default_fallback_options + sdl_options
     )
 
-    lite_deps = [lua_dep, sdl_dep, freetype_dep, pcre2_dep, libm, libdl]
+    lite_deps = [lua_dep, sdl_dep, freetype_dep, pcre2_dep, uchardet_dep, libm, libdl]
 endif
 #===============================================================================
 # Install Configuration

--- a/meson.build
+++ b/meson.build
@@ -110,7 +110,9 @@ if not get_option('source-only')
         default_options: default_fallback_options + ['default_library=static', 'zlib=disabled', 'bzip2=disabled', 'png=disabled', 'harfbuzz=disabled', 'brotli=disabled']
     )
 
-    uchardet_dep = dependency('uchardet')
+    uchardet_dep = dependency('uchardet', fallback: ['uchardet', 'uchardet_dep'],
+        default_options: default_fallback_options + ['default_library=static']
+    )
 
     sdl_options = ['default_library=static']
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -6,6 +6,7 @@ int luaopen_regex(lua_State *L);
 int luaopen_process(lua_State *L);
 int luaopen_dirmonitor(lua_State* L);
 int luaopen_utf8extra(lua_State* L);
+int luaopen_encoding(lua_State* L);
 
 static const luaL_Reg libs[] = {
   { "system",     luaopen_system     },
@@ -14,6 +15,7 @@ static const luaL_Reg libs[] = {
   { "process",    luaopen_process    },
   { "dirmonitor", luaopen_dirmonitor },
   { "utf8extra",  luaopen_utf8extra  },
+  { "encoding",   luaopen_encoding   },
   { NULL, NULL }
 };
 

--- a/src/api/encoding.c
+++ b/src/api/encoding.c
@@ -1,0 +1,542 @@
+#include <SDL.h>
+#include <lua.h>
+#include <lauxlib.h>
+#include <lualib.h>
+#include <stdbool.h>
+#include <uchardet.h>
+
+typedef struct {
+  const char* charset;
+  unsigned char bom[4];
+  int len;
+} bom_t;
+
+/*
+ * List of encodings that can have byte order marks.
+ * Note: UTF-32 should be tested before UTF-16, the order matters.
+*/
+static bom_t bom_list[] = {
+  { "UTF-8",    {0xef, 0xbb, 0xbf},       3 },
+  { "UTF-32LE", {0xff, 0xfe, 0x00, 0x00}, 4 },
+  { "UTF-32BE", {0x00, 0x00, 0xfe, 0xff}, 4 },
+  { "UTF-16LE", {0xff, 0xfe},             2 },
+  { "UTF-16BE", {0xfe, 0xff},             2 },
+  { "GB18030",  {0x84, 0x31, 0x95, 0x33}, 4 },
+  { "UTF-7",    {0x2b, 0x2f, 0x76, 0x38}, 4 },
+  { "UTF-7",    {0x2b, 0x2f, 0x76, 0x39}, 4 },
+  { "UTF-7",    {0x2b, 0x2f, 0x76, 0x2b}, 4 },
+  { "UTF-7",    {0x2b, 0x2f, 0x76, 0x2f}, 4 },
+  { NULL }
+};
+
+/*
+ * NOTE:
+ * Newer uchardet currently has some issues properly detecting some instances of
+ * UTF-8 as seen on https://gitlab.freedesktop.org/uchardet/uchardet/-/issues.
+ * REF: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/5310
+ *
+ * For this reason, we included a third party MIT function to check if a string
+ * is valid utf8 and prefer this result over the one from uchardet.
+*/
+/*************************UTF-8 Validation Code********************************/
+/* Found on: https://stackoverflow.com/a/22135005                             */
+/* Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>             */
+/* See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.             */
+#define UTF8_ACCEPT 0
+#define UTF8_REJECT 1
+
+static const uint8_t utf8d[] = {
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 00..1f
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 20..3f
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 40..5f
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 60..7f
+  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, // 80..9f
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, // a0..bf
+  8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, // c0..df
+  0xa,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x4,0x3,0x3, // e0..ef
+  0xb,0x6,0x6,0x6,0x5,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8, // f0..ff
+  0x0,0x1,0x2,0x3,0x5,0x8,0x7,0x1,0x1,0x1,0x4,0x6,0x1,0x1,0x1,0x1, // s0..s0
+  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,1,1, // s1..s2
+  1,2,1,1,1,1,1,2,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1, // s3..s4
+  1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1, // s5..s6
+  1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
+};
+
+uint32_t utf8_validate(uint32_t *state, const char *str, size_t len) {
+   size_t i;
+   uint32_t type;
+
+    for (i = 0; i < len; i++) {
+        // We don't care about the codepoint, so this is
+        // a simplified version of the decode function.
+        type = utf8d[(uint8_t)str[i]];
+        *state = utf8d[256 + (*state) * 16 + type];
+
+        if (*state == UTF8_REJECT)
+            break;
+    }
+
+    return *state;
+}
+/*************************End of UTF-8 Validation Code*************************/
+
+
+/*
+ * The default SDL_iconv_string allows broken conversions so we need
+ * a more stricter replacement. Also there is no easy way to know the len
+ * of the returned output without inspecting a sequence of \0 which is
+ * slower than returning it in the bytes_written parameter.
+ *
+ * Adapted from: SDL/src/stdlib/SDL_iconv.c
+ */
+char* SDL_iconv_string_custom(
+  const char *tocode, const char *fromcode, const char *inbuf,
+  size_t inbytesleft, size_t* bytes_written, bool strict
+) {
+  SDL_iconv_t cd;
+  char *string;
+  size_t stringsize;
+  char *outbuf;
+  size_t outbytesleft;
+  size_t retCode = 0;
+
+  cd = SDL_iconv_open(tocode, fromcode);
+  if (cd == (SDL_iconv_t) - 1) {
+    return NULL;
+  }
+
+  stringsize = inbytesleft > 4 ? inbytesleft : 4;
+  string = (char *) SDL_malloc(stringsize);
+  if (!string) {
+      SDL_iconv_close(cd);
+      return NULL;
+  }
+  outbuf = string;
+  outbytesleft = stringsize;
+  SDL_memset(outbuf, 0, 4);
+
+  bool has_error = false;
+  while (inbytesleft > 0 && !has_error) {
+    const size_t oldinbytesleft = inbytesleft;
+    retCode = SDL_iconv(cd, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+    switch (retCode) {
+    case SDL_ICONV_E2BIG:
+      {
+        char *oldstring = string;
+        stringsize *= 2;
+        string = (char *) SDL_realloc(string, stringsize);
+        if (!string) {
+          SDL_free(oldstring);
+          SDL_iconv_close(cd);
+          return NULL;
+        }
+        outbuf = string + (outbuf - oldstring);
+        outbytesleft = stringsize - (outbuf - string);
+        SDL_memset(outbuf, 0, 4);
+      }
+      break;
+    case SDL_ICONV_EILSEQ:
+      /* Try skipping some input data - not perfect, but... */
+      if (!strict) {
+        ++inbuf;
+        --inbytesleft;
+      } else {
+        has_error = true;
+      }
+      break;
+    case SDL_ICONV_EINVAL:
+    case SDL_ICONV_ERROR:
+      /* We can't continue... */
+      if (!strict)
+        inbytesleft = 0;
+      else
+        has_error = true;
+      break;
+    }
+    /* Avoid infinite loops when nothing gets converted */
+    if (!strict && oldinbytesleft == inbytesleft) {
+        break;
+    }
+  }
+  SDL_iconv_close(cd);
+
+  if (bytes_written)
+    *bytes_written = outbuf - string;
+
+  if (has_error) {
+    SDL_free(string);
+    return NULL;
+  }
+
+  return string;
+}
+
+
+/* Get the applicable byte order marks for the given charset */
+static const unsigned char* encoding_bom_from_charset(const char* charset, size_t* len) {
+  for (size_t i=0; bom_list[i].charset != NULL; i++){
+    if (strcmp(bom_list[i].charset, charset) == 0) {
+      if (len) *len = bom_list[i].len;
+      return bom_list[i].bom;
+    }
+  }
+
+  if (len) *len = 0;
+
+  return NULL;
+}
+
+
+/* Detect the encoding of the given string if a valid bom sequence is found */
+static const char* encoding_charset_from_bom(
+  const char* string, size_t len, size_t* bom_len
+) {
+  const unsigned char* bytes = (unsigned char*) string;
+
+  for (size_t i=0; bom_list[i].charset != NULL; i++) {
+    if (len >= bom_list[i].len) {
+      bool all_match = true;
+      for (size_t b = 0; b<bom_list[i].len; b++) {
+        if (bytes[b] != bom_list[i].bom[b]) {
+          all_match = false;
+          break;
+        }
+      }
+      if (all_match) {
+        if (bom_len) *bom_len = bom_list[i].len;
+        return bom_list[i].charset;
+      }
+    }
+  }
+
+  if (bom_len)
+      *bom_len = 0;
+
+  return NULL;
+}
+
+
+/* Detects the encoding of a string. */
+const char* encoding_detect(const char* string, size_t string_len) {
+  static char charset[30];
+
+  if (string_len == 0) {
+		return "UTF-8";
+  }
+
+  memset(charset, 0, 30);
+
+  size_t bom_len = 0;
+  const char* bom_charset = encoding_charset_from_bom(
+    string, string_len, &bom_len
+  );
+
+  uint32_t state = UTF8_ACCEPT;
+  bool valid_utf8 = true;
+  uchardet_t handle = uchardet_new();
+
+	int retval = uchardet_handle_data(handle, string, string_len);
+	if (retval == 0) {
+    uchardet_data_end(handle);
+    const char* ucharset = uchardet_get_charset(handle);
+    strcpy(charset, ucharset);
+	}
+	uchardet_delete(handle);
+
+	if(utf8_validate(&state, string, string_len) == UTF8_REJECT) {
+		valid_utf8 = false;
+	}
+
+  state = UTF8_ACCEPT;
+  char* utf8_output = NULL;
+  size_t utf8_len = 0;
+  if (
+    bom_charset
+    &&
+    (
+      (utf8_output = SDL_iconv_string_custom(
+        "UTF-8", bom_charset,
+        string+bom_len, string_len-bom_len,
+        &utf8_len, true
+      )) != NULL
+      &&
+      utf8_validate(&state, utf8_output, utf8_len) != UTF8_REJECT
+    )
+  ) {
+    SDL_free(utf8_output);
+    return bom_charset;
+  }
+
+  if (utf8_output)
+    SDL_free(utf8_output);
+
+  if (valid_utf8) {
+    return "UTF-8";
+  } else if (*charset) {
+    return charset;
+  }
+
+  return NULL;
+}
+
+
+/*
+ * encoding.detect(filename)
+ *
+ * Try to detect the best encoding for the given file.
+ *
+ * Arguments:
+ *  filename, the filename to check
+ *
+ * Returns:
+ *  The charset string or nil
+ *  The error message
+ */
+int f_detect(lua_State *L) {
+  const char* file_name = luaL_checkstring(L, 1);
+
+  FILE* file = fopen(file_name, "rb");
+  fseek(file, 0, SEEK_END);
+
+  size_t file_size = ftell(file);
+  char* string = malloc(file_size);
+
+  if (!string) {
+    lua_pushnil(L);
+		lua_pushfstring(L, "out of ram while detecting charset of '%s'", file_name);
+		fclose(file);
+		return 2;
+  }
+
+  fseek(file, 0, SEEK_SET);
+  fread(string, 1, file_size, file);
+
+  const char* charset = encoding_detect(string, file_size);
+
+  fclose(file);
+  free(string);
+
+  if (charset) {
+    lua_pushstring(L, charset);
+  } else {
+    lua_pushnil(L);
+		lua_pushstring(L, "could not detect the file encoding");
+		return 2;
+  }
+
+  return 1;
+}
+
+
+/*
+ * encoding.detect_string(filename)
+ *
+ * Same as encoding.detect() but for a string.
+ *
+ * Arguments:
+ *  string, the string to check
+ *
+ * Returns:
+ *  The charset string or nil
+ *  The error message
+ */
+int f_detect_string(lua_State *L) {
+	size_t string_len = 0;
+  const char* string = luaL_checklstring(L, 1, &string_len);
+
+  const char* charset = encoding_detect(string, string_len);
+
+  if (charset) {
+    lua_pushstring(L, charset);
+  } else {
+    lua_pushnil(L);
+		lua_pushstring(L, "could not detect the file encoding");
+		return 2;
+  }
+
+  return 1;
+}
+
+
+/*
+ * encoding.convert(tocharset, fromcharset, text, options)
+ *
+ * Convert the given text from one charset into another if possible.
+ *
+ * Arguments:
+ *  tocharset, a string representing a valid iconv charset
+ *  fromcharset, a string representing a valid iconv charset
+ *  text, the string to convert
+ *  options, a table of conversion options
+ *
+ * Returns:
+ *  The converted ouput string or nil
+ *  The error message
+ */
+int f_convert(lua_State *L) {
+  const char* to = luaL_checkstring(L, 1);
+  const char* from = luaL_checkstring(L, 2);
+  size_t text_len = 0;
+  const char* text = luaL_checklstring(L, 3, &text_len);
+  /* conversion options */
+  bool strict = false;
+  bool handle_to_bom = false;
+  bool handle_from_bom = false;
+  const unsigned char* bom;
+  size_t bom_len = 0;
+
+  if (lua_gettop(L) > 3 && lua_istable(L, 4)) {
+    lua_getfield(L, 4, "handle_to_bom");
+    if (lua_isboolean(L, -1)) {
+      handle_to_bom = lua_toboolean(L, -1);
+    }
+    lua_getfield(L, 4, "handle_from_bom");
+    if (lua_isboolean(L, -1)) {
+      handle_from_bom = lua_toboolean(L, -1);
+    }
+    lua_getfield(L, 4, "strict");
+    if (lua_isboolean(L, -1)) {
+      strict = lua_toboolean(L, -1);
+    }
+  }
+
+  /* to strip the bom from the input text if any */
+  if (handle_from_bom) {
+    encoding_charset_from_bom(text, text_len, &bom_len);
+  }
+
+  size_t output_len = 0;
+  char* output = SDL_iconv_string_custom(
+    to, from, text+bom_len, text_len-bom_len, &output_len, strict
+  );
+
+  /* strip bom sometimes added when converting to utf-8, we don't need it */
+  if (output && strcmp(to, "UTF-8") == 0) {
+    encoding_charset_from_bom(output, output_len, &bom_len);
+    if (bom_len > 0) {
+      SDL_memmove(output,output+bom_len, output_len-bom_len);
+      output = SDL_realloc(output, output_len-bom_len);
+      output_len -= bom_len;
+    }
+  }
+
+  if (output != NULL && handle_to_bom) {
+    if (handle_to_bom) {
+      bom = encoding_bom_from_charset(to, &bom_len);
+      if (bom != NULL) {
+        output = SDL_realloc(output, output_len + bom_len);
+        SDL_memmove(output+bom_len, output, output_len);
+        SDL_memcpy(output, bom, bom_len);
+        output_len += bom_len;
+      }
+    }
+  } else if (!output) {
+    lua_pushnil(L);
+    lua_pushfstring(L, "failed converting from '%s' to '%s'", from, to);
+    return 2;
+  }
+
+  lua_pushlstring(L, output, output_len);
+
+  SDL_free(output);
+
+  return 1;
+}
+
+
+/*
+ * encoding.get_charset_bom(charset)
+ *
+ * Retrieve the byte order marks sequence for the given charset if applicable.
+ *
+ * Arguments:
+ *  charset, a string representing a valid iconv charset
+ *
+ * Returns:
+ *  The bom sequence string or empty string if not applicable.
+ */
+int f_get_charset_bom(lua_State *L) {
+  const char* charset = luaL_checkstring(L, 1);
+
+  size_t bom_len = 0;
+  const unsigned char* bom = encoding_bom_from_charset(charset, &bom_len);
+
+  if (bom)
+    lua_pushlstring(L, (char*)bom, bom_len);
+  else
+    lua_pushstring(L, "");
+
+  return 1;
+}
+
+
+/*
+ * encoding.strip_bom(text, charset)
+ *
+ * Remove the byte order marks from the given string.
+ *
+ * Arguments:
+ *  text, a string that may contain a byte order marks to be removed.
+ *  charset, optional charset to scan for, if empty scan all charsets with bom.
+ *
+ * Returns:
+ *  The input text string with the byte order marks removed if found.
+ */
+int f_strip_bom(lua_State* L) {
+  size_t text_len = 0;
+  const char* text = luaL_checklstring(L, 1, &text_len);
+  const char* charset = luaL_optstring(L, 2, NULL);
+  size_t bom_len = 0;
+
+  if (text_len <= 0) {
+    lua_pushstring(L, "");
+  } else {
+    if (charset) {
+      for (size_t i=0; bom_list[i].charset != NULL; i++) {
+        if (
+          strcmp(bom_list[i].charset, charset) == 0
+          &&
+          text_len >= bom_list[i].len
+        ) {
+          bool bom_found = true;
+          for (size_t b=0; b<bom_list[i].len; b++) {
+            if (bom_list[i].bom[b] != (unsigned char)text[b]) {
+              bom_found = false;
+              break;
+            }
+          }
+          if (bom_found) {
+            bom_len = bom_list[i].len;
+            break;
+          }
+        }
+      }
+    } else {
+      encoding_charset_from_bom(text, text_len, &bom_len);
+    }
+  }
+
+  if (bom_len > 0 && text_len-bom_len > 0) {
+    lua_pushlstring(L, text+bom_len, text_len-bom_len);
+  } else {
+    lua_pushlstring(L, text, text_len);
+  }
+
+  return 1;
+}
+
+
+static const luaL_Reg lib[] = {
+  { "detect",          f_detect          },
+  { "detect_string",   f_detect_string   },
+  { "convert",         f_convert         },
+  { "get_charset_bom", f_get_charset_bom },
+  { "strip_bom",       f_strip_bom       },
+  { NULL, NULL }
+};
+
+
+int luaopen_encoding(lua_State *L) {
+  luaL_newlib(L, lib);
+  return 1;
+}

--- a/src/api/encoding.c
+++ b/src/api/encoding.c
@@ -2,8 +2,13 @@
 #include <lua.h>
 #include <lauxlib.h>
 #include <lualib.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <uchardet.h>
+
+#ifdef _WIN32
+  #include <windows.h>
+#endif
 
 typedef struct {
   const char* charset;
@@ -295,7 +300,21 @@ const char* encoding_detect(const char* string, size_t string_len) {
 int f_detect(lua_State *L) {
   const char* file_name = luaL_checkstring(L, 1);
 
+#ifndef _WIN32
   FILE* file = fopen(file_name, "rb");
+#else
+  wchar_t utf16[1024];
+  memset(utf16, 0, sizeof(utf16));
+  MultiByteToWideChar(CP_UTF8, 0, file_name, strlen(file_name), utf16, 1024);
+  FILE* file = _wfopen(utf16, L"rb");
+#endif
+
+  if (!file) {
+    lua_pushnil(L);
+    lua_pushfstring(L, "unable to open file '%s', code=%d", file_name, errno);
+    return 2;
+  }
+
   fseek(file, 0, SEEK_END);
 
   size_t file_size = ftell(file);

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,6 +5,7 @@ lite_sources = [
     'api/system.c',
     'api/process.c',
     'api/utf8.c',
+    'api/encoding.c',
     'renderer.c',
     'renwindow.c',
     'rencache.c',

--- a/subprojects/uchardet.wrap
+++ b/subprojects/uchardet.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = uchardet-0.0.7
+source_url = https://github.com/freedesktop/uchardet/archive/refs/tags/v0.0.7.tar.gz
+source_filename = uchardet-0.0.7.tar.gz
+source_hash = 561db71ffe3b090da48cd17f441bb7976694db55edd9cc16a6bd6ffcb9e66e8f
+patch_filename = uchardet_0.0.7-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/uchardet_0.0.7-2/get_patch
+patch_hash = 10f207101b701a78aaf0bf4bcd0b1669dceea956e4184970e05bca6378f430aa
+wrapdb_version = 0.0.7-2
+
+[provide]
+uchardet = uchardet_dep

--- a/subprojects/uchardet.wrap
+++ b/subprojects/uchardet.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
 directory = uchardet-0.0.7
-source_url = https://github.com/freedesktop/uchardet/archive/refs/tags/v0.0.7.tar.gz
-source_filename = uchardet-0.0.7.tar.gz
-source_hash = 561db71ffe3b090da48cd17f441bb7976694db55edd9cc16a6bd6ffcb9e66e8f
+source_url = https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.7.tar.xz
+source_filename = uchardet-0.0.7.tar.xz
+source_hash = 3fc79408ae1d84b406922fa9319ce005631c95ca0f34b205fad867e8b30e45b1
 patch_filename = uchardet_0.0.7-2_patch.zip
 patch_url = https://wrapdb.mesonbuild.com/v2/uchardet_0.0.7-2/get_patch
 patch_hash = 10f207101b701a78aaf0bf4bcd0b1669dceea956e4184970e05bca6378f430aa


### PR DESCRIPTION
New dependency introduced:
* uchardet - for automatic encoding detection

This PR is for performing automatic encoding detection and conversion on the fly from non UTF-8 to UTF-8 when opening files and from UTF-8 to non UTF-8 on file save. 

Also it properly handles byte order marks management on UTF-16LE, UTF-16BE, UTF-32LE. UTF-32BE, UTF-7, UTF-8 and GB18030 when opening and saving, it also uses the BOM to detect the file charset on file load.

Already in working shape but needs testing and maybe improvements (one of them having a uchardet.wrap for meson build system to support static building), leaving it here for those interested.

![loading-non-utf-8-encodings](https://user-images.githubusercontent.com/1702572/196560029-89d95acb-b5aa-4db3-b4f2-8bece94fa009.png)

![select-output-encoding-on-save](https://user-images.githubusercontent.com/1702572/196560037-8dab6e10-5cd3-4384-a5b4-c505f1b37879.png)
