### PR TITLE
Optimizing MSYS2 CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,8 @@ jobs:
           "LUA_SUBPROJECT_PATH=subprojects/lua-5.4.4" >> $env:GITHUB_ENV
       - name: Configure
         run: |
+          # Download the subprojects first so we can patch it before configuring.
+          # This avoids reconfiguring the subprojects when compiling.
           meson subprojects download
           Get-Content -Path resources/windows/001-lua-unicode.diff -Raw | patch -d $env:LUA_SUBPROJECT_PATH -p1 --forward
           meson setup --wrap-mode=forcefallback build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,8 +162,9 @@ jobs:
           "LUA_SUBPROJECT_PATH=subprojects/lua-5.4.4" >> $env:GITHUB_ENV
       - name: Configure
         run: |
-          meson setup --wrap-mode=forcefallback build
+          meson subprojects download
           Get-Content -Path resources/windows/001-lua-unicode.diff -Raw | patch -d $env:LUA_SUBPROJECT_PATH -p1 --forward
+          meson setup --wrap-mode=forcefallback build
       - name: Build
         run: meson install -C build --destdir="../lite-xl"
       - name: Package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,9 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        msystem: [MINGW32, MINGW64]
+        config:
+          - {msystem: MINGW32, arch: i686}
+          - {msystem: MINGW64, arch: x86_64}
     defaults:
       run:
         shell: msys2 {0}
@@ -103,12 +105,17 @@ jobs:
     - uses: actions/checkout@v2
     - uses: msys2/setup-msys2@v2
       with:
-        msystem: ${{ matrix.msystem }}
+        msystem: ${{ matrix.config.msystem }}
         update: true
         install: >-
           base-devel
           git
           zip
+          mingw-w64-${{ matrix.config.arch }}-gcc
+          mingw-w64-${{ matrix.config.arch }}-meson
+          mingw-w64-${{ matrix.config.arch }}-ninja
+          mingw-w64-${{ matrix.config.arch }}-ca-certificates
+          mingw-w64-${{ matrix.config.arch }}-ntldd
     - name: Set Environment Variables
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -119,6 +126,7 @@ jobs:
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-i686" >> "$GITHUB_ENV"
         fi
     - name: Install Dependencies
+      if: false
       run: bash scripts/install-dependencies.sh --debug
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,6 @@ jobs:
     - uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.config.msystem }}
-        update: true
         install: >-
           base-devel
           git

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -124,6 +124,16 @@ main() {
 
   rm -rf "${build_dir}"
 
+  if [[ $patch_lua == "true" ]] && [[ ! -z $force_fallback ]]; then
+    # download the subprojects so we can start patching before configure.
+    # this will prevent reconfiguring the project.
+    meson subprojects download
+    lua_subproject_path=$(echo subprojects/lua-*/)
+    if [[ -d $lua_subproject_path ]]; then
+      patch -d $lua_subproject_path -p1 --forward < resources/windows/001-lua-unicode.diff
+    fi
+  fi
+
   CFLAGS=$CFLAGS LDFLAGS=$LDFLAGS meson setup \
     --buildtype=$build_type \
     --prefix "$prefix" \
@@ -133,11 +143,6 @@ main() {
     $portable \
     $pgo \
     "${build_dir}"
-
-  lua_subproject_path=$(echo subprojects/lua-*/)
-  if [[ $patch_lua == "true" ]] && [[ ! -z $force_fallback ]] && [[ -d $lua_subproject_path ]]; then
-    patch -d $lua_subproject_path -p1 --forward < resources/windows/001-lua-unicode.diff
-  fi
 
   meson compile -C "${build_dir}"
 


### PR DESCRIPTION
This PR tries to reduce CI build times.

1. MSYS2 updates are not run. This usually isn't necessary.
2. Install MSYS2 packages in the setup phase. If you look at the workflow, MSYS2 packages installed when running in MSYS2 will not be cached since there is no post-build step.
3. Download the subprojects before patching. This prevents meson from reconfiguring the project due to file changes.