### PR TITLE
`detectindent`: Limit subsyntax depth

### DIFF
--- a/data/plugins/detectindent.lua
+++ b/data/plugins/detectindent.lua
@@ -75,7 +75,9 @@ local function escape_comment_tokens(token)
 end
 
 
-local function get_comment_patterns(syntax)
+local function get_comment_patterns(syntax, _loop)
+  _loop = _loop or 1
+  if _loop > 5 then return end
   if comments_cache[syntax] then
     if #comments_cache[syntax] > 0 then
       return comments_cache[syntax]
@@ -125,7 +127,7 @@ local function get_comment_patterns(syntax)
     elseif pattern.syntax then
       local subsyntax = type(pattern.syntax) == 'table' and pattern.syntax
         or core_syntax.get("file"..pattern.syntax, "")
-      local sub_comments = get_comment_patterns(subsyntax)
+      local sub_comments = get_comment_patterns(subsyntax, _loop + 1)
       if sub_comments then
         for s=1, #sub_comments do
           table.insert(comments, sub_comments[s])


### PR DESCRIPTION
Fixes #1247.

This limits to 5 the subsyntaxes depth `detectindent` will consider. This ought to be enough for anybody.
This is an alternative to #1250.

As said in #1250, I still don't think this is the correct way to fix the issue because it's still using subsyntax info in places outside the actual subsyntax block, which can create "false negatives" and skip checking lines that would actually determine the indent.