### PR TITLE
Added in double-clicking on emptyview and tab bar.

### DIFF
--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -179,9 +179,8 @@ command.add(function()
 
 -- double clicking the tab bar, or on the emptyview should open a new doc
 command.add(function(x, y)
-  if not x or not y then return false end
-  local node = core.root_view.root_node:get_child_overlapping_point(x, y)
-  return node and node:should_show_tabs() and node:is_in_tab_area(x, y)
+  local node = x and y and core.root_view.root_node:get_child_overlapping_point(x, y)
+  return node and node:is_in_tab_area(x, y)
 end, {
   ["tabbar:new-doc"] = function()
     command.perform("core:new-doc")

--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -179,17 +179,18 @@ command.add(function()
 
 -- double clicking the tab bar, or on the emptyview should open a new doc
 command.add(function(x, y)
-    local node = core.root_view.overlapping_node
-    if not node or not node:should_show_tabs() then return false end
-    local _, y, w, h, scroll_padding = node:get_scroll_button_rect(1)
-    return ((not node.hovered_tab and node.hovered_scroll_button == 0) and y < h)
+  if not x or not y then return false end
+  local node = core.root_view.root_node:get_child_overlapping_point(x, y)
+  if not node or not node:should_show_tabs() then return false end
+  local _, ty, _, th, scroll_padding = node:get_scroll_button_rect(1)
+  return ((not node.hovered_tab and node.hovered_scroll_button == 0) and y >= ty and y < ty + th)
 end, {
-  ["root:new-doc"] = function() 
+  ["root:new-doc"] = function()
     command.perform("core:new-doc")
   end
 })
 command.add("core.emptyview", {
-  ["emptyview:new-doc"] = function() 
+  ["emptyview:new-doc"] = function()
     command.perform("core:new-doc")
   end
 })

--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -185,7 +185,7 @@ command.add(function(x, y)
   local _, ty, _, th, scroll_padding = node:get_scroll_button_rect(1)
   return ((not node.hovered_tab and node.hovered_scroll_button == 0) and y >= ty and y < ty + th)
 end, {
-  ["root:new-doc"] = function()
+  ["tabbar:new-doc"] = function()
     command.perform("core:new-doc")
   end
 })

--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -181,9 +181,7 @@ command.add(function()
 command.add(function(x, y)
   if not x or not y then return false end
   local node = core.root_view.root_node:get_child_overlapping_point(x, y)
-  if not node or not node:should_show_tabs() then return false end
-  local _, ty, _, th, scroll_padding = node:get_scroll_button_rect(1)
-  return ((not node.hovered_tab and node.hovered_scroll_button == 0) and y >= ty and y < ty + th)
+  return node and node:should_show_tabs() and node:is_in_tab_area(x, y)
 end, {
   ["tabbar:new-doc"] = function()
     command.perform("core:new-doc")

--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -176,3 +176,20 @@ command.add(function()
     end
   }
 )
+
+-- double clicking the tab bar, or on the emptyview should open a new doc
+command.add(function(x, y)
+    local node = core.root_view.overlapping_node
+    if not node or not node:should_show_tabs() then return false end
+    local _, y, w, h, scroll_padding = node:get_scroll_button_rect(1)
+    return ((not node.hovered_tab and node.hovered_scroll_button == 0) and y < h)
+end, {
+  ["root:new-doc"] = function() 
+    command.perform("core:new-doc")
+  end
+})
+command.add("core.emptyview", {
+  ["emptyview:new-doc"] = function() 
+    command.perform("core:new-doc")
+  end
+})

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -369,7 +369,7 @@ keymap.add_direct {
   ["shift+1lclick"] = "doc:select-to-cursor",
   ["ctrl+1lclick"] = "doc:split-cursor",
   ["1lclick"] = "doc:set-cursor",
-  ["2lclick"] = "doc:set-cursor-word",
+  ["2lclick"] = { "doc:set-cursor-word", "emptyview:new-doc", "root:new-doc" },
   ["3lclick"] = "doc:set-cursor-line",
   ["shift+left"] = "doc:select-to-previous-char",
   ["shift+right"] = "doc:select-to-next-char",

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -369,7 +369,7 @@ keymap.add_direct {
   ["shift+1lclick"] = "doc:select-to-cursor",
   ["ctrl+1lclick"] = "doc:split-cursor",
   ["1lclick"] = "doc:set-cursor",
-  ["2lclick"] = { "doc:set-cursor-word", "emptyview:new-doc", "root:new-doc" },
+  ["2lclick"] = { "doc:set-cursor-word", "emptyview:new-doc", "tabbar:new-doc" },
   ["3lclick"] = "doc:set-cursor-line",
   ["shift+left"] = "doc:select-to-previous-char",
   ["shift+right"] = "doc:select-to-next-char",

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -615,6 +615,12 @@ function Node:is_empty()
 end
 
 
+function Node:is_in_tab_area(x, y)
+  local _, ty, _, th = self:get_scroll_button_rect(1)
+  return y >= ty and y < ty + th
+end
+
+
 function Node:close_all_docviews(keep_active)
   local node_active_view = self.active_view
   local lost_active_view = false

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -308,7 +308,7 @@ function Node:tab_hovered_update(px, py)
     if px >= cx and px < cx + cw and py >= y and py < y + h and config.tab_close_button then
       self.hovered_close = tab_index
     end
-  else
+  elseif #self.views > self:get_visible_tabs_number() then
     self.hovered_scroll_button = self:get_scroll_button_index(px, py) or 0
   end
 end

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -616,6 +616,7 @@ end
 
 
 function Node:is_in_tab_area(x, y)
+  if not self:should_show_tabs() then return false end
   local _, ty, _, th = self:get_scroll_button_rect(1)
   return y >= ty and y < ty + th
 end

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -294,17 +294,10 @@ function RootView:on_mouse_moved(x, y, dx, dy)
   if not self.overlapping_node then return end
 
   local div = self.root_node:get_divider_overlapping_point(x, y)
-  local ty, th
-  if self.overlapping_node:should_show_tabs() then
-    local tx, ny, tw, nh = self.overlapping_node:get_scroll_button_rect(1)
-    ty, th = ny, nh
-  end
-  if self.overlapping_node:get_scroll_button_index(x, y) then
+  if self.overlapping_node:get_scroll_button_index(x, y) or self.overlapping_node:is_in_tab_area(x, y) then
     core.request_cursor("arrow")
   elseif div and not self.overlapping_node.active_view:scrollbar_overlaps_point(x, y) then
     core.request_cursor(div.type == "hsplit" and "sizeh" or "sizev")
-  elseif th and ty and y > ty and y < (ty + th) then
-    core.request_cursor("arrow")
   else
     core.request_cursor(self.overlapping_node.active_view.cursor)
   end

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -291,20 +291,21 @@ function RootView:on_mouse_moved(x, y, dx, dy)
   if last_overlapping_node and last_overlapping_node ~= self.overlapping_node then
     last_overlapping_node:on_mouse_left()
   end
+  if not self.overlapping_node then return end
 
   local div = self.root_node:get_divider_overlapping_point(x, y)
   local ty, th
-  if self.overlapping_node and self.overlapping_node:should_show_tabs() then
+  if self.overlapping_node:should_show_tabs() then
     local tx, ny, tw, nh = self.overlapping_node:get_scroll_button_rect(1)
     ty, th = ny, nh
   end
-  if self.overlapping_node and self.overlapping_node:get_scroll_button_index(x, y) then
+  if self.overlapping_node:get_scroll_button_index(x, y) then
     core.request_cursor("arrow")
-  elseif div and (self.overlapping_node and not self.overlapping_node.active_view:scrollbar_overlaps_point(x, y)) then
+  elseif div and not self.overlapping_node.active_view:scrollbar_overlaps_point(x, y) then
     core.request_cursor(div.type == "hsplit" and "sizeh" or "sizev")
   elseif th and ty and y > ty and y < (ty + th) then
     core.request_cursor("arrow")
-  elseif self.overlapping_node then
+  else
     core.request_cursor(self.overlapping_node.active_view.cursor)
   end
 end

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -293,12 +293,16 @@ function RootView:on_mouse_moved(x, y, dx, dy)
   end
 
   local div = self.root_node:get_divider_overlapping_point(x, y)
-  local tab_height = self.overlapping_node and self.overlapping_node:should_show_tabs() and select(4, self.overlapping_node:get_scroll_button_rect(1))
+  local ty, th
+  if self.overlapping_node and self.overlapping_node:should_show_tabs() then
+    local tx, ny, tw, nh = self.overlapping_node:get_scroll_button_rect(1)
+    ty, th = ny, nh
+  end
   if self.overlapping_node and self.overlapping_node:get_scroll_button_index(x, y) then
     core.request_cursor("arrow")
   elseif div and (self.overlapping_node and not self.overlapping_node.active_view:scrollbar_overlaps_point(x, y)) then
     core.request_cursor(div.type == "hsplit" and "sizeh" or "sizev")
-  elseif tab_height and y < tab_height then
+  elseif th and ty and y > ty and y < (ty + th) then
     core.request_cursor("arrow")
   elseif self.overlapping_node then
     core.request_cursor(self.overlapping_node.active_view.cursor)

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -293,12 +293,12 @@ function RootView:on_mouse_moved(x, y, dx, dy)
   end
 
   local div = self.root_node:get_divider_overlapping_point(x, y)
-  local tab_index = self.overlapping_node and self.overlapping_node:get_tab_overlapping_point(x, y)
+  local tab_height = self.overlapping_node and self.overlapping_node:should_show_tabs() and select(4, self.overlapping_node:get_scroll_button_rect(1))
   if self.overlapping_node and self.overlapping_node:get_scroll_button_index(x, y) then
     core.request_cursor("arrow")
   elseif div and (self.overlapping_node and not self.overlapping_node.active_view:scrollbar_overlaps_point(x, y)) then
     core.request_cursor(div.type == "hsplit" and "sizeh" or "sizev")
-  elseif tab_index then
+  elseif tab_height and y < tab_height then
     core.request_cursor("arrow")
   elseif self.overlapping_node then
     core.request_cursor(self.overlapping_node.active_view.cursor)


### PR DESCRIPTION
As per the old PR #700 , adds these QOL changes from there. Things have changed a bit since then, so I think this is the last outstanding change that needs to be made for the PR to basically be functionally fully integrated in other ways. Should close #700 when merged.