### PR TITLE
trimwhitespace: expose functionality and extra features

### DIFF
--- a/data/plugins/trimwhitespace.lua
+++ b/data/plugins/trimwhitespace.lua
@@ -1,10 +1,53 @@
 -- mod-version:3
-local core = require "core"
+local common = require "core.common"
+local config = require "core.config"
 local command = require "core.command"
 local Doc = require "core.doc"
 
+---@class config.plugins.trimwhitespace
+---@field enabled boolean
+---@field trim_empty_end_lines boolean
+config.plugins.trimwhitespace = common.merge({
+  enabled = true,
+  trim_empty_end_lines = false,
+  config_spec = {
+    name = "Trim Whitespace",
+    {
+      label = "Enabled",
+      description = "Disable or enable the trimming of white spaces by default.",
+      path = "enabled",
+      type = "toggle",
+      default = true
+    },
+    {
+      label = "Trim Empty End Lines",
+      description = "Remove any empty new lines at the end of documents.",
+      path = "trim_empty_end_lines",
+      type = "toggle",
+      default = false
+    }
+  }
+}, config.plugins.trimwhitespace)
 
-local function trim_trailing_whitespace(doc)
+---@class plugins.trimwhitespace
+local trimwhitespace = {}
+
+---Disable whitespace trimming for a specific document.
+---@param doc core.doc
+function trimwhitespace.disable(doc)
+  doc.disable_trim_whitespace = true
+end
+
+---Re-enable whitespace trimming if previously disabled.
+---@param doc core.doc
+function trimwhitespace.enable(doc)
+  doc.disable_trim_whitespace = nil
+end
+
+---Perform whitespace trimming in all lines of a document except the
+---line where the caret is currently positioned.
+---@param doc core.doc
+function trimwhitespace.trim(doc)
   local cline, ccol = doc:get_selection()
   for i = 1, #doc.lines do
     local old_text = doc:get_text(i, 1, i, math.huge)
@@ -22,16 +65,54 @@ local function trim_trailing_whitespace(doc)
   end
 end
 
+---Removes all empty new lines at the end of the document.
+---@param doc core.doc
+---@param raw_remove? boolean Perform the removal not registering to undo stack
+function trimwhitespace.trim_empty_end_lines(doc, raw_remove)
+  for _=#doc.lines, 1, -1 do
+    local l = #doc.lines
+    if l > 1 and doc.lines[l] == "\n" then
+      local current_line = doc:get_selection()
+      if current_line == l then
+        doc:set_selection(l-1, math.huge, l-1, math.huge)
+      end
+      if not raw_remove then
+        doc:remove(l-1, math.huge, l, math.huge)
+      else
+        table.remove(doc.lines, l)
+      end
+    else
+      break
+    end
+  end
+end
+
 
 command.add("core.docview", {
   ["trim-whitespace:trim-trailing-whitespace"] = function(dv)
-    trim_trailing_whitespace(dv.doc)
+    trimwhitespace.trim(dv.doc)
+  end,
+
+  ["trim-whitespace:trim-empty-end-lines"] = function(dv)
+    trimwhitespace.trim_empty_end_lines(dv.doc)
   end,
 })
 
 
-local save = Doc.save
+local doc_save = Doc.save
 Doc.save = function(self, ...)
-  trim_trailing_whitespace(self)
-  save(self, ...)
+  if
+    config.plugins.trimwhitespace.enabled
+    and
+    not self.disable_trim_whitespace
+  then
+    trimwhitespace.trim(self)
+    if config.plugins.trimwhitespace.trim_empty_end_lines then
+      trimwhitespace.trim_empty_end_lines(self)
+    end
+  end
+  doc_save(self, ...)
 end
+
+
+return trimwhitespace


### PR DESCRIPTION
This PR exposes trimwhitespace plugin for use by plugins like the [editorconfig](https://github.com/lite-xl/lite-xl-plugins/pull/163) , new features include:

* config to enable or disable trimwhitespace on the fly (which raises the question if we could nuke this line https://github.com/lite-xl/lite-xl/blob/master/data/core/config.lua#L69 now)
* optional `trim_empty_end_lines` config that when enabled strips empty lines at the end of the documents.
* added `trim-whitespace:trim-empty-end-lines` command
* introduced api to explicitly disable/enable trimming for specific documents, which will be useful to prevent double trimming when other plugins like editorconfig are already doing it if mandated by the `.editorconfig` rules.