### PR TITLE
Make `system.path_compare` more case-aware

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1021,11 +1021,11 @@ static int f_load_native_plugin(lua_State *L) {
    order used in the TreeView view of the project's files. Returns true iff
    path1 < path2 in the TreeView order. */
 static int f_path_compare(lua_State *L) {
-  const char *path1 = luaL_checkstring(L, 1);
+  size_t len1, len2;
+  const char *path1 = luaL_checklstring(L, 1, &len1);
   const char *type1_s = luaL_checkstring(L, 2);
-  const char *path2 = luaL_checkstring(L, 3);
+  const char *path2 = luaL_checklstring(L, 3, &len2);
   const char *type2_s = luaL_checkstring(L, 4);
-  const int len1 = strlen(path1), len2 = strlen(path2);
   int type1 = strcmp(type1_s, "dir") != 0;
   int type2 = strcmp(type2_s, "dir") != 0;
   /* Find the index of the common part of the path. */


### PR DESCRIPTION
Before, strings like `README.md` would be sorted before `changelog.md`, because we only looked at the raw ascii values.
Now the character case is considered as a secondary sorting key.

Before:
![Schermata del 2023-04-05 10-11-57_2](https://user-images.githubusercontent.com/2798487/230023098-e6c97952-cb1d-4e16-88cf-c2c8888b504c.png)

After:
![Schermata del 2023-04-05 10-11-41_2](https://user-images.githubusercontent.com/2798487/230023119-0e97b77b-dd1c-4d12-adc0-0fcbe6c52463.png)