### PR TITLE
Fix os.getenv() not supporting UTF-8 output

### DIFF
--- a/resources/windows/001-lua-unicode.diff
+++ b/resources/windows/001-lua-unicode.diff
@@ -1,6 +1,6 @@
-diff -ruN lua-5.4.4/meson.build lua-5.4.4-mod/meson.build
---- lua-5.4.4/meson.build	2022-11-16 10:33:38.424383300 +0800
-+++ lua-5.4.4-mod/meson.build	2022-11-16 09:40:57.697918000 +0800
+diff -ruN lua-5.4.4\meson.build lua-5.4.4-patched\meson.build
+--- lua-5.4.4\meson.build	Wed Feb 22 18:16:56 2023
++++ lua-5.4.4-patched\meson.build	Wed Feb 22 04:10:01 2023
 @@ -85,6 +85,7 @@
    'src/lutf8lib.c',
    'src/lvm.c',
@@ -9,9 +9,9 @@ diff -ruN lua-5.4.4/meson.build lua-5.4.4-mod/meson.build
    dependencies: lua_lib_deps,
    version: meson.project_version(),
    soversion: lua_versions[0] + '.' + lua_versions[1],
-diff -ruN lua-5.4.4/src/luaconf.h lua-5.4.4-mod/src/luaconf.h
---- lua-5.4.4/src/luaconf.h	2022-01-13 19:24:43.000000000 +0800
-+++ lua-5.4.4-mod/src/luaconf.h	2022-11-16 09:40:57.703926000 +0800
+diff -ruN lua-5.4.4\src\luaconf.h lua-5.4.4-patched\src\luaconf.h
+--- lua-5.4.4\src\luaconf.h	Thu Jan 13 19:24:43 2022
++++ lua-5.4.4-patched\src\luaconf.h	Wed Feb 22 04:10:02 2023
 @@ -782,5 +782,15 @@
  
  
@@ -28,9 +28,9 @@ diff -ruN lua-5.4.4/src/luaconf.h lua-5.4.4-mod/src/luaconf.h
 +
  #endif
  
-diff -ruN lua-5.4.4/src/Makefile lua-5.4.4-mod/src/Makefile
---- lua-5.4.4/src/Makefile	2021-07-15 22:01:52.000000000 +0800
-+++ lua-5.4.4-mod/src/Makefile	2022-11-16 09:40:57.708921800 +0800
+diff -ruN lua-5.4.4\src\Makefile lua-5.4.4-patched\src\Makefile
+--- lua-5.4.4\src\Makefile	Thu Jul 15 22:01:52 2021
++++ lua-5.4.4-patched\src\Makefile	Wed Feb 22 04:10:02 2023
 @@ -33,7 +33,7 @@
  PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
  
@@ -40,10 +40,10 @@ diff -ruN lua-5.4.4/src/Makefile lua-5.4.4-mod/src/Makefile
  LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
  BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
  
-diff -ruN lua-5.4.4/src/utf8_wrappers.c lua-5.4.4-mod/src/utf8_wrappers.c
---- lua-5.4.4/src/utf8_wrappers.c	1970-01-01 07:30:00.000000000 +0730
-+++ lua-5.4.4-mod/src/utf8_wrappers.c	2022-11-16 10:09:04.583866600 +0800
-@@ -0,0 +1,101 @@
+diff -ruN lua-5.4.4\src\utf8_wrappers.c lua-5.4.4-patched\src\utf8_wrappers.c
+--- lua-5.4.4\src\utf8_wrappers.c	Thu Jan 01 08:00:00 1970
++++ lua-5.4.4-patched\src\utf8_wrappers.c	Wed Feb 22 18:13:45 2023
+@@ -0,0 +1,129 @@
 +/**
 + * Wrappers to provide Unicode (UTF-8) support on Windows.
 + *
@@ -58,11 +58,16 @@ diff -ruN lua-5.4.4/src/utf8_wrappers.c lua-5.4.4-mod/src/utf8_wrappers.c
 +#include <stdlib.h>
 +#include <errno.h>
 +
++// A environment variable has the maximum length of 32767 characters
++// including the terminator.
++#define MAX_ENV_SIZE    32767
 +// Set a high limit in case long paths are enabled.
 +#define MAX_PATH_SIZE   4096
 +#define MAX_MODE_SIZE   128
 +// cmd.exe argument length is reportedly limited to 8192.
 +#define MAX_CMD_SIZE    8192
++
++static char env_value[MAX_ENV_SIZE];
 +
 +FILE *fopen_utf8(const char *pathname, const char *mode) {
 +    wchar_t pathname_w[MAX_PATH_SIZE];
@@ -144,11 +149,34 @@ diff -ruN lua-5.4.4/src/utf8_wrappers.c lua-5.4.4-mod/src/utf8_wrappers.c
 +    }
 +    return LoadLibraryExW(pathname_w, hFile, dwFlags);
 +}
++
++char* getenv_utf8(const char *varname) {
++  /** This implementation is not thread safe.
++   * The string is only valid until the next call to getenv.
++   * This behavior is allowed per POSIX.1-2017 where it was said that:
++   * > The returned string pointer might be invalidated or the string content might be overwritten by a subsequent call to getenv(), setenv(), unsetenv(), or (if supported) putenv() but they shall not be affected by a call to any other function in this volume of POSIX.1-2017.
++   * > The returned string pointer might also be invalidated if the calling thread is terminated.
++   * > The getenv() function need not be thread-safe.
++   */
++  wchar_t *value_w;
++  wchar_t varname_w[MAX_ENV_SIZE];
++
++  if (!MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, varname, -1, varname_w, MAX_ENV_SIZE))
++    return NULL;
++  value_w = _wgetenv((const wchar_t *) varname_w);
++  if (!value_w)
++    return NULL;
++
++  if (!WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, value_w, -1, env_value, MAX_ENV_SIZE, NULL, NULL))
++    return NULL;
++
++  return env_value;
++}
 +#endif
-diff -ruN lua-5.4.4/src/utf8_wrappers.h lua-5.4.4-mod/src/utf8_wrappers.h
---- lua-5.4.4/src/utf8_wrappers.h	1970-01-01 07:30:00.000000000 +0730
-+++ lua-5.4.4-mod/src/utf8_wrappers.h	2022-11-16 10:29:46.044102000 +0800
-@@ -0,0 +1,44 @@
+diff -ruN lua-5.4.4\src\utf8_wrappers.h lua-5.4.4-patched\src\utf8_wrappers.h
+--- lua-5.4.4\src\utf8_wrappers.h	Thu Jan 01 08:00:00 1970
++++ lua-5.4.4-patched\src\utf8_wrappers.h	Wed Feb 22 18:09:48 2023
+@@ -0,0 +1,46 @@
 +/**
 + * Wrappers to provide Unicode (UTF-8) support on Windows.
 + *
@@ -180,9 +208,11 @@ diff -ruN lua-5.4.4/src/utf8_wrappers.h lua-5.4.4-mod/src/utf8_wrappers.h
 +int remove_utf8(const char *pathname);
 +int rename_utf8(const char *oldpath, const char *newpath);
 +int system_utf8(const char *command);
++char *getenv_utf8(const char *varname);
 +#define remove              remove_utf8
 +#define rename              rename_utf8
 +#define system              system_utf8
++#define getenv              getenv_utf8
 +#endif
 +
 +#ifdef loadlib_c


### PR DESCRIPTION
Mostly likely will fix #1359.

EDIT:
Fixes #1359.