### PR TITLE
feat(process): allow commands and envs on proces_start

### DIFF
--- a/src/api/process.c
+++ b/src/api/process.c
@@ -547,11 +547,11 @@ static int process_env_add(process_env_t *env_list, size_t *env_len, const char 
   var_len += r;
   return process_env_add_variable(env_list, env_len, env_var, var_len);
 #else
-  *env_list[*env_len] = xstrdup(key);
-  if (!*env_list[*env_len])
+  (*env_list)[*env_len] = xstrdup(key);
+  if (!(*env_list)[*env_len])
     return ENOMEM;
-  *env_list[*env_len + 1] = xstrdup(value);
-  if (!*env_list[*env_len + 1])
+  (*env_list)[*env_len + 1] = xstrdup(value);
+  if (!(*env_list)[*env_len + 1])
     return ENOMEM;
   *env_len += 2;
 #endif
@@ -560,10 +560,11 @@ static int process_env_add(process_env_t *env_list, size_t *env_len, const char 
 
 
 static void process_env_free(process_env_t *list) {
+  if (!*list) return;
 #ifdef _WIN32
   free(*list);
 #else
-  for (size_t i = 0; *list[i]; i++) free(*list[i]);
+  for (size_t i = 0; (*list)[i]; i++) free((*list)[i]);
   free(*list);
 #endif
   *list = NULL;

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -574,8 +574,8 @@ static void process_env_free(process_env_t *list) {
 static int process_start(lua_State* L) {
   int r, retval = 1;
   size_t env_len = 0, cmd_len = 0, arglist_len = 0, env_vars_len = 0;
-  process_arglist_t arglist;
-  process_env_t env_vars;
+  process_arglist_t arglist = NULL;
+  process_env_t env_vars = NULL;
   const char *cwd = NULL;
   bool detach = false, escape = true;
   int deadline = 10, new_fds[3] = { STDIN_FD, STDOUT_FD, STDERR_FD };

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -574,7 +574,7 @@ static void process_env_free(process_env_t *list) {
 static int process_start(lua_State* L) {
   int r, retval = 1;
   size_t env_len = 0, cmd_len = 0, arglist_len = 0, env_vars_len = 0;
-  process_arglist_t arglist = NULL;
+  process_arglist_t arglist;
   process_env_t env_vars = NULL;
   const char *cwd = NULL;
   bool detach = false, escape = true;

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -526,6 +526,7 @@ static int process_env_add_system(process_env_t *env_list, size_t *env_list_len)
       goto cleanup;
     proc_env_block_p += proc_env_len + 1;
   }
+  retval = 0;
 
 cleanup:
   if (proc_env_block) FreeEnvironmentStringsW(proc_env_block);

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -50,6 +50,12 @@ typedef char **process_arglist_t;
 
 #endif
 
+#ifdef __GNUC__
+#define UNUSED __attribute__((__unused__))
+#else
+#define UNUSED
+#endif
+
 typedef struct {
   bool running, detached;
   int returncode, deadline;
@@ -342,7 +348,7 @@ static bool signal_process(process_t* proc, signal_e sig) {
 }
 
 
-static char *xstrdup(const char *str) {
+static UNUSED char *xstrdup(const char *str) {
   char *result = str ? malloc(strlen(str) + 1) : NULL;
   if (result) strcpy(result, str);
   return result;

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -786,7 +786,7 @@ static int process_start(lua_State* L) {
         close(self->child_pipes[stream][stream == STDIN_FD ? 1 : 0]);
       }
       size_t set;
-      for (set = 0; set < env_vars_len && setenv(env_vars[set], env_vars[set+1], 1); set += 2);
+      for (set = 0; set < env_vars_len && setenv(env_vars[set], env_vars[set+1], 1) == 0; set += 2);
       if (set == env_vars_len && (!detach || setsid() != -1) && (!cwd || chdir(cwd) != -1))
         execvp(arglist[0], (char** const)arglist);
       write(control_pipe[1], &errno, sizeof(errno));

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -418,8 +418,8 @@ static int process_arglist_add(process_arglist_t *list, size_t *list_len, const 
     cmdline[len++] = L'\0';
   }
 #else
-  const char **cmd = *list;
-  cmd[len] = xstrdup(cmd);
+  char **cmd = *list;
+  cmd[len] = xstrdup(arg);
   if (!cmd[len]) return ENOMEM;
   len++;
 #endif


### PR DESCRIPTION
This would allow something like this:

```lua
local cmd = { "bash", "-c", "echo $#", "--" }
for i = 1, 1000 do
  table.insert(cmd, "wow" .. i)
end
process.start(cmd, { stdout = process.REDIRECT_PARENT })
```
To run correctly.