### PR TITLE
Add example settings to _overwrite_ an existing key binding

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -495,6 +495,10 @@ local style = require "core.style"
 -- key binding:
 -- keymap.add { ["ctrl+escape"] = "core:quit" }
 
+-- pass 'true' for second parameter to overwrite an existing binding
+-- keymap.add({ ["ctrl+pageup"] = "root:switch-to-previous-tab" }, true)
+-- keymap.add({ ["ctrl+pagedown"] = "root:switch-to-next-tab" }, true)
+
 ------------------------------- Fonts ----------------------------------------
 
 -- customize fonts:


### PR DESCRIPTION
Rationale: 
- I prefer to have ctrl+pageup/down bound to previous/next tabs, consistent with other editors and my web browser.
- it took a little time to figure out that settings are _additive_ by default, and it's necessary to pass a second parameter to overwrite an existing binding completely.
- adding an example in the config file saves the next person some time :) 