### PR TITLE
Build releases with Ubuntu 18.04 container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
     name: Linux
     needs: release
     runs-on: ubuntu-latest
+    container: ghcr.io/lite-xl/lite-xl-build-box:latest
     env:
       CC: gcc
       CXX: g++
@@ -66,6 +67,7 @@ jobs:
       - name: Update Packages
         run: sudo apt-get update
       - name: Install Dependencies
+        if: false
         run: |
           bash scripts/install-dependencies.sh --debug
           sudo apt-get install -y ccache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v3
       - name: Python Setup
+        if: false
         uses: actions/setup-python@v4
         with:
           python-version: 3.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Update Packages
+        if: false
         run: sudo apt-get update
       - name: Install Dependencies
         if: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,19 +60,26 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v3
+
+      # disabled because this will break our own Python install
       - name: Python Setup
         if: false
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
+
+      # disabled because the container has up-to-date packages
       - name: Update Packages
         if: false
         run: sudo apt-get update
+
+      # disabled if the dependencies are already installed
       - name: Install Dependencies
         if: false
         run: |
           bash scripts/install-dependencies.sh --debug
           sudo apt-get install -y ccache
+
       - name: Build Portable
         run: |
           bash --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     name: Linux
     needs: release
     runs-on: ubuntu-latest
-    container: ghcr.io/lite-xl/lite-xl-build-box:latest
+    container: ghcr.io/takase1121/lite-xl-build-box:latest
     env:
       CC: gcc
       CXX: g++

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         if: false
         run: sudo apt-get update
 
-      # disabled if the dependencies are already installed
+      # disabled as the dependencies are already installed
       - name: Install Dependencies
         if: false
         run: |

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -181,7 +181,7 @@ generate_appimage() {
     version="${version}-addons"
   fi
 
-  ./appimagetool LiteXL.AppDir LiteXL${version}-${ARCH}.AppImage
+  ./appimagetool --appimage-extract-and-run LiteXL.AppDir LiteXL${version}-${ARCH}.AppImage
 }
 
 setup_appimagetool


### PR DESCRIPTION
This PR will fix the release workflow by using a Ubuntu 18.04 container.
The container is available at https://github.com/lite-xl/lite-xl-build-box.

This workflow uses my fork because I cannot make our packages public.
If someone forks and wants to run a release they wouldn't be able to download the image.
