### PR TITLE
Add `config.keep_newline_whitespace` option

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -287,7 +287,7 @@ local commands = {
         indent = indent:sub(#indent + 2 - col)
       end
       -- Remove current line if it contains only whitespace
-      if dv.doc.lines[line]:match("^%s+$") then
+      if not config.keep_newline_whitespace and dv.doc.lines[line]:match("^%s+$") then
         dv.doc:remove(line, 1, line, math.huge)
       end
       dv.doc:text_input("\n" .. indent, idx)

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -30,6 +30,7 @@ config.highlight_current_line = true
 config.line_height = 1.2
 config.indent_size = 2
 config.tab_type = "soft"
+config.keep_newline_whitespace = false
 config.line_limit = 80
 config.max_project_files = 2000
 config.transitions = true


### PR DESCRIPTION
This option will avoid removing line content when pressing enter in lines with only whitespace.

See #1060.