### PR TITLE
fix: move tab scroll buttons to remove spacing before 1st tab

### DIFF
--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -565,13 +565,13 @@ function Node:draw_tabs()
   end
 
   if #self.views > tabs_number then
-    local xrb, yrb, wrb = self:get_scroll_button_rect(2)
-    local button_style = (self.hovered_scroll_button == 2 and #self.views > self.tab_offset + tabs_number - 1) and style.text or style.dim
-    common.draw_text(style.icon_font, button_style, ">", nil, xrb + scroll_padding, yrb, 0, h)
+    local xrb, yrb, _ = self:get_scroll_button_rect(1)
+    local left_button_style = (self.hovered_scroll_button == 1 and self.tab_offset > 1) and style.text or style.dim
+    common.draw_text(style.icon_font, left_button_style, "<", nil, xrb + scroll_padding, yrb, 0, h)
 
-    xrb, yrb, wrb = self:get_scroll_button_rect(2)
-    button_style = (self.hovered_scroll_button == 1 and self.tab_offset > 1) and style.text or style.dim
-    common.draw_text(style.icon_font, button_style, "<", nil, xrb + scroll_padding - wrb, yrb, 0, h)
+    xrb, yrb, _ = self:get_scroll_button_rect(2)
+    local right_button_style = (self.hovered_scroll_button == 2 and #self.views > self.tab_offset + tabs_number - 1) and style.text or style.dim
+    common.draw_text(style.icon_font, right_button_style, ">", nil, xrb + scroll_padding, yrb, 0, h)
   end
 
   core.pop_clip_rect()

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -323,7 +323,7 @@ end
 function Node:get_scroll_button_rect(index)
   local w, pad = get_scroll_button_width()
   local h = style.font:get_height() + style.padding.y * 2
-  local x = self.position.x + (index == 1 and 0 or self.size.x - w)
+  local x = self.position.x + (index == 1 and self.size.x - w * 2 or self.size.x - w)
   return x, self.position.y, w, h, pad
 end
 
@@ -331,7 +331,7 @@ end
 function Node:get_tab_rect(idx)
   local sbw = get_scroll_button_width()
   local maxw = self.size.x - 2 * sbw
-  local x0 = self.position.x + sbw
+  local x0 = self.position.x
   local x1 = x0 + common.clamp(self.tab_width * (idx - 1) - self.tab_shift, 0, maxw)
   local x2 = x0 + common.clamp(self.tab_width * idx - self.tab_shift, 0, maxw)
   local h = style.font:get_height() + style.padding.y * 2
@@ -547,24 +547,14 @@ function Node:draw_tab(view, is_active, is_hovered, is_close_hovered, x, y, w, h
 end
 
 function Node:draw_tabs()
-  local x, y, w, h, scroll_padding = self:get_scroll_button_rect(1)
+  local _, y, w, h, scroll_padding = self:get_scroll_button_rect(1)
+  local x = self.position.x
   local ds = style.divider_size
   local dots_width = style.font:get_width("…")
   core.push_clip_rect(x, y, self.size.x, h)
   renderer.draw_rect(x, y, self.size.x, h, style.background2)
   renderer.draw_rect(x, y + h - ds, self.size.x, ds, style.divider)
-
-  if self.tab_offset > 1 then
-    local button_style = self.hovered_scroll_button == 1 and style.text or style.dim
-    common.draw_text(style.icon_font, button_style, "<", nil, x + scroll_padding, y, 0, h)
-  end
-
   local tabs_number = self:get_visible_tabs_number()
-  if #self.views > self.tab_offset + tabs_number - 1 then
-    local xrb, yrb, wrb = self:get_scroll_button_rect(2)
-    local button_style = self.hovered_scroll_button == 2 and style.text or style.dim
-    common.draw_text(style.icon_font, button_style, ">", nil, xrb + scroll_padding, yrb, 0, h)
-  end
 
   for i = self.tab_offset, self.tab_offset + tabs_number - 1 do
     local view = self.views[i]
@@ -572,6 +562,22 @@ function Node:draw_tabs()
     self:draw_tab(view, view == self.active_view,
                   i == self.hovered_tab, i == self.hovered_close,
                   x, y, w, h)
+  end
+
+  if #self.views > self.tab_offset + tabs_number - 1 then
+    local xrb, yrb, wrb = self:get_scroll_button_rect(2)
+    local button_style = self.hovered_scroll_button == 2 and style.text or style.dim
+    common.draw_text(style.icon_font, button_style, ">", nil, xrb + scroll_padding, yrb, 0, h)
+  end
+
+  if self.tab_offset > 1 then
+    local xrb, yrb, wrb = self:get_scroll_button_rect(2)
+    local wsbr = wrb
+    -- move the arrow based on if there's tabs to scroll to the right?
+    --local wsbr = 0
+    --if #self.views > self.tab_offset + tabs_number - 1 then wsbr = wrb end
+    local button_style = self.hovered_scroll_button == 1 and style.text or style.dim
+    common.draw_text(style.icon_font, button_style, "<", nil, xrb + scroll_padding - wsbr, yrb, 0, h)
   end
 
   core.pop_clip_rect()

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -467,8 +467,9 @@ end
 
 
 function Node:target_tab_width()
+  local n = self:get_visible_tabs_number()
   local w = self.size.x
-  if #self.views > self:get_visible_tabs_number() then
+  if #self.views > n then
     w = self.size.x - get_scroll_button_width() * 2
   end
   return common.clamp(style.tab_width, w / config.max_tabs, w / n)

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -329,8 +329,7 @@ end
 
 
 function Node:get_tab_rect(idx)
-  local sbw = get_scroll_button_width()
-  local maxw = self.size.x - 2 * sbw
+  local maxw = self.size.x
   local x0 = self.position.x
   local x1 = x0 + common.clamp(self.tab_width * (idx - 1) - self.tab_shift, 0, maxw)
   local x2 = x0 + common.clamp(self.tab_width * idx - self.tab_shift, 0, maxw)
@@ -468,8 +467,10 @@ end
 
 
 function Node:target_tab_width()
-  local n = self:get_visible_tabs_number()
-  local w = self.size.x - get_scroll_button_width() * 2
+  local w = self.size.x
+  if #self.views > self:get_visible_tabs_number() then
+    w = self.size.x - get_scroll_button_width() * 2
+  end
   return common.clamp(style.tab_width, w / config.max_tabs, w / n)
 end
 
@@ -565,11 +566,13 @@ function Node:draw_tabs()
   end
 
   if #self.views > tabs_number then
-    local xrb, yrb, _ = self:get_scroll_button_rect(1)
+    local _, pad = get_scroll_button_width()
+    local xrb, yrb, wrb, hrb = self:get_scroll_button_rect(1)
+    renderer.draw_rect(xrb + pad, yrb, wrb * 2, hrb, style.background2)
     local left_button_style = (self.hovered_scroll_button == 1 and self.tab_offset > 1) and style.text or style.dim
     common.draw_text(style.icon_font, left_button_style, "<", nil, xrb + scroll_padding, yrb, 0, h)
 
-    xrb, yrb, _ = self:get_scroll_button_rect(2)
+    xrb, yrb, wrb = self:get_scroll_button_rect(2)
     local right_button_style = (self.hovered_scroll_button == 2 and #self.views > self.tab_offset + tabs_number - 1) and style.text or style.dim
     common.draw_text(style.icon_font, right_button_style, ">", nil, xrb + scroll_padding, yrb, 0, h)
   end

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -564,20 +564,14 @@ function Node:draw_tabs()
                   x, y, w, h)
   end
 
-  if #self.views > self.tab_offset + tabs_number - 1 then
+  if #self.views > tabs_number then
     local xrb, yrb, wrb = self:get_scroll_button_rect(2)
-    local button_style = self.hovered_scroll_button == 2 and style.text or style.dim
+    local button_style = (self.hovered_scroll_button == 2 and #self.views > self.tab_offset + tabs_number - 1) and style.text or style.dim
     common.draw_text(style.icon_font, button_style, ">", nil, xrb + scroll_padding, yrb, 0, h)
-  end
 
-  if self.tab_offset > 1 then
-    local xrb, yrb, wrb = self:get_scroll_button_rect(2)
-    local wsbr = wrb
-    -- move the arrow based on if there's tabs to scroll to the right?
-    --local wsbr = 0
-    --if #self.views > self.tab_offset + tabs_number - 1 then wsbr = wrb end
-    local button_style = self.hovered_scroll_button == 1 and style.text or style.dim
-    common.draw_text(style.icon_font, button_style, "<", nil, xrb + scroll_padding - wsbr, yrb, 0, h)
+    xrb, yrb, wrb = self:get_scroll_button_rect(2)
+    button_style = (self.hovered_scroll_button == 1 and self.tab_offset > 1) and style.text or style.dim
+    common.draw_text(style.icon_font, button_style, "<", nil, xrb + scroll_padding - wrb, yrb, 0, h)
   end
 
   core.pop_clip_rect()


### PR DESCRIPTION
this removes the honestly bad looking empty space before the 1st tab that's there when there isnt an overflow of tabs

before: ![](https://safe.kashima.moe/yid2zna4qlwv.png)
![](https://safe.kashima.moe/masgbb9dw8j1.png)

after: ![](https://safe.kashima.moe/grz04xldsudn.png)
![](https://safe.kashima.moe/rrpn4liybujw.png)