### PR TITLE
Add more options to `Scrollbar`

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -6,6 +6,8 @@ config.message_timeout = 5
 config.mouse_wheel_scroll = 50 * SCALE
 config.animate_drag_scroll = false
 config.scroll_past_end = true
+---@type "expanded" | "contracted" | false @Force the scrollbar status of the DocView
+config.force_scrollbar_status = false
 config.file_size_limit = 10
 config.ignore_files = {
   -- folders

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -62,6 +62,8 @@ function DocView:new(doc)
   self.font = "code_font"
   self.last_x_offset = {}
   self.ime_selection = { from = 0, size = 0 }
+  self.v_scrollbar:set_forced_status(config.force_scrollbar_status)
+  self.h_scrollbar:set_forced_status(config.force_scrollbar_status)
 end
 
 

--- a/data/core/scrollbar.lua
+++ b/data/core/scrollbar.lua
@@ -22,7 +22,7 @@ local Scrollbar = Object:extend()
 ---@class ScrollbarOptions
 ---@field direction "v" | "h" @Vertical or Horizontal
 ---@field alignment "s" | "e" @Start or End (left to right, top to bottom)
----@field force_status "expanded" | "contracted" | false @Force the scrollbar status on hover
+---@field force_status "expanded" | "contracted" | false @Force the scrollbar status
 ---@field expanded_size number? @Override the default value specified by `style.expanded_scrollbar_size`
 ---@field contracted_size number? @Override the default value specified by `style.scrollbar_size`
 
@@ -55,15 +55,23 @@ function Scrollbar:new(options)
   self.alignment = options.alignment or "e"
   ---@type number @Private. Used to keep track of animations
   self.expand_percent = 0
-  ---@type "expanded" | "contracted" | false @Force the scrollbar status on hover
+  ---@type "expanded" | "contracted" | false @Force the scrollbar status
   self.force_status = options.force_status
-  if self.force_status == "expanded" then
-    self.expand_percent = 1
-  end
+  self:set_forced_status(options.force_status)
   ---@type number? @Override the default value specified by `style.expanded_scrollbar_size`
   self.contracted_size = options.contracted_size
   ---@type number? @Override the default value specified by `style.scrollbar_size`
   self.expanded_size = options.expanded_size
+end
+
+
+---Set the status the scrollbar is forced to keep
+---@param status "expanded" | "contracted" | false @The status to force
+function Scrollbar:set_forced_status(status)
+  self.force_status = status
+  if self.force_status == "expanded" then
+    self.expand_percent = 1
+  end
 end
 
 

--- a/data/core/scrollbar.lua
+++ b/data/core/scrollbar.lua
@@ -19,9 +19,12 @@ local Object = require "core.object"
 ---@class core.scrollbar : core.object
 local Scrollbar = Object:extend()
 
----@param direction "v" | "h" @Vertical or Horizontal
----@param alignment "s" | "e" @Start or End (left to right, top to bottom)
-function Scrollbar:new(direction, alignment)
+---@class ScrollbarOptions
+---@field direction "v" | "h" @Vertical or Horizontal
+---@field alignment "s" | "e" @Start or End (left to right, top to bottom)
+
+---@param options ScrollbarOptions
+function Scrollbar:new(options)
   ---Position information of the owner
   self.rect = {
     x = 0, y = 0, w = 0, h = 0,
@@ -44,9 +47,9 @@ function Scrollbar:new(direction, alignment)
   ---What is currently being hovered. `thumb` implies` track`
   self.hovering = { track = false, thumb = false }
   ---@type "v" | "h"@Vertical or Horizontal
-  self.direction = direction or "v"
+  self.direction = options.direction or "v"
   ---@type "s" | "e" @Start or End (left to right, top to bottom)
-  self.alignment = alignment or "e"
+  self.alignment = options.alignment or "e"
   ---@type number @Private. Used to keep track of animations
   self.expand_percent = 0
 end

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -59,8 +59,8 @@ function View:new()
   self.scroll = { x = 0, y = 0, to = { x = 0, y = 0 } }
   self.cursor = "arrow"
   self.scrollable = false
-  self.v_scrollbar = Scrollbar("v", "e")
-  self.h_scrollbar = Scrollbar("h", "e")
+  self.v_scrollbar = Scrollbar({direction = "v", alignment = "e"})
+  self.h_scrollbar = Scrollbar({direction = "h", alignment = "e"})
   self.current_scale = SCALE
 end
 


### PR DESCRIPTION
This adds options to:
* Choose the sizes of the expanded/contracted statuses of the `Scrollbar`.
* Force the status of the `Scrollbar` to expanded/contracted.

Should we use the full name also for the direction and alignment?
What should we do for the "margin" used by `Scrollbar:_overlaps_normal`?
What other options should be added?

@adamharrison I decided to avoid keeping compatibility with `Scrollbar:new(direction, alignment)`, so the `minimap` plugin PR might have to be updated.

Edit: added `config.force_scrollbar_status` to allow forcing the `DocView` scrollbars status.