### PR TITLE
Fix some syntax errors

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -5,16 +5,16 @@
 #include "rencache.h"
 #include "renderer.h"
 
+#include <signal.h>
+
 #ifdef _WIN32
   #include <windows.h>
-#elif __linux__
+#elif defined(__linux__)
   #include <unistd.h>
-  #include <signal.h>
 #elif __APPLE__
   #include <mach-o/dyld.h>
 #elif __FreeBSD__
   #include <sys/sysctl.h>
-  #include <signal.h>
 #endif
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -11,9 +11,9 @@
   #include <windows.h>
 #elif defined(__linux__)
   #include <unistd.h>
-#elif __APPLE__
+#elif defined(__APPLE__)
   #include <mach-o/dyld.h>
-#elif __FreeBSD__
+#elif defined(__FreeBSD__)
   #include <sys/sysctl.h>
 #endif
 
@@ -51,7 +51,7 @@ static void get_exe_filename(char *buf, int sz) {
   const int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
   sysctl(mib, 4, buf, &len, NULL, 0);
 #else
-  *buf = NULL;
+  *buf = 0;
 #endif
 }
 


### PR DESCRIPTION
Some fixes for uncommon code paths (when compiling for everything other than linux, windows, mac, etc.)