### PR TITLE
Made coroutines make more sense, and fixed a bug.

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1402,6 +1402,8 @@ local run_threads = coroutine.wrap(function()
         else
           minimal_time_to_wake = 0
         end
+      else
+        minimal_time_to_wake =  math.min(minimal_time_to_wake, thread.wake - system.get_time())
       end
 
       -- stop running threads if we're about to hit the end of frame
@@ -1440,7 +1442,7 @@ function core.run()
     else
       idle_iterations = 0
       local elapsed = system.get_time() - core.frame_start
-      system.sleep(math.max(0, 1 / config.fps - elapsed))
+      system.sleep(math.min(math.max(0, 1 / config.fps - elapsed), minimal_time_to_wake))
     end
   end
 end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1400,7 +1400,7 @@ local run_threads = coroutine.wrap(function()
           thread.wake = system.get_time() + wait
           minimal_time_to_wake = math.min(minimal_time_to_wake, wait)
         else
-          minimal_time_to_wake = max_time
+          minimal_time_to_wake = 0
         end
       end
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1431,14 +1431,15 @@ function core.run()
 
     if not did_redraw then
       if system.window_has_focus() then
+        local now = system.get_time()
         if not next_step then -- compute the time until the next blink
-          local t = system.get_time() - core.blink_start
+          local t = now - core.blink_start
           local h = config.blink_period / 2
           local dt = math.ceil(t / h) * h - t
           local cursor_time_to_wake = dt + 1 / config.fps
-          next_step = system.get_time() + cursor_time_to_wake
+          next_step = now + cursor_time_to_wake
         end
-        if time_to_wake > 0 and system.wait_event(math.min(next_step - system.get_time(), time_to_wake)) then
+        if time_to_wake > 0 and system.wait_event(math.min(next_step - now, time_to_wake)) then
           next_step = nil -- if we've recevied an event, perform a step
         end
       else
@@ -1446,9 +1447,10 @@ function core.run()
         next_step = nil -- perform a step when we're not in focus if get we an event
       end
     else -- if we redrew, then make sure we only draw at most FPS/sec
-      local elapsed = system.get_time() - core.frame_start
+      local now = system.get_time()
+      local elapsed = now - core.frame_start
       local next_frame = math.max(0, 1 / config.fps - elapsed)
-      next_step = next_step or (system.get_time() + next_frame)
+      next_step = next_step or (now + next_frame)
       system.sleep(math.min(next_frame, time_to_wake))
     end
   end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1447,7 +1447,9 @@ function core.run()
       end
     else -- if we redrew, then make sure we only draw at most FPS/sec
       local elapsed = system.get_time() - core.frame_start
-      system.sleep(math.min(math.max(0, 1 / config.fps - elapsed), time_to_wake))
+      local next_frame = math.max(0, 1 / config.fps - elapsed)
+      next_step = next_step or (system.get_time() + next_frame)
+      system.sleep(math.min(next_frame, time_to_wake))
     end
   end
 end


### PR DESCRIPTION
So there were a couple issues here:

1. Coroutines, even in foreground, were only running on events, with the cursor blink cycle. This is wrong; if we're in foreground, and the coroutine requests that it should be serviced in 10ms, it shouldn't take 400ms.
2. I dun goofed, and mixed up then/else in a ternary; the thread watching for directory changes was sleeping when changes were happening, and revving like crazy when they weren't. This was masked by the above issue, now fixed.