### PR TITLE
Reduce default coroutine timeout

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1406,7 +1406,7 @@ local run_threads = coroutine.wrap(function()
             core.threads[k] = nil
           end
         else
-          wait = wait or (1/30)
+          wait = wait or (1/400)
           thread.wake = system.get_time() + wait
           minimal_time_to_wake = math.min(minimal_time_to_wake, wait)
         end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1406,7 +1406,7 @@ local run_threads = coroutine.wrap(function()
             core.threads[k] = nil
           end
         else
-          wait = wait or (1/400)
+          wait = wait or 0.001
           thread.wake = system.get_time() + wait
           minimal_time_to_wake = math.min(minimal_time_to_wake, wait)
         end


### PR DESCRIPTION
The new value allows for better responsiveness when a coroutine doesn't defines a timeout on yield as in the case of lsp plugin and other unknown existing code in the wild.

Preview of current `1/30`  timeout with lsp plugin which makes it almost unusable:

![current-wait-time](https://user-images.githubusercontent.com/1702572/231230835-e09a1386-d6b3-41b5-86e7-4e069e3e98a8.gif)

Preview of smaller `1/400` timeout:

![lower-wait-time](https://user-images.githubusercontent.com/1702572/231231100-551c047f-c52d-4ab1-968c-304050018ff1.gif)

For reference the issue began with the coroutines timing fix from #1381 and the commit https://github.com/lite-xl/lite-xl/commit/e8c317494a24db068fde9cd6d0a29d447e3d11b8 introduced a default non zero timeout value as originally suggested to prevent the editor getting blocked but as shown on the previews above it is too long causing lagged response times.

Related to #1467