### PR TITLE
ci release: add macos arm64 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,9 @@ jobs:
     name: macOS (x86_64)
     needs: release
     runs-on: macos-11
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
     env:
       CC: clang
       CXX: clang++
@@ -110,8 +113,8 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-          echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-macos-$(uname -m)" >> "$GITHUB_ENV"
-          echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos-$(uname -m)" >> "$GITHUB_ENV"
+          echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
+          echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v2
       - name: Python Setup
         uses: actions/setup-python@v2
@@ -122,11 +125,11 @@ jobs:
       - name: Build
         run: |
           bash --version
-          bash scripts/build.sh --bundle --debug --forcefallback --release
+          CROSS_ARCH=${{ matrix.arch }} bash scripts/build.sh --bundle --debug --forcefallback --release
       - name: Create DMG Image
         run: |
-          bash scripts/package.sh --version ${INSTALL_REF} --debug --dmg --release
-          bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --dmg --release
+          CROSS_ARCH=${{ matrix.arch }} bash scripts/package.sh --version ${INSTALL_REF} --debug --dmg --release
+          CROSS_ARCH=${{ matrix.arch }} bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --dmg --release
       - name: Upload Files
         uses: softprops/action-gh-release@v1
         with:

--- a/resources/macos/Info.plist.in
+++ b/resources/macos/Info.plist.in
@@ -27,7 +27,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>@PROJECT_VERSION@</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>© 2019-2021 Francesco Abbate</string>
+	<string>© 2019-2022 Lite XL Team</string>
 </dict>
-</plist> 
+</plist>
 

--- a/resources/macos/macos_arm64.conf
+++ b/resources/macos/macos_arm64.conf
@@ -1,0 +1,24 @@
+[host_machine]
+system = 'darwin'
+cpu_family = 'aarch64'
+cpu = 'arm64'
+endian = 'little'
+
+[binaries]
+c = ['clang']
+cpp = ['clang++']
+objc = ['clang']
+objcpp = ['clang++']
+ar = ['ar']
+strip = ['strip']
+pkgconfig = ['pkg-config']
+
+[built-in options]
+c_args = ['-arch', 'arm64']
+cpp_args = ['-stdlib=libc++', '-arch', 'arm64']
+objc_args = ['-arch', 'arm64']
+objcpp_args = ['-stdlib=libc++', '-arch', 'arm64']
+c_link_args = ['-arch', 'arm64']
+cpp_link_args = ['-arch', 'arm64']
+objc_link_args = ['-arch', 'arm64']
+objcpp_link_args = ['-arch', 'arm64']

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,6 +31,7 @@ show_help() {
 
 main() {
   local platform="$(get_platform_name)"
+  local arch="$(get_platform_arch)"
   local build_dir="$(get_default_build_dir)"
   local build_type="debug"
   local prefix=/
@@ -106,11 +107,16 @@ main() {
       portable=""
   fi
 
+  if [[ $platform == "macos" && $arch == "arm64" ]]; then
+      cross_file="--cross-file resources/macos/macos_arm64.conf"
+  fi
+
   rm -rf "${build_dir}"
 
   CFLAGS=$CFLAGS LDFLAGS=$LDFLAGS meson setup \
     --buildtype=$build_type \
     --prefix "$prefix" \
+    $cross_file \
     $force_fallback \
     $bundle \
     $portable \
@@ -124,7 +130,7 @@ main() {
 
   meson compile -C "${build_dir}"
 
-  if [ ! -z ${pgo+x} ]; then
+  if [[ $pgo != "" ]]; then
     cp -r data "${build_dir}/src"
     "${build_dir}/src/lite-xl"
     meson configure -Db_pgo=use "${build_dir}"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -81,6 +81,8 @@ get_platform_arch() {
     else
       arch=i686
     fi
+  elif [[ $CROSS_ARCH != "" ]]; then
+    arch=$CROSS_ARCH
   fi
   echo "$arch"
 }


### PR DESCRIPTION
As the title says, added support for cross compiling to MacOS arm64 from the GitHub release.yml workflow by adding a cross file for meson and that architecture along other minor changes. Haven't tested the binaries since I don't have Apple Silicon Hardware (M1, M2...) but the resulting testing binaries can be downloaded from the links below:

* https://github.com/jgmdev/lite-xl/releases/download/v2.1.0/lite-xl-v2.1.0-addons-macos-arm64.dmg
* https://github.com/jgmdev/lite-xl/releases/download/v2.1.0/lite-xl-v2.1.0-macos-arm64.dmg