### PR TITLE
docview: support gutter click selection, fixes #1116

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -62,6 +62,7 @@ function DocView:new(doc)
   self.font = "code_font"
   self.last_x_offset = {}
   self.ime_selection = { from = 0, size = 0 }
+  self.hovering_gutter = false
 end
 
 
@@ -245,8 +246,14 @@ end
 function DocView:on_mouse_moved(x, y, ...)
   DocView.super.on_mouse_moved(self, x, y, ...)
 
+  self.hovering_gutter = false
+  local gw = self:get_gutter_width()
+
   if self:scrollbar_hovering() or self:scrollbar_dragging() then
     self.cursor = "arrow"
+  elseif gw > 0 and x >= self.position.x and x <= (self.position.x + gw) then
+    self.cursor = "hand"
+    self.hovering_gutter = true
   else
     self.cursor = "ibeam"
   end
@@ -285,6 +292,26 @@ function DocView:mouse_selection(doc, snap_type, line1, col1, line2, col2)
     return line2, col2, line1, col1
   end
   return line1, col1, line2, col2
+end
+
+
+function DocView:on_mouse_pressed(button, x, y, clicks)
+  if button ~= "left" or not self.hovering_gutter then return end
+  local line = self:resolve_screen_position(x, y)
+  if keymap.modkeys["shift"] then
+    local sline, scol, sline2, scol2 = self.doc:get_selection(true)
+    if line > sline then
+      self.doc:set_selection(line, #self.doc.lines[line], sline, scol)
+    else
+      self.doc:set_selection(line, #self.doc.lines[line], sline2, scol2)
+    end
+  else
+    if clicks == 1 then
+      self.doc:set_selection(line, 1, line, 1)
+    elseif clicks == 2 then
+      self.doc:set_selection(line, 1, line, #self.doc.lines[line])
+    end
+  end
 end
 
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -296,14 +296,16 @@ end
 
 
 function DocView:on_mouse_pressed(button, x, y, clicks)
-  if button ~= "left" or not self.hovering_gutter then return end
+  if button ~= "left" or not self.hovering_gutter then
+    return DocView.super.on_mouse_pressed(self, button, x, y, clicks)
+  end
   local line = self:resolve_screen_position(x, y)
   if keymap.modkeys["shift"] then
     local sline, scol, sline2, scol2 = self.doc:get_selection(true)
     if line > sline then
-      self.doc:set_selection(line, #self.doc.lines[line], sline, scol)
+      self.doc:set_selection(sline, 1, line,  #self.doc.lines[line])
     else
-      self.doc:set_selection(line, #self.doc.lines[line], sline2, scol2)
+      self.doc:set_selection(line, 1, sline2, #self.doc.lines[sline2])
     end
   else
     if clicks == 1 then
@@ -312,6 +314,7 @@ function DocView:on_mouse_pressed(button, x, y, clicks)
       self.doc:set_selection(line, 1, line, #self.doc.lines[line])
     end
   end
+  return true
 end
 
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -252,7 +252,7 @@ function DocView:on_mouse_moved(x, y, ...)
   if self:scrollbar_hovering() or self:scrollbar_dragging() then
     self.cursor = "arrow"
   elseif gw > 0 and x >= self.position.x and x <= (self.position.x + gw) then
-    self.cursor = "hand"
+    self.cursor = "arrow"
     self.hovering_gutter = true
   else
     self.cursor = "ibeam"


### PR DESCRIPTION
Add support to setting current line selection by clicking on the gutter which fixes #1116, behaviour is a follows:

* Change mouse cursor to hand when hovering the gutter
* Single click puts cursor on clicked line at column 1
* Double click sames as single click but selects entire line
* Shift and click allows selection both up or down


https://user-images.githubusercontent.com/1702572/197376152-dce90282-f1ef-4081-abb1-2eca9b25c27e.mp4

