### PR TITLE
macOS: `-mmacosx-version-min` is required for setting min version

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -108,8 +108,16 @@ main() {
   fi
 
   if [[ $CROSS_ARCH != "" ]]; then
-    if [[ $platform == "macos" && $CROSS_ARCH == "arm64" ]]; then
+    if [[ $platform == "macos" ]]; then
+      macos_version_min=10.11
+      if [[ $CROSS_ARCH == "arm64" ]]; then
         cross_file="--cross-file resources/macos/macos_arm64.conf"
+        macos_version_min=11.0
+      fi
+      export MIN_SUPPORTED_MACOSX_DEPLOYMENT_TARGET=$macos_version_min
+      export CFLAGS=-mmacosx-version-min=$macos_version_min
+      export CXXFLAGS=-mmacosx-version-min=$macos_version_min
+      export LDFLAGS=-mmacosx-version-min=$macos_version_min
     fi
   fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -114,6 +114,7 @@ main() {
         cross_file="--cross-file resources/macos/macos_arm64.conf"
         macos_version_min=11.0
       fi
+      export MACOSX_DEPLOYMENT_TARGET=$macos_version_min
       export MIN_SUPPORTED_MACOSX_DEPLOYMENT_TARGET=$macos_version_min
       export CFLAGS=-mmacosx-version-min=$macos_version_min
       export CXXFLAGS=-mmacosx-version-min=$macos_version_min


### PR DESCRIPTION
Before vs After:
<img width="965" alt="image" src="https://user-images.githubusercontent.com/602245/200920127-b87c9174-3f16-4e02-b768-125be6b159b6.png">

`vtool -show-build lite-xl` (just a nicer checker than `otool -l`)

Before:
```
Load command 10
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform MACOS
    minos 11.0
      sdk 12.1
   ntools 1
     tool LD
  version 711.0
```

After (Intel build):
```
Load command 9
      cmd LC_VERSION_MIN_MACOSX
  cmdsize 16
  version 10.11
      sdk 12.1
```
`vtool` output of Apple Silicon build is unchanged.

Setting the min version to 11.0 for Apple Silicon, and 10.11 for Intel, verified thru GitHub actions: https://github.com/vkedwardli/lite-xl/releases/tag/v2.1.3
https://github.com/vkedwardli/lite-xl/actions/runs/3431233066

Fixes https://github.com/lite-xl/lite-xl/issues/429 