### PR TITLE
meson: updated all subproject wraps

### DIFF
--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,9 +1,10 @@
 [wrap-file]
-directory = freetype-2.11.1
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.11.1.tar.gz
-source_filename = freetype-2.11.1.tar.gz
-source_hash = f8db94d307e9c54961b39a1cc799a67d46681480696ed72ecf78d4473770f09b
+directory = freetype-2.12.1
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.12.1.tar.xz
+source_filename = freetype-2.12.1.tar.xz
+source_hash = 4766f20157cc4cf0cd292f80bf917f92d1c439b243ac3018debf6b9140c41a7f
+wrapdb_version = 2.12.1-2
 
 [provide]
 freetype2 = freetype_dep
-
+freetype = freetype_dep

--- a/subprojects/pcre2.wrap
+++ b/subprojects/pcre2.wrap
@@ -1,15 +1,15 @@
 [wrap-file]
-directory = pcre2-10.39
-source_url = https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-10.39.tar.bz2
-source_filename = pcre2-10.39.tar.bz2
-source_hash = 0f03caf57f81d9ff362ac28cd389c055ec2bf0678d277349a1a4bee00ad6d440
-patch_filename = pcre2_10.39-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.39-2/get_patch
-patch_hash = c4cfffff83e7bb239c8c330339b08f4367b019f79bf810f10c415e35fb09cf14
+directory = pcre2-10.40
+source_url = https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.40/pcre2-10.40.tar.bz2
+source_filename = pcre2-10.40.tar.bz2
+source_hash = 14e4b83c4783933dc17e964318e6324f7cae1bc75d8f3c79bc6969f00c159d68
+patch_filename = pcre2_10.40-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.40-3/get_patch
+patch_hash = 95391923529b4c1647a2cf88cd3b59cceb4f92393775e011f530e7865de0c7fb
+wrapdb_version = 10.40-3
 
 [provide]
 libpcre2-8 = -libpcre2_8
 libpcre2-16 = -libpcre2_16
 libpcre2-32 = -libpcre2_32
 libpcre2-posix = -libpcre2_posix
-

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -1,12 +1,12 @@
 [wrap-file]
-directory = SDL2-2.24.1
-source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.24.1/SDL2-2.24.1.tar.gz
-source_filename = SDL2-2.24.1.tar.gz
-source_hash = bc121588b1105065598ce38078026a414c28ea95e66ed2adab4c44d80b309e1b
-patch_filename = sdl2_2.24.1-4_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.24.1-4/get_patch
-patch_hash = effe31a11a8a0bd844ab11338519c40ed4460176c946236740ee65fc10aa4af0
-wrapdb_version = 2.24.1-4
+directory = SDL2-2.24.2
+source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.24.2/SDL2-2.24.2.tar.gz
+source_filename = SDL2-2.24.2.tar.gz
+source_hash = b35ef0a802b09d90ed3add0dcac0e95820804202914f5bb7b0feb710f1a1329f
+patch_filename = sdl2_2.24.2-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.24.2-1/get_patch
+patch_hash = 9952a79eee3e53dc04daac494a4c0b8cd4c062bfe7365c4766a6bfa15c85b52d
+wrapdb_version = 2.24.2-1
 
 [provide]
 sdl2 = sdl2_dep


### PR DESCRIPTION
Updated outdated meson subproject wraps as reported with `meson wrap status` using `meson wrap update`