### PR TITLE
Add mouse grab

### DIFF
--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -104,7 +104,7 @@ end, t)
 
 command.add(nil, {
   ["root:scroll"] = function(delta)
-    local view = (core.root_view.overlapping_node and core.root_view.overlapping_node.active_view) or core.active_view
+    local view = core.root_view.overlapping_view or core.active_view
     if view and view.scrollable then
       view.scroll.to.y = view.scroll.to.y + delta * -config.mouse_wheel_scroll
       return true
@@ -112,7 +112,7 @@ command.add(nil, {
     return false
   end,
   ["root:horizontal-scroll"] = function(delta)
-    local view = (core.root_view.overlapping_node and core.root_view.overlapping_node.active_view) or core.active_view
+    local view = core.root_view.overlapping_view or core.active_view
     if view and view.scrollable then
       view.scroll.to.x = view.scroll.to.x + delta * -config.mouse_wheel_scroll
       return true
@@ -154,7 +154,7 @@ command.add(function(node)
 )
 
 command.add(function()
-    local node = core.root_view.overlapping_node
+    local node = core.root_view.root_node:get_child_overlapping_point(core.root_view.mouse.x, core.root_view.mouse.y)
     if not node then return false end
     return (node.hovered_tab or node.hovered_scroll_button > 0) and true, node
   end,

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1490,4 +1490,15 @@ function core.on_error(err)
 end
 
 
+local alerted_deprecations = {}
+---Show deprecation notice once per `kind`.
+---
+---@param kind string
+function core.deprecation_log(kind)
+  if alerted_deprecations[kind] then return end
+  alerted_deprecations[kind] = true
+  core.warn("Used deprecated functionality [%s]. Check if your plugins are up to date.", kind)
+end
+
+
 return core

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -34,9 +34,8 @@ end
 
 ---@deprecated
 function Node:on_mouse_moved(x, y, ...)
-  assert(false)
+  core.deprecation_log("Node:on_mouse_moved")
   if self.type == "leaf" then
-    self.hovered.x, self.hovered.y = x, y
     self.active_view:on_mouse_moved(x, y, ...)
   else
     self:propagate("on_mouse_moved", x, y, ...)
@@ -46,7 +45,7 @@ end
 
 ---@deprecated
 function Node:on_mouse_released(...)
-  assert(false)
+  core.deprecation_log("Node:on_mouse_released")
   if self.type == "leaf" then
     self.active_view:on_mouse_released(...)
   else
@@ -57,7 +56,7 @@ end
 
 ---@deprecated
 function Node:on_mouse_left()
-  assert(false)
+  core.deprecation_log("Node:on_mouse_left")
   if self.type == "leaf" then
     self.active_view:on_mouse_left()
   else
@@ -65,13 +64,17 @@ function Node:on_mouse_left()
   end
 end
 
+
+---@deprecated
 function Node:on_touch_moved(...)
+  core.deprecation_log("Node:on_touch_moved")
   if self.type == "leaf" then
     self.active_view:on_touch_moved(...)
   else
     self:propagate("on_touch_moved", ...)
   end
 end
+
 
 function Node:consume(node)
   for k, _ in pairs(self) do self[k] = nil end

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -18,7 +18,6 @@ function Node:new(type)
   if self.type == "leaf" then
     self:add_view(EmptyView())
   end
-  self.hovered = {x = -1, y = -1 }
   self.hovered_close = 0
   self.tab_shift = 0
   self.tab_offset = 1
@@ -33,7 +32,9 @@ function Node:propagate(fn, ...)
 end
 
 
+---@deprecated
 function Node:on_mouse_moved(x, y, ...)
+  assert(false)
   if self.type == "leaf" then
     self.hovered.x, self.hovered.y = x, y
     self.active_view:on_mouse_moved(x, y, ...)
@@ -43,7 +44,9 @@ function Node:on_mouse_moved(x, y, ...)
 end
 
 
+---@deprecated
 function Node:on_mouse_released(...)
+  assert(false)
   if self.type == "leaf" then
     self.active_view:on_mouse_released(...)
   else
@@ -52,7 +55,9 @@ function Node:on_mouse_released(...)
 end
 
 
+---@deprecated
 function Node:on_mouse_left()
+  assert(false)
   if self.type == "leaf" then
     self.active_view:on_mouse_left()
   else
@@ -489,7 +494,7 @@ function Node:update()
     for _, view in ipairs(self.views) do
       view:update()
     end
-    self:tab_hovered_update(self.hovered.x, self.hovered.y)
+    self:tab_hovered_update(core.root_view.mouse.x, core.root_view.mouse.y)
     local tab_width = self:target_tab_width()
     self:move_towards("tab_shift", tab_width * (self.tab_offset - 1), nil, "tabs")
     self:move_towards("tab_width", tab_width, nil, "tabs")

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -989,6 +989,12 @@ function StatusView:on_mouse_pressed(button, x, y, clicks)
 end
 
 
+function StatusView:on_mouse_left()
+  StatusView.super.on_mouse_left(self)
+  self.hovered_item = {}
+end
+
+
 function StatusView:on_mouse_moved(x, y, dx, dy)
   if not self.visible then return end
   StatusView.super.on_mouse_moved(self, x, y, dx, dy)

--- a/data/core/titleview.lua
+++ b/data/core/titleview.lua
@@ -112,6 +112,12 @@ function TitleView:on_mouse_pressed(button, x, y, clicks)
 end
 
 
+function TitleView:on_mouse_left()
+  TitleView.super.on_mouse_left(self)
+  self.hovered_item = nil
+end
+
+
 function TitleView:on_mouse_moved(px, py, ...)
   if self.size.y == 0 then return end
   TitleView.super.on_mouse_moved(self, px, py, ...)

--- a/data/plugins/toolbarview.lua
+++ b/data/plugins/toolbarview.lua
@@ -100,6 +100,16 @@ function ToolbarView:on_mouse_pressed(button, x, y, clicks)
 end
 
 
+function ToolbarView:on_mouse_left()
+  ToolbarView.super.on_mouse_left(self)
+  if self.tooltip then
+    core.status_view:remove_tooltip()
+    self.tooltip = false
+  end
+  self.hovered_item = nil
+end
+
+
 function ToolbarView:on_mouse_moved(px, py, ...)
   if not self.visible then return end
   ToolbarView.super.on_mouse_moved(self, px, py, ...)

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -51,7 +51,7 @@ function TreeView:new()
   self.target_size = config.plugins.treeview.size
   self.cache = {}
   self.tooltip = { x = 0, y = 0, begin = 0, alpha = 0 }
-  self.cursor_pos = { x = 0, y = 0 }
+  self.last_scroll_y = 0
 
   self.item_icon_width = 0
   self.item_text_spacing = 0
@@ -251,10 +251,9 @@ function TreeView:get_text_bounding_box(item, x, y, w, h)
 end
 
 
+
 function TreeView:on_mouse_moved(px, py, ...)
   if not self.visible then return end
-  self.cursor_pos.x = px
-  self.cursor_pos.y = py
   if TreeView.super.on_mouse_moved(self, px, py, ...) then
     -- mouse movement handled by the View (scrollbar)
     self.hovered_item = nil
@@ -310,10 +309,10 @@ function TreeView:update()
   self.item_text_spacing = style.icon_font:get_width("f") / 2
 
   -- this will make sure hovered_item is updated
-  -- we don't want events when the thing is scrolling fast
-  local dy = math.abs(self.scroll.to.y - self.scroll.y)
-  if self.scroll.to.y ~= 0 and dy < self:get_item_height() then
-    self:on_mouse_moved(self.cursor_pos.x, self.cursor_pos.y, 0, 0)
+  local dy = math.abs(self.last_scroll_y - self.scroll.y)
+  if dy > 0 then
+    self:on_mouse_moved(core.root_view.mouse.x, core.root_view.mouse.y, 0, 0)
+    self.last_scroll_y = self.scroll.y
   end
 
   local config = config.plugins.treeview
@@ -757,7 +756,7 @@ command.add(
 
   ["treeview-context:show"] = function()
     if view.hovered_item then
-      menu:show(view.cursor_pos.x, view.cursor_pos.y)
+      menu:show(core.root_view.mouse.x, core.root_view.mouse.y)
       return
     end
 

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -281,6 +281,12 @@ function TreeView:on_mouse_moved(px, py, ...)
 end
 
 
+function TreeView:on_mouse_left()
+  TreeView.super.on_mouse_left(self)
+  self.hovered_item = nil
+end
+
+
 function TreeView:update()
   -- update width
   local dest = self.visible and self.target_size or 0


### PR DESCRIPTION
We now also send mouse movement events only to the interested view.

Suggestions are welcome for better names for `RootView:grab_mouse` and `RootView:release_mouse_grab`.

This PR is not ready, as it needs testing and the implementation for touch.