### PR TITLE
Merge carets after `doc:move-to-{previous,next}-char`

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -698,6 +698,7 @@ commands["doc:move-to-previous-char"] = function(dv)
       dv.doc:move_to_cursor(idx, translate.previous_char)
     end
   end
+  dv.doc:merge_cursors()
 end
 
 commands["doc:move-to-next-char"] = function(dv)
@@ -708,6 +709,7 @@ commands["doc:move-to-next-char"] = function(dv)
       dv.doc:move_to_cursor(idx, translate.next_char)
     end
   end
+  dv.doc:merge_cursors()
 end
 
 command.add("core.docview", commands)


### PR DESCRIPTION
Previously if we had multiple carets and we used `doc:move-to-{previous,next}-char` to go the the beginning/end of a document, the carets weren't merged correctly.