### PR TITLE
separate useful preprocessors into their own header

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -2,6 +2,7 @@
 #include "api.h"
 #include "../renderer.h"
 #include "../rencache.h"
+#include "defines.h"
 #include "lua.h"
 
 // a reference index to a table that stores the fonts

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -666,11 +666,6 @@ static int f_list_dir(lua_State *L) {
 #endif
 }
 
-
-#ifdef _WIN32
-  #define realpath(x, y) _wfullpath(y, x, MAX_PATH)
-#endif
-
 static int f_absolute_path(lua_State *L) {
   const char *path = luaL_checkstring(L, 1);
 #ifdef _WIN32

--- a/src/defines.h
+++ b/src/defines.h
@@ -1,0 +1,14 @@
+#ifndef DEFINES_H
+#define DEFINES_H
+
+#ifdef __GNUC__
+#define UNUSED __attribute__((__unused__))
+#else
+#define UNUSED
+#endif
+
+#ifdef _WIN32
+  #define realpath(x, y) _wfullpath(y, x, MAX_PATH)
+#endif
+
+#endif

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -5,11 +5,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef __GNUC__
-#define UNUSED __attribute__((__unused__))
-#else
-#define UNUSED
-#endif
+#include "defines.h"
 
 #define FONT_FALLBACK_MAX 10
 typedef struct RenFont RenFont;

--- a/src/renwindow.c
+++ b/src/renwindow.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include "renwindow.h"
+#include "defines.h"
 
 #ifdef LITE_USE_SDL_RENDERER
 static int query_surface_scale(RenWindow *ren) {


### PR DESCRIPTION
This makes them easier to use in a global context without adding a heap of data to each translation unit.

This will also make future changes for #1318 easier