### PR TITLE
Asynchronous process reaping

### DIFF
--- a/src/api/process.c
+++ b/src/api/process.c
@@ -11,7 +11,7 @@
 #if _WIN32
   // https://stackoverflow.com/questions/60645/overlapped-i-o-on-anonymous-pipe
   // https://docs.microsoft.com/en-us/windows/win32/procthread/creating-a-child-process-with-redirected-input-and-output
-  #include <windows.h> 
+  #include <windows.h>
 #else
   #include <errno.h>
   #include <unistd.h>
@@ -322,7 +322,7 @@ static int process_start(lua_State* L) {
   if (arg_len > 1) {
     lua_getfield(L, 2, "env");
     if (!lua_isnil(L, -1)) {
-      lua_pushnil(L); 
+      lua_pushnil(L);
       while (lua_next(L, -2) != 0) {
         const char* key = luaL_checklstring(L, -2, &key_len);
         const char* val = luaL_checklstring(L, -1, &val_len);
@@ -349,7 +349,7 @@ static int process_start(lua_State* L) {
       }
     }
   }
-  
+
   process_t* self = lua_newuserdata(L, sizeof(process_t));
   memset(self, 0, sizeof(process_t));
   luaL_setmetatable(L, API_TYPE_PROCESS);
@@ -366,9 +366,9 @@ static int process_start(lua_State* L) {
           }
           self->child_pipes[i][i == STDIN_FD ? 1 : 0] = INVALID_HANDLE_VALUE;
         break;
-        case REDIRECT_DISCARD: 
-          self->child_pipes[i][0] = INVALID_HANDLE_VALUE; 
-          self->child_pipes[i][1] = INVALID_HANDLE_VALUE; 
+        case REDIRECT_DISCARD:
+          self->child_pipes[i][0] = INVALID_HANDLE_VALUE;
+          self->child_pipes[i][1] = INVALID_HANDLE_VALUE;
         break;
         default: {
           if (new_fds[i] == i) {
@@ -459,7 +459,7 @@ static int process_start(lua_State* L) {
       goto cleanup;
     }
     self->pid = (long)self->process_information.dwProcessId;
-    if (detach) 
+    if (detach)
       CloseHandle(self->process_information.hProcess);
     CloseHandle(self->process_information.hThread);
   #else
@@ -637,7 +637,7 @@ static int f_close_stream(lua_State* L) {
 static int process_strerror(lua_State* L) {
   #if _WIN32
     return 1;
-  #endif 
+  #endif
   int error_code = luaL_checknumber(L, 1);
   if (error_code < 0)
     lua_pushstring(L, strerror(error_code));
@@ -696,7 +696,7 @@ static int f_terminate(lua_State* L) { return self_signal(L, SIGNAL_TERM); }
 static int f_kill(lua_State* L) { return self_signal(L, SIGNAL_KILL); }
 static int f_interrupt(lua_State* L) { return self_signal(L, SIGNAL_INTERRUPT); }
 
-static int f_gc(lua_State* L) { 
+static int f_gc(lua_State* L) {
   process_t* self = (process_t*) luaL_checkudata(L, 1, API_TYPE_PROCESS);
 
   if (poll_process(self, 0) && !self->detached) {
@@ -791,7 +791,7 @@ int luaopen_process(lua_State *L) {
   API_CONSTANT_DEFINE(L, -1, "STREAM_STDERR", STDERR_FD);
 
   API_CONSTANT_DEFINE(L, -1, "REDIRECT_DEFAULT", REDIRECT_DEFAULT);
-  API_CONSTANT_DEFINE(L, -1, "REDIRECT_STDOUT", STDOUT_FD); 
+  API_CONSTANT_DEFINE(L, -1, "REDIRECT_STDOUT", STDOUT_FD);
   API_CONSTANT_DEFINE(L, -1, "REDIRECT_STDERR", STDERR_FD);
   API_CONSTANT_DEFINE(L, -1, "REDIRECT_PARENT", REDIRECT_PARENT); // Redirects to parent's STDOUT/STDERR
   API_CONSTANT_DEFINE(L, -1, "REDIRECT_DISCARD", REDIRECT_DISCARD); // Closes the filehandle, discarding it.

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -22,7 +22,6 @@
 #endif
 
 #define READ_BUF_SIZE 2048
-#define KILL_LIST_MIN_SIZE 16
 #define PROCESS_TERM_TRIES 3
 #define PROCESS_TERM_DELAY 50
 

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -218,7 +218,7 @@ static int kill_list_worker(void *ud) {
       process_kill_t *temp;
 
       // do not check for completion if the timeout has not expired
-      if ((SDL_GetTicks() - current_task->start_time < PROCESS_TERM_DELAY)) {
+      if ((SDL_GetTicks() - current_task->start_time) < PROCESS_TERM_DELAY) {
         last_task = current_task;
         current_task = current_task->next;
         continue;

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -763,7 +763,6 @@ static const struct luaL_Reg lib[] = {
 };
 
 int luaopen_process(lua_State *L) {
-  setvbuf(stdout, NULL, _IONBF, 0);
   if (kill_list_init(&kill_list))
     kill_list_thread = SDL_CreateThread(kill_list_worker, "process_kill", &kill_list);
 

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -23,9 +23,11 @@
 #define READ_BUF_SIZE 2048
 
 #if _WIN32
+typedef HANDLE process_stream_handle;
 typedef HANDLE process_handle;
 #else
-typedef int process_handle;
+typedef int process_stream_handle;
+typedef pid_t process_handle;
 #endif
 
 typedef struct {
@@ -38,7 +40,7 @@ typedef struct {
     bool reading[2];
     char buffer[2][READ_BUF_SIZE];
   #endif
-  process_handle child_pipes[3][2];
+  process_stream_handle child_pipes[3][2];
 } process_t;
 
 typedef enum {
@@ -372,7 +374,7 @@ static int process_start(lua_State* L) {
     free((char*)env_values[i]);
   }
   for (int stream = 0; stream < 3; ++stream) {
-    process_handle* pipe = &self->child_pipes[stream][stream == STDIN_FD ? 0 : 1];
+    process_stream_handle* pipe = &self->child_pipes[stream][stream == STDIN_FD ? 0 : 1];
     if (*pipe) {
       close_fd(pipe);
     }

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -259,12 +259,15 @@ static int kill_list_worker(void *ud) {
 
 
 static bool poll_process(process_t* proc, int timeout) {
+  uint32_t ticks;
+
   if (!proc->running)
     return false;
-  uint32_t ticks = SDL_GetTicks();
+
   if (timeout == WAIT_DEADLINE)
     timeout = proc->deadline;
 
+  ticks = SDL_GetTicks();
   do {
     int status;
     if (!process_handle_is_running(PROCESS_GET_HANDLE(proc), &status)) {
@@ -273,7 +276,7 @@ static bool poll_process(process_t* proc, int timeout) {
       break;
     }
     if (timeout)
-      SDL_Delay(5);
+      SDL_Delay(timeout >= 5 ? 5 : 0);
   } while (timeout == WAIT_INFINITE || (int)SDL_GetTicks() - ticks < timeout);
 
   return proc->running;

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -243,7 +243,7 @@ static int kill_list_worker(void *ud) {
         free(current_task);
       }
     }
-    delay = list->head ? SDL_GetTicks() - list->head->start_time : 0;
+    delay = list->head ? (list->head->start_time + PROCESS_TERM_DELAY) - SDL_GetTicks() : 0;
     SDL_UnlockMutex(list->mutex);
     SDL_Delay(delay);
   }

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -140,9 +140,8 @@ static void kill_list_push(process_kill_list_t *list, process_kill_t *task) {
 static void kill_list_wait_all(process_kill_list_t *list) {
   SDL_LockMutex(list->mutex);
   // wait until list is empty
-  while (list->head) {
+  while (list->head)
     SDL_CondWait(list->work_done, list->mutex);
-  }
   // tell the worker to stop
   list->stop = true;
   SDL_CondSignal(list->has_work);

--- a/src/main.c
+++ b/src/main.c
@@ -259,8 +259,10 @@ init_lua:
     goto init_lua;
   }
 
-  lua_close(L);
+  // This allows the window to be destroyed before lite-xl is done with
+  // reaping child processes
   ren_free_window_resources(&window_renderer);
+  lua_close(L);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR allows process handles to be reaped asynchronously.
Previously, process reaping on `__gc` will stall the GC due to waiting for process to actually exit.
Now, this PR will allow the GC to run continuously while the process is sent to a background thread where it is terminated.

This also fixes an issue on Windows where console applications are improperly kept open, holding lite-xl in the background.
