### PR TITLE
#1393 followup

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -62,10 +62,10 @@ local function cut_or_copy(delete)
   local text = ""
   core.cursor_clipboard = {}
   core.cursor_clipboard_whole_line = {}
-  for idx, line1, col1, line2, col2 in doc():get_selections() do
+  for idx, line1, col1, line2, col2 in doc():get_selections(true, true) do
     if line1 ~= line2 or col1 ~= col2 then
       text = doc():get_text(line1, col1, line2, col2)
-      full_text = full_text == "" and text or (full_text .. " " .. text)
+      full_text = full_text == "" and text or (text .. " " .. full_text)
       core.cursor_clipboard_whole_line[idx] = false
       if delete then
         doc():delete_to_cursor(idx, 0)
@@ -73,7 +73,7 @@ local function cut_or_copy(delete)
     else -- Cut/copy whole line
       -- Remove newline from the text. It will be added as needed on paste.
       text = string.sub(doc().lines[line1], 1, -2)
-      full_text = full_text == "" and text or (full_text .. text .. "\n")
+      full_text = full_text == "" and text or (text .. full_text .. "\n")
       core.cursor_clipboard_whole_line[idx] = true
       if delete then
         if line1 < #doc().lines then
@@ -84,6 +84,7 @@ local function cut_or_copy(delete)
           doc():remove(line1 - 1, math.huge, line1, math.huge)
         end
       end
+      doc():set_selections(idx, line1, col1, line2, col2)
     end
     core.cursor_clipboard[idx] = text
   end

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -73,7 +73,7 @@ local function cut_or_copy(delete)
     else -- Cut/copy whole line
       -- Remove newline from the text. It will be added as needed on paste.
       text = string.sub(doc().lines[line1], 1, -2)
-      full_text = full_text == "" and text or (text .. "\n" .. full_text)
+      full_text = full_text == "" and text .. "\n" or (text .. "\n" .. full_text)
       core.cursor_clipboard_whole_line[idx] = true
       if delete then
         if line1 < #doc().lines then

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -73,7 +73,7 @@ local function cut_or_copy(delete)
     else -- Cut/copy whole line
       -- Remove newline from the text. It will be added as needed on paste.
       text = string.sub(doc().lines[line1], 1, -2)
-      full_text = full_text == "" and text or (text .. full_text .. "\n")
+      full_text = full_text == "" and text or (text .. "\n" .. full_text)
       core.cursor_clipboard_whole_line[idx] = true
       if delete then
         if line1 < #doc().lines then
@@ -83,11 +83,12 @@ local function cut_or_copy(delete)
         else
           doc():remove(line1 - 1, math.huge, line1, math.huge)
         end
+        doc():set_selections(idx, line1, col1, line2, col2)
       end
-      doc():set_selections(idx, line1, col1, line2, col2)
     end
     core.cursor_clipboard[idx] = text
   end
+  if delete then doc():merge_cursors() end
   core.cursor_clipboard["full"] = full_text
   system.set_clipboard(full_text)
 end

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -453,7 +453,7 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
       end
     end
 
-    if cline2 > line1 or (cline2 == line2 and ccol2 > col1) then
+    if cline2 > line1 or (cline2 == line1 and ccol2 > col1) then
       if cline2 > line2 then
         l2 = l2 - line_removal
       else


### PR DESCRIPTION
* fix incorrect check in `doc:remove` sometimes resulting in incorrect selections
* restore old behavior of leaving cursors in their original position when using the command `doc:cut`