### PR TITLE
OpenType / FreeType variation fonts

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -528,6 +528,24 @@ local style = require "core.style"
 -- underline: true, false
 -- smoothing: true, false
 -- strikethrough: true, false
+-- variation: see below
+--
+-- Lite XL also support font variations if a OpenType / FreeType variation font is used.
+-- Do not confuse this with TrueType collection files (.ttc) files which contain discrete faces.
+-- This can be used for emboldening / italicizing fonts and generally yields better quality than
+-- setting italic and bold to true as it uses font-specific configuration.
+-- NOTE: Before setting any parameter related to font variation, please consult your font documentation
+-- for possible parameters and value ranges.
+--
+-- Roboto Flex, thin
+-- { variation = "Thin" }
+--
+-- Roboto Flex, thin and slanted
+-- Note that Roboto Flex does not support ital, thus we use slnt to simulate italic.
+-- { variation = { "Thin", slnt = -10 } }
+--
+-- Roboto Flex, very thin stroke
+-- { variation = { YOPQ = 25 } }
 
 ------------------------------ Plugins ----------------------------------------
 

--- a/docs/api/renderer.lua
+++ b/docs/api/renderer.lua
@@ -16,15 +16,36 @@ renderer = {}
 ---@field public a number Alpha
 
 ---
+---Advanced font variation options for OpenType/FreeType variation fonts.
+---This is a table that has key-value pairs of parametric axis tag/names and the value.
+---It can also contain a string at index 1, which the string will be used as a named variation.
+---The values are converted to 16.16 packed fraction for Opentype and Truetype fonts.
+---Only axis tags that are supported by the font will be applied.
+---Only standard Opentype tags will be documented here; for supported tags their value ranges,
+---please refer to the font documentation.
+---@see https://fonts.google.com/knowledge/glossary/parametric_axis
+---@see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide
+---@see https://learn.microsoft.com/en-us/typography/opentype/spec/dvaraxisreg
+---@class renderer.variationoptions
+---@field public ital number Italicizes the font
+---@field public opsz number Optical size
+---@field public slnt number Slant, can be used if ital is unavailable
+---@field public wdth number Width
+---@field public wght number Weight
+renderer.variationoptions = {}
+
+---
 ---Represent options that affect a font's rendering.
 ---@class renderer.fontoptions
----@field public antialiasing "none" | "grayscale" | "subpixel"
----@field public hinting "slight" | "none" | "full"
----@field public bold boolean
----@field public italic boolean
+---@field public antialiasing "'none'" | "'grayscale'" | "'subpixel'"
+---@field public hinting "'slight'" | "'none'" | '"full"'
+---@field public bold boolean Emboldens the font. For advanced options, see renderer.variationoptions.
+---@field public italic boolean Italicizes the font. For advanced options, see renderer.variationoptions.
 ---@field public underline boolean
 ---@field public smoothing boolean
 ---@field public strikethrough boolean
+---@field public variation string | renderer.variationoptions
+renderer.fontoptions = {}
 
 ---
 ---@class renderer.font

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -13,6 +13,7 @@
 
 
 #define FONT_FALLBACK_MAX 10
+#define FONT_VARIATION_AXIS_DEFAULT HUGE_VAL
 typedef struct RenFont RenFont;
 typedef enum { FONT_HINTING_NONE, FONT_HINTING_SLIGHT, FONT_HINTING_FULL } ERenFontHinting;
 typedef enum { FONT_ANTIALIASING_NONE, FONT_ANTIALIASING_GRAYSCALE, FONT_ANTIALIASING_SUBPIXEL } ERenFontAntialiasing;
@@ -20,13 +21,15 @@ typedef enum { FONT_STYLE_BOLD = 1, FONT_STYLE_ITALIC = 2, FONT_STYLE_UNDERLINE 
 typedef struct { uint8_t b, g, r, a; } RenColor;
 typedef struct { int x, y, width, height; } RenRect;
 typedef struct { SDL_Surface *surface; int scale; } RenSurface;
+typedef struct { const char *tag; double value; } RenFontVariationAxis;
+typedef struct { const char *name; int axis_len; RenFontVariationAxis *axis; } RenFontVariation;
 
 struct RenWindow;
 typedef struct RenWindow RenWindow;
 extern RenWindow window_renderer;
 
-RenFont* ren_font_load(RenWindow *window_renderer, const char *filename, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, unsigned char style);
-RenFont* ren_font_copy(RenWindow *window_renderer, RenFont* font, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, int style);
+RenFont* ren_font_load(RenWindow *window_renderer, const char *filename, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, unsigned char style, RenFontVariation *variation);
+RenFont* ren_font_copy(RenWindow *window_renderer, RenFont* font, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, int style, RenFontVariation *variation);
 const char* ren_font_get_path(RenFont *font);
 void ren_font_free(RenFont *font);
 int ren_font_group_get_tab_size(RenFont **font);


### PR DESCRIPTION
Introduces OpenType / FreeTYpe variation font support.

This is a rather advanced configuration option but would allow us to ditch faux-italic and emboldening on supported fonts.

Here are some examples that I documented in init file:

1. Thin
![image](https://user-images.githubusercontent.com/20792268/202341001-d47bf835-4372-4e70-9752-22fa3fc9fc0c.png)

2. Thin and slanted
![image](https://user-images.githubusercontent.com/20792268/202341012-56a05529-6fd7-42b4-91f2-dfd97a1fc9da.png)

3. Thin stroke (???)
![image](https://user-images.githubusercontent.com/20792268/202341029-fd97d589-969f-4f6d-acfe-5eeb365f4a35.png)

Some question remains, namely:
1. should we try italicize/embolden with variation fonts before faux-italicizing/emboldening?
2. Not all fonts supports the ital parameter (which is basically boolean to toggle italicization), but some do support slnt (which is the same, but its in degrees of slantness). Should we fall back to that as well?
3. For emboldening, it can be done via specifying a named style (eg. "Bold"). Should we cover that behavior as well with `bold = true`?

I don't expect this PR to be merged immediately as we might have bugfix releases before another feature release. We should definitely prioritize bugs and regressions.

Closes #747 