### PR TITLE
pass RenWindow by argument

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -284,13 +284,13 @@ static int f_get_size(lua_State *L) {
 
 
 static int f_begin_frame(UNUSED lua_State *L) {
-  rencache_begin_frame();
+  rencache_begin_frame(&window_renderer);
   return 0;
 }
 
 
 static int f_end_frame(UNUSED lua_State *L) {
-  rencache_end_frame();
+  rencache_end_frame(&window_renderer);
   // clear the font reference table
   lua_newtable(L);
   lua_rawseti(L, LUA_REGISTRYINDEX, RENDERER_FONT_REF);
@@ -348,7 +348,7 @@ static int f_draw_text(lua_State *L) {
   float x = luaL_checknumber(L, 3);
   int y = luaL_checknumber(L, 4);
   RenColor color = checkcolor(L, 5, 255);
-  x = rencache_draw_text(fonts, text, len, x, y, color);
+  x = rencache_draw_text(&window_renderer, fonts, text, len, x, y, color);
   lua_pushnumber(L, x);
   return 1;
 }

--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -90,7 +90,7 @@ static int f_font_load(lua_State *L) {
     return ret_code;
 
   RenFont** font = lua_newuserdata(L, sizeof(RenFont*));
-  *font = ren_font_load(filename, size, antialiasing, hinting, style);
+  *font = ren_font_load(&window_renderer, filename, size, antialiasing, hinting, style);
   if (!*font)
     return luaL_error(L, "failed to load font");
   luaL_setmetatable(L, API_TYPE_FONT);
@@ -130,7 +130,7 @@ static int f_font_copy(lua_State *L) {
   }
   for (int i = 0; i < FONT_FALLBACK_MAX && fonts[i]; ++i) {
     RenFont** font = lua_newuserdata(L, sizeof(RenFont*));
-    *font = ren_font_copy(fonts[i], size, antialiasing, hinting, style);
+    *font = ren_font_copy(&window_renderer, fonts[i], size, antialiasing, hinting, style);
     if (!*font)
       return luaL_error(L, "failed to copy font");
     luaL_setmetatable(L, API_TYPE_FONT);
@@ -198,7 +198,7 @@ static int f_font_get_width(lua_State *L) {
   size_t len;
   const char *text = luaL_checklstring(L, 2, &len);
 
-  lua_pushnumber(L, ren_font_group_get_width(fonts, text, len));
+  lua_pushnumber(L, ren_font_group_get_width(&window_renderer, fonts, text, len));
   return 1;
 }
 
@@ -217,7 +217,7 @@ static int f_font_get_size(lua_State *L) {
 static int f_font_set_size(lua_State *L) {
   RenFont* fonts[FONT_FALLBACK_MAX]; font_retrieve(L, fonts, 1);
   float size = luaL_checknumber(L, 2);
-  ren_font_group_set_size(fonts, size);
+  ren_font_group_set_size(&window_renderer, fonts, size);
   return 0;
 }
 
@@ -276,7 +276,7 @@ static int f_show_debug(lua_State *L) {
 
 static int f_get_size(lua_State *L) {
   int w, h;
-  ren_get_size(&w, &h);
+  ren_get_size(&window_renderer, &w, &h);
   lua_pushnumber(L, w);
   lua_pushnumber(L, h);
   return 2;

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -37,8 +37,6 @@
 #endif
 #endif
 
-extern RenWindow window_renderer;
-
 static const char* button_name(int button) {
   switch (button) {
     case SDL_BUTTON_LEFT   : return "left";
@@ -188,7 +186,7 @@ top:
 
     case SDL_WINDOWEVENT:
       if (e.window.event == SDL_WINDOWEVENT_RESIZED) {
-        ren_resize_window();
+        ren_resize_window(&window_renderer);
         lua_pushstring(L, "resized");
         /* The size below will be in points. */
         lua_pushinteger(L, e.window.data1);
@@ -473,7 +471,7 @@ static int f_set_window_size(lua_State *L) {
   double y = luaL_checknumber(L, 4);
   SDL_SetWindowSize(window_renderer.window, w, h);
   SDL_SetWindowPosition(window_renderer.window, x, y);
-  ren_resize_window();
+  ren_resize_window(&window_renderer);
   return 0;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -260,7 +260,7 @@ init_lua:
   }
 
   lua_close(L);
-  ren_free_window_resources();
+  ren_free_window_resources(&window_renderer);
 
   return EXIT_SUCCESS;
 }

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -173,7 +173,7 @@ void rencache_draw_rect(RenRect rect, RenColor color) {
 
 float rencache_draw_text(RenFont **fonts, const char *text, size_t len, float x, int y, RenColor color)
 {
-  float width = ren_font_group_get_width(fonts, text, len);
+  float width = ren_font_group_get_width(&window_renderer, fonts, text, len);
   RenRect rect = { x, y, (int)width, ren_font_group_get_height(fonts) };
   if (rects_overlap(screen_rect, rect)) {
     int sz = len + 1;
@@ -201,7 +201,7 @@ void rencache_begin_frame() {
   /* reset all cells if the screen width/height has changed */
   int w, h;
   resize_issue = false;
-  ren_get_size(&w, &h);
+  ren_get_size(&window_renderer, &w, &h);
   if (screen_rect.width != w || h != screen_rect.height) {
     screen_rect.width = w;
     screen_rect.height = h;
@@ -281,33 +281,33 @@ void rencache_end_frame() {
   for (int i = 0; i < rect_count; i++) {
     /* draw */
     RenRect r = rect_buf[i];
-    ren_set_clip_rect(r);
+    ren_set_clip_rect(&window_renderer, r);
 
     cmd = NULL;
     while (next_command(&cmd)) {
       switch (cmd->type) {
         case SET_CLIP:
-          ren_set_clip_rect(intersect_rects(cmd->rect, r));
+          ren_set_clip_rect(&window_renderer, intersect_rects(cmd->rect, r));
           break;
         case DRAW_RECT:
-          ren_draw_rect(cmd->rect, cmd->color);
+          ren_draw_rect(&window_renderer, cmd->rect, cmd->color);
           break;
         case DRAW_TEXT:
           ren_font_group_set_tab_size(cmd->fonts, cmd->tab_size);
-          ren_draw_text(cmd->fonts, cmd->text, cmd->len, cmd->text_x, cmd->rect.y, cmd->color);
+          ren_draw_text(&window_renderer, cmd->fonts, cmd->text, cmd->len, cmd->text_x, cmd->rect.y, cmd->color);
           break;
       }
     }
 
     if (show_debug) {
       RenColor color = { rand(), rand(), rand(), 50 };
-      ren_draw_rect(r, color);
+      ren_draw_rect(&window_renderer, r, color);
     }
   }
 
   /* update dirty rects */
   if (rect_count > 0) {
-    ren_update_rects(rect_buf, rect_count);
+    ren_update_rects(&window_renderer, rect_buf, rect_count);
   }
 
   /* swap cell buffer and reset */

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -171,9 +171,9 @@ void rencache_draw_rect(RenRect rect, RenColor color) {
   }
 }
 
-float rencache_draw_text(RenFont **fonts, const char *text, size_t len, float x, int y, RenColor color)
+float rencache_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, float x, int y, RenColor color)
 {
-  float width = ren_font_group_get_width(&window_renderer, fonts, text, len);
+  float width = ren_font_group_get_width(window_renderer, fonts, text, len);
   RenRect rect = { x, y, (int)width, ren_font_group_get_height(fonts) };
   if (rects_overlap(screen_rect, rect)) {
     int sz = len + 1;
@@ -197,11 +197,11 @@ void rencache_invalidate(void) {
 }
 
 
-void rencache_begin_frame() {
+void rencache_begin_frame(RenWindow *window_renderer) {
   /* reset all cells if the screen width/height has changed */
   int w, h;
   resize_issue = false;
-  ren_get_size(&window_renderer, &w, &h);
+  ren_get_size(window_renderer, &w, &h);
   if (screen_rect.width != w || h != screen_rect.height) {
     screen_rect.width = w;
     screen_rect.height = h;
@@ -239,7 +239,7 @@ static void push_rect(RenRect r, int *count) {
 }
 
 
-void rencache_end_frame() {
+void rencache_end_frame(RenWindow *window_renderer) {
   /* update cells from commands */
   Command *cmd = NULL;
   RenRect cr = screen_rect;
@@ -281,33 +281,33 @@ void rencache_end_frame() {
   for (int i = 0; i < rect_count; i++) {
     /* draw */
     RenRect r = rect_buf[i];
-    ren_set_clip_rect(&window_renderer, r);
+    ren_set_clip_rect(window_renderer, r);
 
     cmd = NULL;
     while (next_command(&cmd)) {
       switch (cmd->type) {
         case SET_CLIP:
-          ren_set_clip_rect(&window_renderer, intersect_rects(cmd->rect, r));
+          ren_set_clip_rect(window_renderer, intersect_rects(cmd->rect, r));
           break;
         case DRAW_RECT:
-          ren_draw_rect(&window_renderer, cmd->rect, cmd->color);
+          ren_draw_rect(window_renderer, cmd->rect, cmd->color);
           break;
         case DRAW_TEXT:
           ren_font_group_set_tab_size(cmd->fonts, cmd->tab_size);
-          ren_draw_text(&window_renderer, cmd->fonts, cmd->text, cmd->len, cmd->text_x, cmd->rect.y, cmd->color);
+          ren_draw_text(window_renderer, cmd->fonts, cmd->text, cmd->len, cmd->text_x, cmd->rect.y, cmd->color);
           break;
       }
     }
 
     if (show_debug) {
       RenColor color = { rand(), rand(), rand(), 50 };
-      ren_draw_rect(&window_renderer, r, color);
+      ren_draw_rect(window_renderer, r, color);
     }
   }
 
   /* update dirty rects */
   if (rect_count > 0) {
-    ren_update_rects(&window_renderer, rect_buf, rect_count);
+    ren_update_rects(window_renderer, rect_buf, rect_count);
   }
 
   /* swap cell buffer and reset */

--- a/src/rencache.h
+++ b/src/rencache.h
@@ -8,9 +8,9 @@
 void  rencache_show_debug(bool enable);
 void  rencache_set_clip_rect(RenRect rect);
 void  rencache_draw_rect(RenRect rect, RenColor color);
-float rencache_draw_text(RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
+float rencache_draw_text(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
 void  rencache_invalidate(void);
-void  rencache_begin_frame();
-void  rencache_end_frame();
+void  rencache_begin_frame(RenWindow *window_renderer);
+void  rencache_end_frame(RenWindow *window_renderer);
 
 #endif

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -11,6 +11,7 @@
 #define UNUSED
 #endif
 
+
 #define FONT_FALLBACK_MAX 10
 typedef struct RenFont RenFont;
 typedef enum { FONT_HINTING_NONE, FONT_HINTING_SLIGHT, FONT_HINTING_FULL } ERenFontHinting;
@@ -19,26 +20,30 @@ typedef enum { FONT_STYLE_BOLD = 1, FONT_STYLE_ITALIC = 2, FONT_STYLE_UNDERLINE 
 typedef struct { uint8_t b, g, r, a; } RenColor;
 typedef struct { int x, y, width, height; } RenRect;
 
-RenFont* ren_font_load(const char *filename, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, unsigned char style);
-RenFont* ren_font_copy(RenFont* font, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, int style);
+struct RenWindow;
+typedef struct RenWindow RenWindow;
+extern RenWindow window_renderer;
+
+RenFont* ren_font_load(RenWindow *window_renderer, const char *filename, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, unsigned char style);
+RenFont* ren_font_copy(RenWindow *window_renderer, RenFont* font, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, int style);
 const char* ren_font_get_path(RenFont *font);
 void ren_font_free(RenFont *font);
 int ren_font_group_get_tab_size(RenFont **font);
 int ren_font_group_get_height(RenFont **font);
 float ren_font_group_get_size(RenFont **font);
-void ren_font_group_set_size(RenFont **font, float size);
+void ren_font_group_set_size(RenWindow *window_renderer, RenFont **font, float size);
 void ren_font_group_set_tab_size(RenFont **font, int n);
-float ren_font_group_get_width(RenFont **font, const char *text, size_t len);
-float ren_draw_text(RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
+float ren_font_group_get_width(RenWindow *window_renderer, RenFont **font, const char *text, size_t len);
+float ren_draw_text(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
 
-void ren_draw_rect(RenRect rect, RenColor color);
+void ren_draw_rect(RenWindow *window_renderer, RenRect rect, RenColor color);
 
 void ren_init(SDL_Window *win);
-void ren_resize_window();
-void ren_update_rects(RenRect *rects, int count);
-void ren_set_clip_rect(RenRect rect);
-void ren_get_size(int *x, int *y); /* Reports the size in points. */
-void ren_free_window_resources();
+void ren_resize_window(RenWindow *window_renderer);
+void ren_update_rects(RenWindow *window_renderer, RenRect *rects, int count);
+void ren_set_clip_rect(RenWindow *window_renderer, RenRect rect);
+void ren_get_size(RenWindow *window_renderer, int *x, int *y); /* Reports the size in points. */
+void ren_free_window_resources(RenWindow *window_renderer);
 
 
 #endif


### PR DESCRIPTION
work towards #1318
requires #1319

Updates all renderer.c and rencache.c function that make use of RenWindow to receive it by argument instead of using it as a global.

More work is needed to allow the creation of multiple windows and fully move it into Lua, but this is a sizable chunk that should be merged first.