### PR TITLE
NagView: properly rescale on scale change

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -44,8 +44,8 @@ local function save(filename)
   else
     core.error(err)
     core.nag_view:show("Saving failed", string.format("Could not save \"%s\" do you want to save to another location?", doc().filename), {
-      { font = style.font, text = "No", default_no = true },
-      { font = style.font, text = "Yes" , default_yes = true }
+      { text = "No", default_no = true },
+      { text = "Yes", default_yes = true }
     }, function(item)
       if item.text == "Yes" then
         core.add_thread(function()

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -818,8 +818,8 @@ function core.init()
 
   if #plugins_refuse_list.userdir.plugins > 0 or #plugins_refuse_list.datadir.plugins > 0 then
     local opt = {
-      { font = style.font, text = "Exit", default_no = true },
-      { font = style.font, text = "Continue" , default_yes = true }
+      { text = "Exit", default_no = true },
+      { text = "Continue", default_yes = true }
     }
     local msg = {}
     for _, entry in pairs(plugins_refuse_list) do
@@ -860,8 +860,8 @@ function core.confirm_close_docs(docs, close_fn, ...)
     end
     local args = {...}
     local opt = {
-      { font = style.font, text = "Yes", default_yes = true },
-      { font = style.font, text = "No" , default_no = true }
+      { text = "Yes", default_yes = true },
+      { text = "No", default_no = true }
     }
     core.nag_view:show("Unsaved Changes", text, opt, function(item)
       if item.text == "Yes" then close_fn(table.unpack(args)) end

--- a/data/core/nagview.lua
+++ b/data/core/nagview.lua
@@ -91,7 +91,7 @@ function NagView:each_option()
 
     for i = #self.options, 1, -1 do
       opt = self.options[i]
-      bw = opt.font:get_width(opt.text) + 2 * BORDER_WIDTH + style.padding.x
+      bw = style.font:get_width(opt.text) + 2 * BORDER_WIDTH + style.padding.x
 
       ox = ox - bw - style.padding.x
       coroutine.yield(i, opt, ox,oy,bw,bh)
@@ -230,7 +230,7 @@ local function draw_nagview_message(self)
       renderer.draw_rect(lx,ly,uw,UNDERLINE_WIDTH, style.nagbar_text)
     end
 
-    common.draw_text(opt.font, style.nagbar_text, opt.text, "center", fx,fy,fw,fh)
+    common.draw_text(style.font, style.nagbar_text, opt.text, "center", fx,fy,fw,fh)
   end
 
   self:draw_scrollbar()
@@ -243,6 +243,16 @@ function NagView:draw()
     return
   end
   core.root_view:defer_draw(draw_nagview_message, self)
+end
+
+function NagView:on_scale_change(new_scale, old_scale)
+  BORDER_WIDTH = common.round(1 * new_scale)
+  UNDERLINE_WIDTH = common.round(2 * new_scale)
+  UNDERLINE_MARGIN = common.round(1 * new_scale)
+  self.target_height = math.max(
+    self:get_message_height(),
+    self:get_buttons_height()
+  )
 end
 
 function NagView:get_message_height()

--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -46,8 +46,8 @@ end
 local function check_prompt_reload(doc)
   if doc and doc.deferred_reload then
     core.nag_view:show("File Changed", doc.filename .. " has changed. Reload this file?", {
-      { font = style.font, text = "Yes", default_yes = true },
-      { font = style.font, text = "No" , default_no = true }
+      { text = "Yes", default_yes = true },
+      { text = "No", default_no = true }
     }, function(item)
       if item.text == "Yes" then reload_doc(doc) end
       doc.deferred_reload = false

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -709,8 +709,8 @@ command.add(
     local file_type = file_info.type == "dir" and "Directory" or "File"
     -- Ask before deleting
     local opt = {
-      { font = style.font, text = "Yes", default_yes = true },
-      { font = style.font, text = "No" , default_no = true }
+      { text = "Yes", default_yes = true },
+      { text = "No", default_no = true }
     }
     core.nag_view:show(
       string.format("Delete %s", file_type),


### PR DESCRIPTION
Besides properly rescaling the NagView overlay on scale changes this PR also drops the font option because:

1. its usage was unnecessary since the `style.font` is always used on the core for the buttons
2. creates unnecessary references to fonts when the user sets a different style.font
3. because of point 2 the font set on the options never scales when using the scale plugin because it goes unmanaged if the style.font changed at some point after the nagview options were set.

Checked the lite-xl-plugins repo and it seems no plugin is affected with the font option removal since none of the plugin is making use of core.nag_view

Before:
![Screenshot_2023-02-01_19-26-48](https://user-images.githubusercontent.com/1702572/216199627-298f9258-d458-460c-8365-61ca959272c8.png)


After:
![Screenshot_2023-02-01_19-45-37](https://user-images.githubusercontent.com/1702572/216199652-b833975f-c2c5-489f-96bf-283fb17d28ef.png)
