### PR TITLE
core syntax: strip the path from filename on syntax.get

### DIFF
--- a/data/core/syntax.lua
+++ b/data/core/syntax.lua
@@ -44,7 +44,7 @@ local function find(string, field)
 end
 
 function syntax.get(filename, header)
-  return find(filename, "files")
+  return find(common.basename(filename), "files")
       or (header and find(header, "headers"))
       or plain_text_syntax
 end


### PR DESCRIPTION
Found issue on `syntax.get()` not matching a syntax to files on a subdirectory when the rules of a syntax are like:

* "^Gemfile$"
* "^meson_options.txt$"
* etc...

This is a simple PR that strips the path of filenames passed to `syntax.get()` to fix the issue
