### PR TITLE
Make `dirwatch` sorting compatible with what `file_bisect` expects

### DIFF
--- a/data/core/dirwatch.lua
+++ b/data/core/dirwatch.lua
@@ -166,7 +166,7 @@ end
 
 
 local function compare_file(a, b)
-  return a.filename < b.filename
+  return system.path_compare(a.filename, a.type, b.filename, b.type)
 end
 
 


### PR DESCRIPTION
The result of `a.filename < b.filename` is sometimes different from  `system.path_compare(a.filename, a.type, b.filename, b.type)` which  causes issues to `file_bisect`, as it expects the sorting to be done  with `system.path_compare`.

For example to trigger the issue, in an empty project dir run:
```bash
rm -rf *; sleep 2; mkdir àa1234àa; sleep 2; mkdir a1234
```

This also fixes #1260 (which was misdiagnosed).