### PR TITLE
(More) standards-compliant system.load_native_plugin

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -978,7 +978,7 @@ static int f_load_native_plugin(lua_State *L) {
   const char *path = luaL_checkstring(L, 2);
   void *library = SDL_LoadObject(path);
   if (!library)
-    return (lua_pushstring(L, SDL_GetError()), lua_error(L));
+    return luaL_error(L, "%s", SDL_GetError());
 
   lua_getglobal(L, "package");
   lua_getfield(L, -1, "native_plugins");

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -990,6 +990,12 @@ static int f_load_native_plugin(lua_State *L) {
   lua_setfield(L, -2, name);
   lua_pop(L, 2);
 
+  // only loading the library for symbols
+  if (strcmp(name, "*") == 0) {
+    lua_pushboolean(L, 1);
+    return 1;
+  }
+
   // create the correct function name
   // if name has hypen, remove itself and everything after the hyphen
   char *name_end = strchr(name, '-');

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -966,7 +966,7 @@ static int f_library_gc(lua_State *L) {
   lua_getfield(L, 1, "handle");
   void* handle = lua_touserdata(L, -1);
   SDL_UnloadObject(handle);
-  
+
   return 0;
 }
 
@@ -1124,7 +1124,7 @@ static const luaL_Reg lib[] = {
 
 
 int luaopen_system(lua_State *L) {
-  luaL_newmetatable(L, API_TYPE_NATIVE_PLUGIN); 
+  luaL_newmetatable(L, API_TYPE_NATIVE_PLUGIN);
   lua_pushcfunction(L, f_library_gc);
   lua_setfield(L, -2, "__gc");
   luaL_newlib(L, lib);


### PR DESCRIPTION
There are some things the old system.load_native_plugin does not support, namely:

- dots in the name (our behavior is to use the last segment)
- dashes in the name

This PR properly converts dots into underscores and removes anything after the dash.
The stack is also properly cleared so that the loaded function gets only the module name and loader data when extra arguments are passed to the function.

# Squash me