### PR TITLE
fix: fix differing stacktrace on stdout and file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -230,7 +230,7 @@ init_lua:
     "end, function(err)\n"
     "  local error_dir\n"
     "  io.stdout:write('Error: '..tostring(err)..'\\n')\n"
-    "  io.stdout:write(debug.traceback(nil, 4)..'\\n')\n"
+    "  io.stdout:write(debug.traceback(nil, 3)..'\\n')\n"
     "  if core and core.on_error then\n"
     "    error_dir=USERDIR\n"
     "    pcall(core.on_error, err)\n"

--- a/src/main.c
+++ b/src/main.c
@@ -230,7 +230,7 @@ init_lua:
     "end, function(err)\n"
     "  local error_dir\n"
     "  io.stdout:write('Error: '..tostring(err)..'\\n')\n"
-    "  io.stdout:write(debug.traceback(nil, 3)..'\\n')\n"
+    "  io.stdout:write(debug.traceback(nil, 2)..'\\n')\n"
     "  if core and core.on_error then\n"
     "    error_dir=USERDIR\n"
     "    pcall(core.on_error, err)\n"


### PR DESCRIPTION
The stack trace printed on the terminal and the file is different.
This PR fixes that.