### PR TITLE
Reorganize resources/ + wasm target

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -18,3 +18,6 @@ This folder contains resources that is used for building or packaging the projec
 ### Development
 
 - `lite_xl_plugin_api.h`: Native plugin API header. See the contents of `lite_xl_plugin_api.h` for more details.
+
+
+[1]: https://mesonbuild.com/Cross-compilation.html

--- a/resources/README.md
+++ b/resources/README.md
@@ -13,7 +13,6 @@ This folder contains resources that is used for building or packaging the projec
 - `linux/org.lite_xl.lite_xl.desktop`: Desktop file for Linux desktops.
 - `macos/appdmg.png`: Background image for packaging MacOS DMGs.
 - `macos/Info.plist.in`: Template for generating `info.plist` on MacOS. See `macos/macos-retina-display.md` for details.
-
 - `windows/001-lua-unicode.diff`: Patch for allowing Lua to load files with UTF-8 filenames on Windows.
 
 ### Development

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,21 @@
+# Resources
+
+This folder contains resources that is used for building or packaging the project.
+
+### Build
+
+- `cross/*.txt`: Meson [cross files][1] for cross-compiling lite-xl on other platforms.
+
+### Packaging
+
+- `icons/icon.{icns,ico,inl,rc,svg}`: lite-xl icon in various formats.
+- `linux/org.lite_xl.lite_xl.appdata.xml`: AppStream metadata.
+- `linux/org.lite_xl.lite_xl.desktop`: Desktop file for Linux desktops.
+- `macos/appdmg.png`: Background image for packaging MacOS DMGs.
+- `macos/Info.plist.in`: Template for generating `info.plist` on MacOS. See `macos/macos-retina-display.md` for details.
+
+- `windows/001-lua-unicode.diff`: Patch for allowing Lua to load files with UTF-8 filenames on Windows.
+
+### Development
+
+- `lite_xl_plugin_api.h`: Native plugin API header. See the contents of `lite_xl_plugin_api.h` for more details.

--- a/resources/cross/macos_arm64.txt
+++ b/resources/cross/macos_arm64.txt
@@ -1,3 +1,6 @@
+# cross file for compiling on MacOS ARM (Apple Sillicon).
+# use this file by running meson setup --cross-file resources/cross/macos_arm64.txt <builddir>
+
 [host_machine]
 system = 'darwin'
 cpu_family = 'aarch64'

--- a/resources/cross/wasm.txt
+++ b/resources/cross/wasm.txt
@@ -14,13 +14,17 @@ initial_heap = '104857600'
 
 
 [binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+strip = 'emstrip'
+cmake = ['emmake', 'cmake']
+pkg-config = ['emconfigure', 'pkg-config']
+sdl2-config = ['emconfigure', 'sdl2-config']
 
-# modify these for your machine; this is based on Arch Linux's emscripten package
-c = '/usr/lib/emscripten/emcc'
-cpp = '/usr/lib/emscripten/em++'
-ar = '/usr/lib/emscripten/emar'
-strip = '/usr/lib/emscripten/emstrip'
-sdl2-config = '/usr/lib/emscripten/system/bin/sdl2-config'
+
+[properties]
+needs_exe_wrapper = true
 
 
 [built-in options]

--- a/resources/cross/wasm.txt
+++ b/resources/cross/wasm.txt
@@ -7,7 +7,7 @@
 asyncify_ignores = '["SDL_BlitScaled","SDL_UpperBlitScaled","SDL_MapRGB*","SDL_FillRect","SDL_FreeSurface","SDL_CreateRGBSurface","SDL_GetWindowSurface","SDL_PollEvent","SDL_CreateSystemCursor","SDL_SetWindowTitle","SDL_SetCursor","SDL_GetWindowSize","SDL_GetWindowPosition","lua_push*","lua_rawget*","luaL_check*","pcre2*","FT_*","Bezier_*","g_*","FT_*","ft_*","TT_*","tt_*","__*","*printf","gray_*","fopen","fclose","fread","fflush","qsort","sift"]'
 
 # enable advising for optimizing the list above; disable this to prevent flooding logs
-asyncify_advise = '1'
+asyncify_advise = '0'
 
 # initial heap size in bytes; make sure it is not too low (around 64mb - 250mb)
 initial_heap = '104857600'

--- a/resources/cross/wasm.txt
+++ b/resources/cross/wasm.txt
@@ -1,0 +1,42 @@
+# cross file for WASM.
+# use this file by running meson setup --cross-file resources/cross/wasm.txt <builddir>
+
+[constants]
+
+# a list of functions that can run without being asyncified; proceed with caution
+asyncify_ignores = '["SDL_BlitScaled","SDL_UpperBlitScaled","SDL_MapRGB*","SDL_FillRect","SDL_FreeSurface","SDL_CreateRGBSurface","SDL_GetWindowSurface","SDL_PollEvent","SDL_CreateSystemCursor","SDL_SetWindowTitle","SDL_SetCursor","SDL_GetWindowSize","SDL_GetWindowPosition","lua_push*","lua_rawget*","luaL_check*","pcre2*","FT_*","Bezier_*","g_*","FT_*","ft_*","TT_*","tt_*","__*","*printf","gray_*","fopen","fclose","fread","fflush","qsort","sift"]'
+
+# enable advising for optimizing the list above; disable this to prevent flooding logs
+asyncify_advise = '1'
+
+# initial heap size in bytes; make sure it is not too low (around 64mb - 250mb)
+initial_heap = '104857600'
+
+
+[binaries]
+
+# modify these for your machine; this is based on Arch Linux's emscripten package
+c = '/usr/lib/emscripten/emcc'
+cpp = '/usr/lib/emscripten/em++'
+ar = '/usr/lib/emscripten/emar'
+strip = '/usr/lib/emscripten/emstrip'
+sdl2-config = '/usr/lib/emscripten/system/bin/sdl2-config'
+
+
+[built-in options]
+c_args = []
+c_link_args = []
+cpp_args = []
+cpp_link_args = []
+
+
+[project options]
+buildtype = 'release'
+c_link_args = ['-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'INITIAL_MEMORY=' + initial_heap, '-s', 'ASYNCIFY=1', '-s', 'ASYNCIFY_ADVISE=' + asyncify_advise, '-s', 'ASYNCIFY_STACK_SIZE=6144', '-s', 'ASYNCIFY_REMOVE=' + asyncify_ignores, '-s', 'FORCE_FILESYSTEM=1']
+
+	
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm32'
+endian = 'little'


### PR DESCRIPTION
Added a README to point out files and their usage.

Other than that, moved the existing M1 cross file to dedicated `cross/` directory along with the wasm cross file.