### PR TITLE
Replace globally when replacing from selection

### DIFF
--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -211,6 +211,7 @@ command.add("core.docview!", {
   ["find-replace:replace"] = function()
     local l1, c1, l2, c2 = doc():get_selection()
     local selected_text = doc():get_text(l1, c1, l2, c2)
+    doc():set_selection(l2, c2, l2, c2)
     replace("Text", l1 == l2 and selected_text or "", function(text, old, new)
       if not find_regex then
         return text:gsub(old:gsub("%W", "%%%1"), new:gsub("%%", "%%%%"), nil)


### PR DESCRIPTION
This is a major usability issue for me, because by workflow often looks like this:
1. Select smth
2. Call the `find-replace:replace` command
3. Confirm the auto-filled search term
4. Enter the replacement term (often based on the search term)
5. Expect the replacement to occur in the whole file

The "replace in selection" feature is good, but it's not required so often as global replacement. And the global replacement is currently possible only if there's no selection while calling the `find-replace:replace`, which is not convenient at all (copy-pasting sucks).

As a workaround for scoped replacement, I like to copy a part of my text to another file, replace there and get it back.

closes #1225