### PR TITLE
Allow `TreeView` file operation commands when focused

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -714,16 +714,8 @@ command.add(
         end
       end
     )
-  end
-})
+  end,
 
-
-command.add(function()
-    if not (core.root_view.overlapping_node and core.root_view.overlapping_node.active_view) then return end
-    if core.root_view.overlapping_node.active_view ~= view then return end
-    local item = treeitem()
-    return item ~= nil, item
-  end, {
   ["treeview:rename"] = function(item)
     local old_filename = item.filename
     local old_abs_filename = item.abs_filename


### PR DESCRIPTION
Fixes #1255.

Impacts `treeview:{rename,new-file,new-folder,open-in-system}`.
Previously those were only available when the mouse was over the  `TreeView`.
They now use the same predicate as `treeview:delete`.