### PR TITLE
`detectindent`: Don't consider subsyntax patterns

### DIFF
--- a/data/plugins/detectindent.lua
+++ b/data/plugins/detectindent.lua
@@ -122,15 +122,6 @@ local function get_comment_patterns(syntax)
           table.insert(comments, {"r", regex.compile(startp)})
         end
       end
-    elseif pattern.syntax then
-      local subsyntax = type(pattern.syntax) == 'table' and pattern.syntax
-        or core_syntax.get("file"..pattern.syntax, "")
-      local sub_comments = get_comment_patterns(subsyntax)
-      if sub_comments then
-        for s=1, #sub_comments do
-          table.insert(comments, sub_comments[s])
-        end
-      end
     end
   end
   if #comments == 0 then


### PR DESCRIPTION
Fixes #1247.

We aren't checking when a certain pattern should be used anyways (thus using subsyntax patterns outside of the subsyntax code blocks), and recursing over subsyntaxes can cause problems, so we should just ignore them.