### PR TITLE
Improve IME location updates

### DIFF
--- a/data/core/ime.lua
+++ b/data/core/ime.lua
@@ -4,6 +4,7 @@ local ime = { }
 
 function ime.reset()
   ime.editing = false
+  ime.last_location = { x = 0, y = 0, w = 0, h = 0 }
 end
 
 ---Convert from utf-8 offset and length (from SDL) to byte offsets
@@ -76,7 +77,15 @@ end
 ---@param w number
 ---@param h number
 function ime.set_location(x, y, w, h)
-  system.set_text_input_rect(x, y, w, h)
+  if not ime.last_location or
+     ime.last_location.x ~= x or
+     ime.last_location.y ~= y or
+     ime.last_location.w ~= w or
+     ime.last_location.h ~= h
+  then
+    ime.last_location.x, ime.last_location.y, ime.last_location.w, ime.last_location.h = x, y, w, h
+    system.set_text_input_rect(x, y, w, h)
+  end
 end
 
 ime.reset()

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -178,9 +178,9 @@ end
 -- Events listening
 --------------------------------------------------------------------------------
 function keymap.on_key_pressed(k, ...)
-  -- In Windows during IME composition, input is still sent to us
+  -- In MacOS and Windows during IME composition input is still sent to us
   -- so we just ignore it
-  if ime.editing then return false end
+  if PLATFORM ~= "Linux" and ime.editing then return false end
 
   local mk = modkey_map[k]
   if mk then


### PR DESCRIPTION
* Avoid updating the IME location if it didn't change.
* Update the IME location to follow `DocView` scroll.
* Only apply input blocking workaround to Windows.

About the last point, can someone test if MacOS needs the workaround too?
For example try to press `tab` while the composition menu is visible.