### PR TITLE
Make empty groups in `regex.gmatch` return their offset

### DIFF
--- a/src/api/regex.c
+++ b/src/api/regex.c
@@ -91,7 +91,10 @@ static int regex_gmatch_iterator(lua_State *L) {
         int total_results = ovector_count * 2;
         size_t last_offset = 0;
         for (int i = index; i < total_results; i+=2) {
-          lua_pushlstring(L, state->subject+ovector[i], ovector[i+1] - ovector[i]);
+          if (ovector[i] == ovector[i+1])
+            lua_pushinteger(L, ovector[i] + 1);
+          else
+            lua_pushlstring(L, state->subject+ovector[i], ovector[i+1] - ovector[i]);
           last_offset = ovector[i+1];
           total++;
         }


### PR DESCRIPTION
This makes `regex.gmatch` behave like `string.gmatch`.