### PR TITLE
Allow command buffer to be expanded

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -507,8 +507,13 @@ void ren_draw_rect(RenRect rect, RenColor color) {
 
 /*************** Window Management ****************/
 void ren_free_window_resources() {
+  extern uint8_t *command_buf;
+  extern size_t command_buf_size;
   renwin_free(&window_renderer);
   SDL_FreeSurface(draw_rect_surface);
+  free(command_buf);
+  command_buf = NULL;
+  command_buf_size = 0;
 }
 
 void ren_init(SDL_Window *win) {


### PR DESCRIPTION
This helps when using particular plugins (like `minimap`) or in some particular text drawing cases (like many alternating token types).

This only expands the command buffer. In the future, shrinking it could be considered.

This also avoids printing the error message multiple times per frame, which decreased the performance even more.