### PR TITLE
Use subsyntax info to toggle comments

### DIFF
--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -100,6 +100,21 @@ local function retrieve_syntax_state(incoming_syntax, state)
   return current_syntax, subsyntax_info, current_pattern_idx, current_level
 end
 
+---Return the list of syntaxes used in the specified state.
+---@param base_syntax table @The initial base syntax (the syntax of the file)
+---@param state string @The state of the tokenizer to extract from
+---@return table @Array of syntaxes starting from the innermost one
+function tokenizer.extract_subsyntaxes(base_syntax, state)
+  local current_syntax
+  local t = {}
+  repeat
+    current_syntax = retrieve_syntax_state(base_syntax, state)
+    table.insert(t, current_syntax)
+    state = string.sub(state, 2)
+  until #state == 0
+  return t
+end
+
 local function report_bad_pattern(log_fn, syntax, pattern_idx, msg, ...)
   if not bad_patterns[syntax] then
     bad_patterns[syntax] = { }

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -136,7 +136,7 @@ function tokenizer.tokenize(incoming_syntax, text, state)
     return { "normal", text }
   end
 
-  state = state or ""
+  state = state or string.char(0)
   -- incoming_syntax    : the parent syntax of the file.
   -- state              : a string of bytes representing syntax state (see above)
 


### PR DESCRIPTION
Fixes #1194.

Also this sets the initial tokenizer state to `"\0"` which should to be more similar to how we managed it before.