### PR TITLE
Use proper timeouts for coroutines that don't need to wait

### DIFF
--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -48,7 +48,7 @@ function Highlighter:start()
         self:update_notify(retokenized_from, max - retokenized_from)
       end
       core.redraw = true
-      coroutine.yield()
+      coroutine.yield(0)
     end
     self.max_wanted_line = 0
     self.running = false

--- a/data/plugins/projectsearch.lua
+++ b/data/plugins/projectsearch.lua
@@ -37,7 +37,7 @@ local function find_all_matches_in_file(t, filename, fn)
       table.insert(t, { file = filename, text = (start_index > 1 and "..." or "") .. line:sub(start_index, 256 + start_index), line = n, col = s })
       core.redraw = true
     end
-    if n % 100 == 0 then coroutine.yield() end
+    if n % 100 == 0 then coroutine.yield(0) end
     n = n + 1
     core.redraw = true
   end


### PR DESCRIPTION
There are a couple of `coroutine.yield`s in `autocomplete` too, but I don't know if that one should go as fast as possible.