### PR TITLE
Make divider in contextmenu less aggressive

### DIFF
--- a/data/core/contextmenu.lua
+++ b/data/core/contextmenu.lua
@@ -9,6 +9,7 @@ local View = require "core.view"
 
 local border_width = 1
 local divider_width = 1
+local divider_padding = 5
 local DIVIDER = {}
 
 ---@class core.contextmenu : core.object
@@ -29,7 +30,7 @@ local function get_item_size(item)
   local lw, lh
   if item == DIVIDER then
     lw = 0
-    lh = divider_width
+    lh = divider_width + divider_padding * SCALE * 2
   else
     lw = style.font:get_width(item.text)
     if item.info then
@@ -224,7 +225,7 @@ function ContextMenu:draw_context_menu()
 
   for i, item, x, y, w, h in self:each_item() do
     if item == DIVIDER then
-      renderer.draw_rect(x, y, w, h, style.caret)
+      renderer.draw_rect(x, y + divider_padding * SCALE, w, divider_width, style.divider)
     else
       if i == self.selected then
         renderer.draw_rect(x, y, w, h, style.selection)


### PR DESCRIPTION
Hello.

I propose the following change:
- use divider color instead of caret;
- add a vertical padding on the divider.

Obviously, the divider is even better if its color is brighter, or darker but it makes sense to me to use the same color as the context menu's border. It will feel less "cheap".

Here's a preview:

![menu](https://user-images.githubusercontent.com/930282/206025832-0e862ee6-c553-42de-8917-59d9d626a5c4.png)


