### PR TITLE
Process API Environment variable behavior on Windows

### DIFF
--- a/src/api/process.c
+++ b/src/api/process.c
@@ -418,7 +418,7 @@ static int process_start(lua_State* L) {
         close(self->child_pipes[stream][stream == STDIN_FD ? 1 : 0]);
       }
       size_t set;
-      for (set = 0; set < env_len && setenv(env_names[set], env_values[set], 1) == 0; ++set);
+      for (set = 0; set < env_len && setenv(env[set].key, env[set].value, 1) == 0; set++);
       if (set == env_len && (!detach || setsid() != -1) && (!cwd || chdir(cwd) != -1))
         execvp(cmd[0], (char** const)cmd);
       const char* msg = strerror(errno);

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -10,7 +10,7 @@
 #if _WIN32
   // https://stackoverflow.com/questions/60645/overlapped-i-o-on-anonymous-pipe
   // https://docs.microsoft.com/en-us/windows/win32/procthread/creating-a-child-process-with-redirected-input-and-output
-  #include <windows.h> 
+  #include <windows.h>
 #else
   #include <errno.h>
   #include <unistd.h>
@@ -116,7 +116,7 @@ static bool signal_process(process_t* proc, signal_e sig) {
       case SIGNAL_INTERRUPT: kill(-proc->pid, SIGINT); break;
     }
   #endif
-  if (terminate) 
+  if (terminate)
     poll_process(proc, WAIT_NONE);
   return true;
 }
@@ -199,9 +199,9 @@ static int process_start(lua_State* L) {
           }
           self->child_pipes[i][i == STDIN_FD ? 1 : 0] = INVALID_HANDLE_VALUE;
         break;
-        case REDIRECT_DISCARD: 
-          self->child_pipes[i][0] = INVALID_HANDLE_VALUE; 
-          self->child_pipes[i][1] = INVALID_HANDLE_VALUE; 
+        case REDIRECT_DISCARD:
+          self->child_pipes[i][0] = INVALID_HANDLE_VALUE;
+          self->child_pipes[i][1] = INVALID_HANDLE_VALUE;
         break;
         default: {
           if (new_fds[i] == i) {
@@ -288,7 +288,7 @@ static int process_start(lua_State* L) {
       goto cleanup;
     }
     self->pid = (long)self->process_information.dwProcessId;
-    if (detach) 
+    if (detach)
       CloseHandle(self->process_information.hProcess);
     CloseHandle(self->process_information.hThread);
   #else
@@ -420,7 +420,7 @@ static int f_close_stream(lua_State* L) {
 static int process_strerror(lua_State* L) {
   #if _WIN32
     return 1;
-  #endif 
+  #endif
   int error_code = luaL_checknumber(L, 1);
   if (error_code < 0)
     lua_pushstring(L, strerror(error_code));
@@ -478,13 +478,13 @@ static int self_signal(lua_State* L, signal_e sig) {
 static int f_terminate(lua_State* L) { return self_signal(L, SIGNAL_TERM); }
 static int f_kill(lua_State* L) { return self_signal(L, SIGNAL_KILL); }
 static int f_interrupt(lua_State* L) { return self_signal(L, SIGNAL_INTERRUPT); }
-static int f_gc(lua_State* L) { 
+static int f_gc(lua_State* L) {
   process_t* self = (process_t*) luaL_checkudata(L, 1, API_TYPE_PROCESS);
   if (!self->detached)
     signal_process(self, SIGNAL_TERM);
   close_fd(&self->child_pipes[STDIN_FD ][1]);
   close_fd(&self->child_pipes[STDOUT_FD][0]);
-  close_fd(&self->child_pipes[STDERR_FD][0]); 
+  close_fd(&self->child_pipes[STDERR_FD][0]);
   poll_process(self, 10);
   return 0;
 }
@@ -529,7 +529,7 @@ int luaopen_process(lua_State *L) {
   API_CONSTANT_DEFINE(L, -1, "STREAM_STDERR", STDERR_FD);
 
   API_CONSTANT_DEFINE(L, -1, "REDIRECT_DEFAULT", REDIRECT_DEFAULT);
-  API_CONSTANT_DEFINE(L, -1, "REDIRECT_STDOUT", STDOUT_FD); 
+  API_CONSTANT_DEFINE(L, -1, "REDIRECT_STDOUT", STDOUT_FD);
   API_CONSTANT_DEFINE(L, -1, "REDIRECT_STDERR", STDERR_FD);
   API_CONSTANT_DEFINE(L, -1, "REDIRECT_PARENT", REDIRECT_PARENT); // Redirects to parent's STDOUT/STDERR
   API_CONSTANT_DEFINE(L, -1, "REDIRECT_DISCARD", REDIRECT_DISCARD); // Closes the filehandle, discarding it.


### PR DESCRIPTION
On Windows, when a string is passed to lpEnvironment the child process will have nothing but the variables in that string. This is contrary with the POSIX side of things which just extends the parent's environment variable. This PR fixes that (along with sorted environment because libuv seems to do it).
