### PR TITLE
Fix invalid EXEFILE and EXEDIR on Windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -32,8 +32,12 @@ static double get_scale(void) {
 
 static void get_exe_filename(char *buf, int sz) {
 #if _WIN32
-  int len = GetModuleFileName(NULL, buf, sz - 1);
-  buf[len] = '\0';
+  wchar_t buf_w[sz];
+  int len = GetModuleFileNameW(NULL, buf_w, sz - 1);
+  buf_w[len] = L'\0';
+  // if the conversion failed we'll empty the string
+  if (!WideCharToMultiByte(CP_UTF8, 0, buf_w, -1, buf, sz, NULL, NULL))
+    buf[0] = '\0';
 #elif __linux__
   char path[] = "/proc/self/exe";
   ssize_t len = readlink(path, buf, sz - 1);

--- a/src/main.c
+++ b/src/main.c
@@ -224,9 +224,10 @@ init_lua:
   const char *init_lite_code = \
     "local core\n"
     "xpcall(function()\n"
+    "  local match = require('utf8extra').match\n"
     "  HOME = os.getenv('" LITE_OS_HOME "')\n"
-    "  local exedir = EXEFILE:match('^(.*)" LITE_PATHSEP_PATTERN LITE_NONPATHSEP_PATTERN "$')\n"
-    "  local prefix = os.getenv('LITE_PREFIX') or exedir:match('^(.*)" LITE_PATHSEP_PATTERN "bin$')\n"
+    "  local exedir = match(EXEFILE, '^(.*)" LITE_PATHSEP_PATTERN LITE_NONPATHSEP_PATTERN "$')\n"
+    "  local prefix = os.getenv('LITE_PREFIX') or match(exedir, '^(.*)" LITE_PATHSEP_PATTERN "bin$')\n"
     "  dofile((MACOS_RESOURCES or (prefix and prefix .. '/share/lite-xl' or exedir .. '/data')) .. '/core/start.lua')\n"
     "  core = require(os.getenv('LITE_XL_RUNTIME') or 'core')\n"
     "  core.init()\n"

--- a/src/main.c
+++ b/src/main.c
@@ -32,12 +32,18 @@ static double get_scale(void) {
 
 static void get_exe_filename(char *buf, int sz) {
 #if _WIN32
-  wchar_t buf_w[sz];
-  int len = GetModuleFileNameW(NULL, buf_w, sz - 1);
-  buf_w[len] = L'\0';
-  // if the conversion failed we'll empty the string
-  if (!WideCharToMultiByte(CP_UTF8, 0, buf_w, -1, buf, sz, NULL, NULL))
+  int len;
+  wchar_t *buf_w = malloc(sizeof(wchar_t) * sz);
+  if (buf_w) {
+    len = GetModuleFileNameW(NULL, buf_w, sz - 1);
+    buf_w[len] = L'\0';
+    // if the conversion failed we'll empty the string
+    if (!WideCharToMultiByte(CP_UTF8, 0, buf_w, -1, buf, sz, NULL, NULL))
+      buf[0] = '\0';
+    free(buf_w);
+  } else {
     buf[0] = '\0';
+  }
 #elif __linux__
   char path[] = "/proc/self/exe";
   ssize_t len = readlink(path, buf, sz - 1);


### PR DESCRIPTION
This is because we still use GetModuleFileName instead of GetModuleFileNameW which will return ACP instead of UTF-8. This should allow DATADIR to be in UTF-8.