### PR TITLE
replace uses of SDL_Window with RenWindow

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -18,7 +18,7 @@
 #endif
 
 
-SDL_Window *window;
+static SDL_Window *window;
 
 static double get_scale(void) {
 #ifndef __APPLE__

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -20,7 +20,7 @@
 #define MAX_LOADABLE_GLYPHSETS 1024
 #define SUBPIXEL_BITMAPS_CACHED 3
 
-static RenWindow window_renderer = {0};
+RenWindow window_renderer = {0};
 static FT_Library library;
 
 // draw_rect_surface is used as a 1x1 surface to simplify ren_draw_rect with blending


### PR DESCRIPTION
Since Renwindow contains our instance of SDL_Window we can use this to simplify future logic to create separate window instances.

Followed up by #1321 

More work is needed to allow the creation of multiple windows and fully move it into Lua, but this is a sizable chunk that should be merged first.