### PR TITLE
Make `DocView` aware of scrollbars sizes

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -226,7 +226,7 @@ end
 
 
 function DocView:scroll_to_make_visible(line, col)
-  local ox, oy = self:get_content_offset()
+  local _, oy = self:get_content_offset()
   local _, ly = self:get_line_screen_position(line, col)
   local lh = self:get_line_height()
   self.scroll.to.y = common.clamp(self.scroll.to.y, ly - oy - self.size.y + lh * 2, ly - oy - lh)
@@ -235,8 +235,10 @@ function DocView:scroll_to_make_visible(line, col)
   local xmargin = 3 * self:get_font():get_width(' ')
   local xsup = xoffset + gw + xmargin
   local xinf = xoffset - xmargin
-  if xsup > self.scroll.x + self.size.x then
-    self.scroll.to.x = xsup - self.size.x
+  local _, _, scroll_w = self.v_scrollbar:get_track_rect()
+  local size_x = math.max(0, self.size.x - scroll_w)
+  if xsup > self.scroll.x + size_x then
+    self.scroll.to.x = xsup - size_x
   elseif xinf < self.scroll.x then
     self.scroll.to.x = math.max(0, xinf)
   end

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -108,7 +108,8 @@ end
 
 function DocView:get_scrollable_size()
   if not config.scroll_past_end then
-    return self:get_line_height() * (#self.doc.lines) + style.padding.y * 2
+    local _, _, _, h_scroll = self.h_scrollbar:get_track_rect()
+    return self:get_line_height() * (#self.doc.lines) + style.padding.y * 2 + h_scroll
   end
   return self:get_line_height() * (#self.doc.lines - 1) + self.size.y
 end
@@ -217,7 +218,8 @@ function DocView:scroll_to_line(line, ignore_if_visible, instant)
   if not (ignore_if_visible and line > min and line < max) then
     local x, y = self:get_line_screen_position(line)
     local ox, oy = self:get_content_offset()
-    self.scroll.to.y = math.max(0, y - oy - self.size.y / 2)
+    local _, _, _, scroll_h = self.h_scrollbar:get_track_rect()
+    self.scroll.to.y = math.max(0, y - oy - (self.size.y - scroll_h) / 2)
     if instant then
       self.scroll.y = self.scroll.to.y
     end
@@ -229,7 +231,8 @@ function DocView:scroll_to_make_visible(line, col)
   local _, oy = self:get_content_offset()
   local _, ly = self:get_line_screen_position(line, col)
   local lh = self:get_line_height()
-  self.scroll.to.y = common.clamp(self.scroll.to.y, ly - oy - self.size.y + lh * 2, ly - oy - lh)
+  local _, _, _, scroll_h = self.h_scrollbar:get_track_rect()
+  self.scroll.to.y = common.clamp(self.scroll.to.y, ly - oy - self.size.y + scroll_h + lh * 2, ly - oy - lh)
   local gw = self:get_gutter_width()
   local xoffset = self:get_col_x_offset(line, col)
   local xmargin = 3 * self:get_font():get_width(' ')


### PR DESCRIPTION
This is useful for plugins like `minimap` or when using custom scrollbar sizes.