### PR TITLE
feat: add option to only draw whitespace if it is within selection

### DIFF
--- a/data/plugins/drawwhitespace.lua
+++ b/data/plugins/drawwhitespace.lua
@@ -202,17 +202,17 @@ function DocView:draw_line_text(idx, x, y)
     return draw_line_text(self, idx, x, y)
   end
 
+  local do_draw = not config.plugins.drawwhitespace.show_selected_only
   if config.plugins.drawwhitespace.show_selected_only and self.doc:has_any_selection() then
-    local do_draw
     for _, l1, _, l2, _ in self.doc:get_selections(true) do
+      do_draw = false
       if idx >= l1 and idx <= l2 then
         do_draw = true
         break
       end
     end
-
-    if not do_draw then return draw_line_text(self, idx, x, y) end
   end
+  if not do_draw then return draw_line_text(self, idx, x, y) end
 
   local font = (self:get_font() or style.syntax_fonts["whitespace"] or style.syntax_fonts["comment"])
   local font_size = font:get_size()

--- a/data/plugins/drawwhitespace.lua
+++ b/data/plugins/drawwhitespace.lua
@@ -1,5 +1,6 @@
 -- mod-version:3
 
+local core = require "core"
 local style = require "core.style"
 local DocView = require "core.docview"
 local common = require "core.common"
@@ -302,20 +303,40 @@ function DocView:draw_line_text(idx, x, y)
     local tw = cache[i + 2]
     local sub = cache[i]
     local color = cache[i + 3]
-    local do_draw = not config.plugins.drawwhitespace.show_selected_only
+    local partials = {}
     if config.plugins.drawwhitespace.show_selected_only and self.doc:has_any_selection() then
       for _, l1, c1, l2, c2 in self.doc:get_selections(true) do
-        do_draw = false
-        if idx >= l1 and idx <= l2 and
-        cache[i + 1] >= self:get_col_x_offset(idx, c1) and
-        (cache[i + 1] + tw) <= self:get_col_x_offset(idx, c2) then
-          do_draw = true
-          break
+        if idx > l1 and idx < l2 then
+          -- Between selection lines, so everything is selected
+          table.insert(partials, false)
+        elseif idx == l1 and idx == l2 then
+          -- Both ends of the selection are on the same line
+          local _x1 = math.max(cache[i + 1], self:get_col_x_offset(idx, c1))
+          local _x2 = math.min((cache[i + 1] + tw), self:get_col_x_offset(idx, c2))
+          if _x1 < _x2 then
+            table.insert(partials, {_x1 + x, 0, _x2 - _x1, math.huge})
+          end
+        elseif idx >= l1 and idx <= l2 then
+          -- On one of the selection ends
+          if idx == l1 then -- Start of the selection
+            local _x = math.max(cache[i + 1], self:get_col_x_offset(idx, c1))
+            table.insert(partials, {_x + x, 0, math.huge, math.huge})
+          else -- End of the selection
+            local _x = math.min((cache[i + 1] + tw), self:get_col_x_offset(idx, c2))
+            table.insert(partials, {0, 0, _x + x, math.huge})
+          end
         end
       end
     end
-    if do_draw then
-      tx = renderer.draw_text(font, sub, tx, ty, color)
+
+    if #partials == 0 and not config.plugins.drawwhitespace.show_selected_only then
+      renderer.draw_text(font, sub, tx, ty, color)
+    else
+      for _, p in pairs(partials) do
+        if p then core.push_clip_rect(table.unpack(p)) end
+        renderer.draw_text(font, sub, tx, ty, color)
+        if p then core.pop_clip_rect() end
+      end
     end
   end
 

--- a/data/plugins/drawwhitespace.lua
+++ b/data/plugins/drawwhitespace.lua
@@ -202,15 +202,16 @@ function DocView:draw_line_text(idx, x, y)
     return draw_line_text(self, idx, x, y)
   end
 
-  local doDraw
-  if self.doc:has_any_selection() then
-    for _, l1, c1, l2, c2 in self.doc:get_selections(true) do
+  if self.doc:has_any_selection() and config.plugin.drawwhitespace.show_selected_only then
+    local do_draw
+    for _, l1, _, l2, _ in self.doc:get_selections(true) do
       if idx >= l1 and idx <= l2 then
-        doDraw = true
+        do_draw = true
+        break
       end
     end
+    if not do_draw then return draw_line_text(self, idx, x, y) end
   end
-  if not doDraw and config.plugins.drawwhitespace.show_selected_only then return draw_line_text(self, idx, x, y) end
 
   local font = (self:get_font() or style.syntax_fonts["whitespace"] or style.syntax_fonts["comment"])
   local font_size = font:get_size()

--- a/data/plugins/drawwhitespace.lua
+++ b/data/plugins/drawwhitespace.lua
@@ -202,7 +202,7 @@ function DocView:draw_line_text(idx, x, y)
     return draw_line_text(self, idx, x, y)
   end
 
-  if self.doc:has_any_selection() and config.plugin.drawwhitespace.show_selected_only then
+  if config.plugins.drawwhitespace.show_selected_only and self.doc:has_any_selection() then
     local do_draw
     for _, l1, _, l2, _ in self.doc:get_selections(true) do
       if idx >= l1 and idx <= l2 then
@@ -210,6 +210,7 @@ function DocView:draw_line_text(idx, x, y)
         break
       end
     end
+
     if not do_draw then return draw_line_text(self, idx, x, y) end
   end
 

--- a/data/plugins/drawwhitespace.lua
+++ b/data/plugins/drawwhitespace.lua
@@ -192,13 +192,6 @@ local function get_option(substitution, option)
   return substitution[option]
 end
 
-local function sort_positions(line1, col1, line2, col2)
-  if line1 > line2 or line1 == line2 and col1 > col2 then
-    return line2, col2, line1, col1, true
-  end
-  return line1, col1, line2, col2, false
-end
-
 local draw_line_text = DocView.draw_line_text
 function DocView:draw_line_text(idx, x, y)
   if
@@ -211,8 +204,7 @@ function DocView:draw_line_text(idx, x, y)
 
   local doDraw
   if self.doc:has_any_selection() then
-    for _, l1, c1, l2, c2 in self.doc:get_selections() do
-      l1, _, l2, _ = sort_positions(l1, c1, l2, c2)
+    for _, l1, c1, l2, c2 in self.doc:get_selections(true) do
       if idx >= l1 and idx <= l2 then
         doDraw = true
       end


### PR DESCRIPTION
i saw someone on discord attempting this so i did it :)

this adds an option to make it so the drawwhitespace plugin will only draw whitespaces if the line it is on is within a selection. it works with multiple selections, and does not show up if the caret is only on a single line (anyone want to suggest a config option for that too or no?)