### PR TITLE
Improve text width calculation precision

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -345,7 +345,7 @@ static int f_draw_text(lua_State *L) {
 
   size_t len;
   const char *text = luaL_checklstring(L, 2, &len);
-  float x = luaL_checknumber(L, 3);
+  double x = luaL_checknumber(L, 3);
   int y = luaL_checknumber(L, 4);
   RenColor color = checkcolor(L, 5, 255);
   x = rencache_draw_text(&window_renderer, fonts, text, len, x, y, color);

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -175,9 +175,9 @@ void rencache_draw_rect(RenRect rect, RenColor color) {
   }
 }
 
-float rencache_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, float x, int y, RenColor color)
+double rencache_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, double x, int y, RenColor color)
 {
-  float width = ren_font_group_get_width(window_renderer, fonts, text, len);
+  double width = ren_font_group_get_width(window_renderer, fonts, text, len);
   RenRect rect = { x, y, (int)width, ren_font_group_get_height(fonts) };
   if (rects_overlap(last_clip_rect, rect)) {
     int sz = len + 1;

--- a/src/rencache.h
+++ b/src/rencache.h
@@ -8,7 +8,7 @@
 void  rencache_show_debug(bool enable);
 void  rencache_set_clip_rect(RenRect rect);
 void  rencache_draw_rect(RenRect rect, RenColor color);
-float rencache_draw_text(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
+double rencache_draw_text(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, double x, int y, RenColor color);
 void  rencache_invalidate(void);
 void  rencache_begin_frame(RenWindow *window_renderer);
 void  rencache_end_frame(RenWindow *window_renderer);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -360,8 +360,8 @@ int ren_font_group_get_height(RenFont **fonts) {
   return fonts[0]->height;
 }
 
-float ren_font_group_get_width(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len) {
-  float width = 0;
+double ren_font_group_get_width(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len) {
+  double width = 0;
   const char* end = text + len;
   GlyphMetric* metric = NULL; GlyphSet* set = NULL;
   while (text < end) {
@@ -376,12 +376,12 @@ float ren_font_group_get_width(RenWindow *window_renderer, RenFont **fonts, cons
   return width / surface_scale;
 }
 
-float ren_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, float x, int y, RenColor color) {
+double ren_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, float x, int y, RenColor color) {
   SDL_Surface *surface = renwin_get_surface(window_renderer);
   const RenRect clip = window_renderer->clip;
 
   const int surface_scale = renwin_surface_scale(window_renderer);
-  float pen_x = x * surface_scale;
+  double pen_x = x * surface_scale;
   y *= surface_scale;
   int bytes_per_pixel = surface->format->BytesPerPixel;
   const char* end = text + len;
@@ -389,7 +389,7 @@ float ren_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *tex
   int clip_end_x = clip.x + clip.width, clip_end_y = clip.y + clip.height;
 
   RenFont* last = NULL;
-  float last_pen_x = x;
+  double last_pen_x = x;
   bool underline = fonts[0]->style & FONT_STYLE_UNDERLINE;
   bool strikethrough = fonts[0]->style & FONT_STYLE_STRIKETHROUGH;
 
@@ -453,7 +453,7 @@ float ren_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *tex
 
     if(!last) last = font;
     else if(font != last || text == end) {
-      float local_pen_x = text == end ? pen_x + adv : pen_x;
+      double local_pen_x = text == end ? pen_x + adv : pen_x;
       if (underline)
         ren_draw_rect(window_renderer, (RenRect){last_pen_x, y / surface_scale + last->height - 1, (local_pen_x - last_pen_x) / surface_scale, last->underline_thickness * surface_scale}, color);
       if (strikethrough)

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -33,8 +33,8 @@ int ren_font_group_get_height(RenFont **font);
 float ren_font_group_get_size(RenFont **font);
 void ren_font_group_set_size(RenWindow *window_renderer, RenFont **font, float size);
 void ren_font_group_set_tab_size(RenFont **font, int n);
-float ren_font_group_get_width(RenWindow *window_renderer, RenFont **font, const char *text, size_t len);
-float ren_draw_text(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
+double ren_font_group_get_width(RenWindow *window_renderer, RenFont **font, const char *text, size_t len);
+double ren_draw_text(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
 
 void ren_draw_rect(RenWindow *window_renderer, RenRect rect, RenColor color);
 


### PR DESCRIPTION
In some extreme cases (~30000 chars), text width precision takes a hit. Using double instead of float fixes that.

To repro the issue:
1. Open a new file (must be plaintext)
2. Write ~30000 chars
3. Notice that the caret position is wrong.

Another possible solution would be to force the tokenizer to split long strings, so that we never calculate the width of extremely long strings.

There might be a performance impact, but I haven't tested that yet.