### PR TITLE
ci: fix msys build now requiring ca-certificates

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -63,10 +63,10 @@ main() {
   elif [[ "$OSTYPE" == "msys" ]]; then
     if [[ $lhelper == true ]]; then
       pacman --noconfirm -S \
-        ${MINGW_PACKAGE_PREFIX}-{gcc,meson,ninja,ntldd,pkg-config,mesa} unzip
+        ${MINGW_PACKAGE_PREFIX}-{ca-certificates,gcc,meson,ninja,ntldd,pkg-config,mesa} unzip
     else
       pacman --noconfirm -S \
-        ${MINGW_PACKAGE_PREFIX}-{gcc,meson,ninja,ntldd,pkg-config,mesa,freetype,pcre2,SDL2} unzip
+        ${MINGW_PACKAGE_PREFIX}-{ca-certificates,gcc,meson,ninja,ntldd,pkg-config,mesa,freetype,pcre2,SDL2} unzip
     fi
   fi
 }


### PR DESCRIPTION
Thanks to Guldoman who discovered the cause for meson failing to validate SSL certificates which turned out to be MSYS now requiring ca-certificates package installed for the different architectures.