### PR TITLE
Abstracted open_doc out to allow for more easy overriding.

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -441,6 +441,11 @@ function TreeView:toggle_expand(toggle)
 end
 
 
+function TreeView:open_doc(filename)
+  core.root_view:open_doc(core.open_doc(filename))
+end
+
+
 -- init
 local view = TreeView()
 local node = core.root_view:get_active_node()
@@ -610,8 +615,7 @@ command.add(TreeView, {
         if core.last_active_view and core.active_view == view then
           core.set_active_view(core.last_active_view)
         end
-        local doc_filename = core.normalize_to_project_dir(item.abs_filename)
-        core.root_view:open_doc(core.open_doc(doc_filename))
+        view:open_doc(core.normalize_to_project_dir(item.abs_filename))
       end)
     end
   end,
@@ -759,7 +763,7 @@ command.add(
         local file = io.open(doc_filename, "a+")
         file:write("")
         file:close()
-        core.root_view:open_doc(core.open_doc(doc_filename))
+        view:open_doc(doc_filename)
         core.log("Created %s", doc_filename)
       end,
       suggest = function(text)
@@ -801,8 +805,8 @@ local projectsearch = pcall(require, "plugins.projectsearch")
 if projectsearch then
   menu:register(function()
     return view.hovered_item and view.hovered_item.type == "dir"
-  end, { 
-    { text = "Find in directory", command = "treeview:search-in-directory" } 
+  end, {
+    { text = "Find in directory", command = "treeview:search-in-directory" }
   })
   command.add(function()
     return view.hovered_item and view.hovered_item.type == "dir"


### PR DESCRIPTION
Specifically for https://github.com/lite-xl/lite-xl-plugins/pull/2; provides an easy hookpoint for plugins to modify treeview's behaviour (and has the added bonus of slightly reducing duplication).