### PR TITLE
Added in support for foreground and background events.

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1340,6 +1340,11 @@ function core.step()
       did_keymap = false
     elseif type == "mousemoved" then
       core.try(core.on_event, type, a, b, c, d)
+    elseif type == "enteringforeground" then
+      -- to break our frame refresh in two if we get entering/entered at the same time.
+      -- required to avoid flashing and refresh issues on mobile
+      core.redraw = true
+      break
     else
       local _, res = core.try(core.on_event, type, a, b, c, d)
       did_keymap = res or did_keymap

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -358,6 +358,21 @@ top:
       lua_pushinteger(L, (lua_Integer)(e.tfinger.dy * h));
       lua_pushinteger(L, e.tfinger.fingerId);
       return 6;
+    case SDL_APP_WILLENTERFOREGROUND:
+    case SDL_APP_DIDENTERFOREGROUND:
+      #ifdef LITE_USE_SDL_RENDERER
+        rencache_invalidate();
+      #else
+        SDL_UpdateWindowSurface(window_renderer.window);
+      #endif
+      lua_pushstring(L, e.type == SDL_APP_WILLENTERFOREGROUND ? "enteringforeground" : "enteredforeground");
+      return 1;
+    case SDL_APP_WILLENTERBACKGROUND:
+      lua_pushstring(L, "enteringbackground");
+      return 1;
+    case SDL_APP_DIDENTERBACKGROUND:
+      lua_pushstring(L, "enteredbackground");
+      return 1;
 
     default:
       goto top;
@@ -966,7 +981,7 @@ static int f_library_gc(lua_State *L) {
   lua_getfield(L, 1, "handle");
   void* handle = lua_touserdata(L, -1);
   SDL_UnloadObject(handle);
-  
+
   return 0;
 }
 
@@ -1107,7 +1122,7 @@ static const luaL_Reg lib[] = {
 
 
 int luaopen_system(lua_State *L) {
-  luaL_newmetatable(L, API_TYPE_NATIVE_PLUGIN); 
+  luaL_newmetatable(L, API_TYPE_NATIVE_PLUGIN);
   lua_pushcfunction(L, f_library_gc);
   lua_setfield(L, -2, "__gc");
   luaL_newlib(L, lib);


### PR DESCRIPTION
Needed for [lite-xl-android](https://github.com/adamharrison/lite-xl-android) to work correctly. Simply adds two common events on mobile, and forces a redraw if they happen.