### PR TITLE
Make `Doc:sanitize_position` return a more appropriate `col`

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -276,9 +276,13 @@ end
 -- End of cursor seciton.
 
 function Doc:sanitize_position(line, col)
-  line = common.clamp(line, 1, #self.lines)
-  col = common.clamp(col, 1, #self.lines[line])
-  return line, col
+  local nlines = #self.lines
+  if line > nlines then
+    return nlines, #self.lines[nlines]
+  elseif line < 1 then
+    return 1, 1
+  end
+  return line, common.clamp(col, 1, #self.lines[line])
 end
 
 


### PR DESCRIPTION
If `line` is out of range, return the `col` "closest" to the original values.

This should be tested to check if it impacts unexpected things.

Needed for #761.