### PR TITLE
Revert "core syntax: strip the path from filename on syntax.get (#1168)"

### DIFF
--- a/data/core/syntax.lua
+++ b/data/core/syntax.lua
@@ -44,7 +44,7 @@ local function find(string, field)
 end
 
 function syntax.get(filename, header)
-  return find(common.basename(filename), "files")
+  return find(filename, "files")
       or (header and find(header, "headers"))
       or plain_text_syntax
 end


### PR DESCRIPTION
This reverts commit af6c4bc152234e13f3e12819e361e1b92a387013.

The previous behavior was correct and allowed access to the full path for path-dependant syntaxes.
The correct way to do filename-only matching is prepending the match with the path separator.
Would need testing on Windows to see whether it's necessary to use `[\\/]`, or if `/` is enough.