### PR TITLE
contextmenu: adjust y positioning if less than zero

### DIFF
--- a/data/core/contextmenu.lua
+++ b/data/core/contextmenu.lua
@@ -83,13 +83,8 @@ function ContextMenu:show(x, y)
     local w, h = self.items.width, self.items.height
 
     -- by default the box is opened on the right and below
-    if x + w >= core.root_view.size.x then
-      x = x - w
-    end
-    if y + h >= core.root_view.size.y then
-      y = y - h
-      if y < 0 then y = 0 end
-    end
+    x = common.clamp(x, 0, core.root_view.size.x - w - style.padding.x)
+    y = common.clamp(y, 0, core.root_view.size.y - h)
 
     self.position.x, self.position.y = x, y
     self.show_context_menu = true

--- a/data/core/contextmenu.lua
+++ b/data/core/contextmenu.lua
@@ -88,6 +88,7 @@ function ContextMenu:show(x, y)
     end
     if y + h >= core.root_view.size.y then
       y = y - h
+      if y < 0 then y = 0 end
     end
 
     self.position.x, self.position.y = x, y


### PR DESCRIPTION
Fixes this:

![contextmenu-large-notvisible](https://user-images.githubusercontent.com/1702572/209696754-8ddfc094-2663-418a-9464-09cdce41517a.png)

to:

![contextmenu-large-visible](https://user-images.githubusercontent.com/1702572/209696799-aa96def7-cab3-41a1-9cd5-bbce9a0fdfc6.png)
