### PR TITLE
Avoid drawing hidden text in `DocView:draw_line_text`

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -422,6 +422,7 @@ function DocView:draw_line_text(line, x, y)
     -- do not render newline, fixes issue #1164
     if tidx == last_token then text = text:sub(1, -2) end
     tx = renderer.draw_text(font, text, tx, ty, color)
+    if tx > self.position.x + self.size.x then break end
   end
   return self:get_line_height()
 end


### PR DESCRIPTION
With this PR, we no longer send hidden (tokenized) text to the renderer.

Non tokenized text or text tokenized as long strings is still a problem, which can be solved by splitting the tokenized text into smaller pieces.

Here there might be a performance impact caused by having to call `font:get_width`, but this needs testing.