### PR TITLE
Do not render newline char on DocView

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -364,9 +364,17 @@ end
 function DocView:draw_line_text(line, x, y)
   local default_font = self:get_font()
   local tx, ty = x, y + self:get_line_text_y_offset()
-  for _, type, text in self.doc.highlighter:each_token(line) do
+  local last_token = nil
+  local tokens = self.doc.highlighter:get_line(line).tokens
+  local tokens_count = #tokens
+  if string.sub(tokens[tokens_count], -1) == "\n" then
+    last_token = tokens_count - 1
+  end
+  for tidx, type, text in self.doc.highlighter:each_token(line) do
     local color = style.syntax[type]
     local font = style.syntax_fonts[type] or default_font
+    -- do not render newline, fixes issue #1164
+    if tidx == last_token then text = text:sub(1, -2) end
     tx = renderer.draw_text(font, text, tx, ty, color)
   end
   return self:get_line_height()

--- a/data/plugins/drawwhitespace.lua
+++ b/data/plugins/drawwhitespace.lua
@@ -244,7 +244,7 @@ function DocView:draw_line_text(idx, x, y)
         local color = base_color
         local draw = false
 
-        if e == #text - 1 then
+        if e >= #text - 1 then
           draw = show_trailing
           color = trailing_color
         elseif s == 1 then


### PR DESCRIPTION
As discussed in discord with @Guldoman  and @adamdharrison, this PR fixes #1164 by not drawing the newline character on each line rendered by the `DocView`. It also allows setting a substitute for the `\n` on the `drawwhitespace` plugin.