### PR TITLE
remove DPI dependent scaling

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -2,7 +2,7 @@
 VERSION = "@PROJECT_VERSION@"
 MOD_VERSION = "3"
 
-SCALE = tonumber(os.getenv("LITE_SCALE") or os.getenv("GDK_SCALE") or os.getenv("QT_SCALE_FACTOR")) or SCALE
+SCALE = tonumber(os.getenv("LITE_SCALE") or os.getenv("GDK_SCALE") or os.getenv("QT_SCALE_FACTOR")) or 1
 PATHSEP = package.config:sub(1, 1)
 
 EXEDIR = EXEFILE:match("^(.+)[/\\][^/\\]+$")

--- a/src/main.c
+++ b/src/main.c
@@ -20,16 +20,6 @@
 
 SDL_Window *window;
 
-static double get_scale(void) {
-#ifndef __APPLE__
-  float dpi;
-  if (SDL_GetDisplayDPI(0, NULL, &dpi, NULL) == 0)
-    return dpi / 96.0;
-#endif
-  return 1.0;
-}
-
-
 static void get_exe_filename(char *buf, int sz) {
 #if _WIN32
   int len = GetModuleFileName(NULL, buf, sz - 1);
@@ -195,9 +185,6 @@ init_lua:
 
   lua_pushstring(L, LITE_ARCH_TUPLE);
   lua_setglobal(L, "ARCH");
-
-  lua_pushnumber(L, get_scale());
-  lua_setglobal(L, "SCALE");
 
   char exename[2048];
   get_exe_filename(exename, sizeof(exename));


### PR DESCRIPTION
For Apple devices the DPI was already not considered, and other systems do not benefit from this.
Retains changing the scale using environment flags.

The original Lite had a different code snippet for getting the scale:
```c
static double get_scale(void) {
  float dpi;
  SDL_GetDisplayDPI(0, NULL, &dpi, NULL);
#if _WIN32
  return dpi / 96.0;
#else
  return 1.0;
#endif
}
```
Considering this with the comment the SDL wiki provides:
```
WARNING: This reports the DPI that the hardware reports, and it is not always reliable! It is almost always better to use SDL_GetWindowSize()
```
this was never a good idea to begin with, and already had an apple specific check for disabling.

<details>
<summary>Image</summary>

Left: This PR
Right: master
![image](https://user-images.githubusercontent.com/15076013/208627627-08b05c7b-e524-4110-9676-9367d1182716.png)
</details>

This Image is from my Laptop with a DPI that I calculated to be 144 (some tools, like xdpyinfo, return incorrect values, using xrandr to fetch the values is preferred)

Resolution: 1920x1080
Display: 344mm x 194mm

With the calculations we end up with
`144 / 96` which is a scale of 1.5, larger than it should be


