### PR TITLE
autocomplete: wrap the autocomplete results around

### DIFF
--- a/data/plugins/autocomplete.lua
+++ b/data/plugins/autocomplete.lua
@@ -647,11 +647,8 @@ command.add(predicate, {
     reset_suggestions()
   end,
 
-  ["autocomplete:previous"] = function()    
-    suggestions_idx = suggestions_idx - 1
-    if suggestions_idx < 1 then
-      suggestions_idx = #suggestions
-    end
+  ["autocomplete:previous"] = function()
+    suggestions_idx = (suggestions_idx - 2) % #suggestions + 1
   end,
 
   ["autocomplete:next"] = function()

--- a/data/plugins/autocomplete.lua
+++ b/data/plugins/autocomplete.lua
@@ -647,12 +647,15 @@ command.add(predicate, {
     reset_suggestions()
   end,
 
-  ["autocomplete:previous"] = function()
-    suggestions_idx = math.max(suggestions_idx - 1, 1)
+  ["autocomplete:previous"] = function()    
+    suggestions_idx = suggestions_idx - 1
+    if suggestions_idx < 1 then
+      suggestions_idx = #suggestions
+    end
   end,
 
   ["autocomplete:next"] = function()
-    suggestions_idx = math.min(suggestions_idx + 1, #suggestions)
+    suggestions_idx = (suggestions_idx % #suggestions) + 1
   end,
 
   ["autocomplete:cycle"] = function()


### PR DESCRIPTION
Changed the ```data/plugins/autocomplete.lua```, so that the autocomplete results get wrapped around