### PR TITLE
Consistent error messages for Process API

### DIFF
--- a/src/api/process.c
+++ b/src/api/process.c
@@ -615,7 +615,7 @@ static int g_read(lua_State *L, int stream, size_t size) {
   if (!self->reading[overlapped_idx]) {
     if (!ReadFile(self->child_pipes[stream][0],
                   self->buffer[overlapped_idx],
-                  read_szie > READ_BUF_SIZE ? READ_BUF_SIZE : read_size,
+                  size> READ_BUF_SIZE ? READ_BUF_SIZE : size,
                   NULL,
                   &self->overlapped[overlapped_idx])
         && (err = GetLastError()) != ERROR_IO_PENDING) {


### PR DESCRIPTION
Error propagation in the Process API is inconsistent.
Some function throws errors while some returns them.

The goal here is to:
1. for argument checking (argument type, argument value, etc.), the function will throw an error. These types of errors are more programmer-oriented (fixable), so throwing an error would help.
2. for runtime errors (such as a system call failing), return the error. This would allow us to return the errno and potentially make the error easier to diagnose.

There are also performance consideration as well, since catching errors in Lua require the use of pcall, which can degrade performance if done in a loop.

tl,dr; **if the arguments seem right, then the function shouldn't throw**.

Might depend on #1477 .