### PR TITLE
feat(renderer): draw bigger rectangles for missing glyph

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -193,7 +193,7 @@ static RenFont* font_group_get_glyph(GlyphSet** set, GlyphMetric** metric, RenFo
   for (int i = 0; i < FONT_FALLBACK_MAX && fonts[i]; ++i) {
     *set = font_get_glyphset(fonts[i], codepoint, bitmap_index);
     *metric = &(*set)->metrics[codepoint % 256];
-    if ((*metric)->loaded || codepoint < 0xFF)
+    if ((*metric)->loaded)
       return fonts[i];
   }
   if (*metric && !(*metric)->loaded && codepoint > 0xFF && codepoint != 0x25A1)

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -278,6 +278,9 @@ static inline bool font_get_whitespace_width(RenFont *font, uint32_t codepoint, 
     case '\v':
     case '\f':
     case '\r':
+    case 0x200C: // zero-width non-joiner
+    case 0x200D: // zero-width joiner
+    case 0x2060: // word joiner
       *xadvance = 0.0f;
       return true;
     case 0x2000:


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/20792268/233249166-f9d44655-680a-486c-9670-a26754995539.png)

After:
![image](https://user-images.githubusercontent.com/20792268/233249259-37aa328b-8138-4854-86c4-734141da68b5.png)
