### PR TITLE
Show number of selections in status view when >1

### DIFF
--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -214,6 +214,10 @@ function StatusView:register_docview_items()
     alignment = StatusView.Item.LEFT,
     get_item = function()
       local dv = core.active_view
+      local nsel = #dv.doc.selections // 4
+      if nsel > 1 then
+        return { style.text, nsel, " selections" }
+      end
       local line, col = dv.doc:get_selection()
       local _, indent_size = dv.doc:get_indent_info()
       -- Calculating tabs when the doc is using the "hard" indent type.


### PR DESCRIPTION
When there is more than one selection, status view still only shows the info for one of them, which is not very useful.

With this change, if there is more than one selection, the status view instead shows the number of selections.
