### PR TITLE
Move SetProcessDPIAware to manifests

### DIFF
--- a/resources/windows/lite-xl.exe.manifest.in
+++ b/resources/windows/lite-xl.exe.manifest.in
@@ -24,6 +24,13 @@
           />
       </dependentAssembly>
   </dependency>
+
+  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!--The ID below indicates application support for Windows Vista -->

--- a/src/main.c
+++ b/src/main.c
@@ -120,11 +120,7 @@ void set_macos_bundle_resources(lua_State *L);
 #endif
 
 int main(int argc, char **argv) {
-#ifdef _WIN32
-  HINSTANCE lib = LoadLibrary("user32.dll");
-  int (*SetProcessDPIAware)() = (void*) GetProcAddress(lib, "SetProcessDPIAware");
-  SetProcessDPIAware();
-#else
+#ifndef _WIN32
   signal(SIGPIPE, SIG_IGN);
 #endif
 


### PR DESCRIPTION
This is the recommended way by MS.

> Note  It is recommended that you set the process-default DPI awareness via application manifest, not an API call. See [Setting the default DPI awareness for a process](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/mt846517(v=vs.85)) for more information. Setting the process-default DPI awareness via API call can lead to unexpected application behavior.