### PR TITLE
Improved plugins config table handling

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -84,14 +84,6 @@ setmetatable(config.plugins, {
       return
     elseif plugins_config[k].enabled == false and v ~= false then
       plugins_config[k].enabled = true
-      -- prevent require looping when plugin enabled from itself
-      if
-        not debug.getinfo(2, "S").source:match(
-          PATHSEP .. "plugins" .. PATHSEP .. k .. "%.lua$"
-        )
-      then
-        require("plugins." .. k)
-      end
     end
     if v == false then
       plugins_config[k].enabled = false

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -1,3 +1,5 @@
+local common = require "core.common"
+
 local config = {}
 
 config.fps = 60
@@ -55,13 +57,60 @@ config.max_clicks = 3
 -- set as true to be able to test non supported plugins
 config.skip_plugins_version = false
 
+-- holds the plugins real config table
+local plugins_config = {}
+
+-- virtual representation of plugins config table
 config.plugins = {}
--- Allow you to set plugin configs even if we haven't seen the plugin before.
+
+-- allows virtual access to the plugins config table
 setmetatable(config.plugins, {
-  __index = function(t, k)
-    local v = rawget(t, k)
-    if v == true or v == nil then v = {} rawset(t, k, v) end
-    return v
+  __index = function(_, k)
+    if not plugins_config[k] then
+      plugins_config[k] = { loaded = false, enabled = true, config = {} }
+    end
+    if plugins_config[k].enabled ~= false then
+      return plugins_config[k].config
+    end
+    return false
+  end,
+  __newindex = function(_, k, v)
+    if not plugins_config[k] then
+      plugins_config[k] = { loaded = false, enabled = nil, config = {} }
+    end
+    if v == false and plugins_config[k].loaded then
+      local core = require "core"
+      core.warn("[%s] is already enabled, restart the editor for the change to take effect", k)
+      return
+    elseif plugins_config[k].enabled == false and v ~= false then
+      plugins_config[k].enabled = true
+      -- prevent require looping when plugin enabled from itself
+      if
+        not debug.getinfo(2, "S").source:match(
+          PATHSEP .. "plugins" .. PATHSEP .. k .. "%.lua$"
+        )
+      then
+        require("plugins." .. k)
+      end
+      plugins_config[k].loaded = true
+      if type(v) == "table" then
+        plugins_config[k].config = common.merge(plugins_config[k].config, v)
+      end
+      return
+    end
+    if v == false then
+      plugins_config[k].enabled = false
+    elseif type(v) == "table" then
+      plugins_config[k].enabled = true
+      plugins_config[k].config = common.merge(plugins_config[k].config, v)
+    end
+  end,
+  __pairs = function()
+    return coroutine.wrap(function()
+      for name, status in pairs(plugins_config) do
+        coroutine.yield(name, status.config)
+      end
+    end)
   end
 })
 

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -67,7 +67,7 @@ config.plugins = {}
 setmetatable(config.plugins, {
   __index = function(_, k)
     if not plugins_config[k] then
-      plugins_config[k] = { loaded = false, enabled = true, config = {} }
+      plugins_config[k] = { enabled = true, config = {} }
     end
     if plugins_config[k].enabled ~= false then
       return plugins_config[k].config
@@ -76,9 +76,9 @@ setmetatable(config.plugins, {
   end,
   __newindex = function(_, k, v)
     if not plugins_config[k] then
-      plugins_config[k] = { loaded = false, enabled = nil, config = {} }
+      plugins_config[k] = { enabled = nil, config = {} }
     end
-    if v == false and plugins_config[k].loaded then
+    if v == false and package.loaded["plugins."..k] then
       local core = require "core"
       core.warn("[%s] is already enabled, restart the editor for the change to take effect", k)
       return
@@ -92,11 +92,6 @@ setmetatable(config.plugins, {
       then
         require("plugins." .. k)
       end
-      plugins_config[k].loaded = true
-      if type(v) == "table" then
-        plugins_config[k].config = common.merge(plugins_config[k].config, v)
-      end
-      return
     end
     if v == false then
       plugins_config[k].enabled = false


### PR DESCRIPTION
* ~~Now it supports automatically loading/requiring a previously disabled plugin by using `config.plugins.plugin_name = true` or `config.plugins.plugin_name = {...}`~~ dropped because of concerns of loading priority issues

* Warns user if trying to disable a plugin that is already enabled when doing `config.plugins.plugin_name = false` and also prevents replacing the current plugin config table with the false value to mitigate runtime issues.

* Uses a merge strategy by default when assigning a table to a plugin config to prevent a user from removing a plugin default config values as experienced and explained on this issue https://github.com/lite-xl/lite-xl-plugins/issues/158

* This change is basically backwards compatible, but will require a change on the settings ui plugin on how it checks for already enabled plugins, since rawget will no longer be a working hack or workaround for this.