### PR TITLE
Added in Config Postload

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1022,8 +1022,8 @@ function core.load_plugins()
         if not ok then
           no_errors = false
         elseif config.plugins[plugin.name].onload then
-	  core.try(config.plugins[plugin.name].onload, loaded_plugin)
-	end
+          core.try(config.plugins[plugin.name].onload, loaded_plugin)
+        end
       end
     end
   end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1010,7 +1010,7 @@ function core.load_plugins()
         table.insert(list, plugin.file)
       elseif config.plugins[plugin.name] ~= false then
         local start = system.get_time()
-        local ok = core.try(require, "plugins." .. plugin.name)
+        local ok, loaded_plugin = core.try(require, "plugins." .. plugin.name)
         if ok then
           core.log_quiet(
             "Loaded plugin %q from %s in %.1fms",
@@ -1021,9 +1021,8 @@ function core.load_plugins()
         end
         if not ok then
           no_errors = false
-        end
-	if config.plugins[plugin.name].onload then
-	  core.try(config.plugins[plugin.name].onload, ok)
+        elseif config.plugins[plugin.name].onload then
+	  core.try(config.plugins[plugin.name].onload, loaded_plugin)
 	end
       end
     end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1022,6 +1022,9 @@ function core.load_plugins()
         if not ok then
           no_errors = false
         end
+	if config.plugins[plugin.name].onload then
+	  core.try(config.plugins[plugin.name].onload, ok)
+	end
       end
     end
   end


### PR DESCRIPTION
Adds in a way of calling code after a plugin is finished loading without actually requiring a plugin.

Good in the falling way:

1. Discourages the user of `require plugins.name` which can change plugin load order, and can lead to errors for plugin developers.
2. Allows an easy, and overridable way for plugins to ensure that code is run after the load of other plugins.