### PR TITLE
Bump version to 2.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       version:
         description: Release Version
-        default: v2.1.0
+        default: v2.1.1
         required: true
 
 jobs:

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changes Log
 
-## [2.1.1] - XXXX-XX-XX
+## [2.1.1] - 2022-12-28
 
 ### New Features
 
@@ -57,6 +57,12 @@
 * fix: move tab scroll buttons to remove spacing before 1st tab
   ([#1231](https://github.com/lite-xl/lite-xl/pull/1231))
 
+* Allow TreeView file operation commands when focused
+  ([#1256](https://github.com/lite-xl/lite-xl/pull/1256))
+
+* contextmenu: adjust y positioning if less than zero
+  ([#1268](https://github.com/lite-xl/lite-xl/pull/1268))
+
 ### Fixes
 
 * Don't sort in Doc:get_selection_idx with an invalid index
@@ -67,7 +73,7 @@
 
 * dirmonitor: give kevent a timeout so it doesn't lock forever
   ([#1180](https://github.com/lite-xl/lite-xl/pull/1180))
-  
+
 * dirmonitor: fix win32 implementation name length to prevent ub
   ([5ab8dc0](https://github.com/lite-xl/lite-xl/commit/5ab8dc027502146dd947b3d2c7544ba096a3881b))
 
@@ -106,6 +112,22 @@
 * detectindent: Limit subsyntax depth
   ([#1253](https://github.com/lite-xl/lite-xl/pull/1253))
 
+* Use Lua string length instead of relying on strlen (#1262)
+  ([#1262](https://github.com/lite-xl/lite-xl/pull/1262))
+
+* dirmonitor: fix high cpu usage
+  ([#1271](https://github.com/lite-xl/lite-xl/pull/1271)),
+  ([#1274](https://github.com/lite-xl/lite-xl/pull/1274))
+
+* Fix popping subsyntaxes that end consecutively
+  ([#1246](https://github.com/lite-xl/lite-xl/pull/1246))
+
+* Fix userdata APIs for Lua 5.4 in native plugin interface
+  ([#1188](https://github.com/lite-xl/lite-xl/pull/1188))
+
+* Fix horizontal scroll with touchpad on MacOS
+  ([74349f8e](https://github.com/lite-xl/lite-xl/commit/74349f8e566ec31acd9a831a060b677d706ae4e8))
+
 ### Other Changes
 
 * (Windows) MSVC Support ([#1199](https://github.com/lite-xl/lite-xl/pull/1199))
@@ -127,8 +149,14 @@
 * plugins projectsearch: expose its functionality
   ([#1235](https://github.com/lite-xl/lite-xl/pull/1235))
 
-* Simplify SDL message boxes (#1249)
+* Simplify SDL message boxes
   ([#1249](https://github.com/lite-xl/lite-xl/pull/1249))
+
+* Add example settings to _overwrite_ an existing key binding
+  ([#1270](https://github.com/lite-xl/lite-xl/pull/1270))
+
+* Fix two typos in data/init.lua
+  ([#1272](https://github.com/lite-xl/lite-xl/pull/1272))
 
 ## [2.1.0] - 2022-11-01
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changes Log
 
-## [2.1.1] - 2022-12-28
+## [2.1.1] - 2022-12-29
 
 ### New Features
 
@@ -157,6 +157,8 @@
 
 * Fix two typos in data/init.lua
   ([#1272](https://github.com/lite-xl/lite-xl/pull/1272))
+
+* Updated meson wraps to latest (SDL v2.26, PCRE2 v10.42)
 
 ## [2.1.0] - 2022-11-01
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('lite-xl',
     ['c'],
-    version : '2.1.0',
+    version : '2.1.1',
     license : 'MIT',
     meson_version : '>= 0.56',
     default_options : [

--- a/resources/linux/org.lite_xl.lite_xl.appdata.xml
+++ b/resources/linux/org.lite_xl.lite_xl.appdata.xml
@@ -29,6 +29,6 @@
   </provides>
 
   <releases>
-    <release version="2.1.1" date="2022-12-28" />
+    <release version="2.1.1" date="2022-12-29" />
   </releases>
 </component>

--- a/resources/linux/org.lite_xl.lite_xl.appdata.xml
+++ b/resources/linux/org.lite_xl.lite_xl.appdata.xml
@@ -29,6 +29,6 @@
   </provides>
 
   <releases>
-    <release version="2.1.0" date="2022-11-01" />
+    <release version="2.1.1" date="2022-12-28" />
   </releases>
 </component>

--- a/subprojects/pcre2.wrap
+++ b/subprojects/pcre2.wrap
@@ -1,15 +1,15 @@
 [wrap-file]
-directory = pcre2-10.40
-source_url = https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.40/pcre2-10.40.tar.bz2
-source_filename = pcre2-10.40.tar.bz2
-source_hash = 14e4b83c4783933dc17e964318e6324f7cae1bc75d8f3c79bc6969f00c159d68
-patch_filename = pcre2_10.40-3_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.40-3/get_patch
-patch_hash = 95391923529b4c1647a2cf88cd3b59cceb4f92393775e011f530e7865de0c7fb
-wrapdb_version = 10.40-3
+directory = pcre2-10.42
+source_url = https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.bz2
+source_filename = pcre2-10.42.tar.bz2
+source_hash = 8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840
+patch_filename = pcre2_10.42-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.42-1/get_patch
+patch_hash = 06969e916dfee663c189810df57d98574f15e0754a44cd93f3f0bc7234b05d89
+wrapdb_version = 10.42-1
 
 [provide]
-libpcre2-8 = -libpcre2_8
-libpcre2-16 = -libpcre2_16
-libpcre2-32 = -libpcre2_32
-libpcre2-posix = -libpcre2_posix
+libpcre2-8 = libpcre2_8
+libpcre2-16 = libpcre2_16
+libpcre2-32 = libpcre2_32
+libpcre2-posix = libpcre2_posix

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -1,12 +1,12 @@
 [wrap-file]
-directory = SDL2-2.24.2
-source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.24.2/SDL2-2.24.2.tar.gz
-source_filename = SDL2-2.24.2.tar.gz
-source_hash = b35ef0a802b09d90ed3add0dcac0e95820804202914f5bb7b0feb710f1a1329f
-patch_filename = sdl2_2.24.2-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.24.2-1/get_patch
-patch_hash = 9952a79eee3e53dc04daac494a4c0b8cd4c062bfe7365c4766a6bfa15c85b52d
-wrapdb_version = 2.24.2-1
+directory = SDL2-2.26.0
+source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.26.0/SDL2-2.26.0.tar.gz
+source_filename = SDL2-2.26.0.tar.gz
+source_hash = 8000d7169febce93c84b6bdf376631f8179132fd69f7015d4dadb8b9c2bdb295
+patch_filename = sdl2_2.26.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.26.0-1/get_patch
+patch_hash = 6fcfd727d71cf7837332723518d5e47ffd64f1e7630681cf4b50e99f2bf7676f
+wrapdb_version = 2.26.0-1
 
 [provide]
 sdl2 = sdl2_dep


### PR DESCRIPTION
Changes needed for 2.1.1 release:

* Updated changes log
* Incremented versions
* Set release dates