### PR TITLE
Better TitleView buttons

### DIFF
--- a/data/core/titleview.lua
+++ b/data/core/titleview.lua
@@ -12,17 +12,29 @@ local icon_colors = {
 };
 
 local restore_command = {
-  symbol = "w", action = function() system.set_window_mode("normal") end
+  symbol = "w",
+  accent = style.accent,
+  action = function() system.set_window_mode("normal") end
 }
 
 local maximize_command = {
-  symbol = "W", action = function() system.set_window_mode("maximized") end
+  symbol = "W",
+  accent = style.accent,
+  action = function() system.set_window_mode("maximized") end
 }
 
 local title_commands = {
-  {symbol = "_", action = function() system.set_window_mode("minimized") end},
+  {
+    symbol = "_",
+    accent = style.accent,
+    action = function() system.set_window_mode("minimized") end
+  },
   maximize_command,
-  {symbol = "X", action = function() core.quit() end},
+  {
+    symbol = "X",
+    accent = style.error,
+    action = function() core.quit() end
+  },
 }
 
 ---@class core.titleview : core.view

--- a/data/core/titleview.lua
+++ b/data/core/titleview.lua
@@ -133,10 +133,7 @@ function TitleView:on_mouse_moved(px, py, ...)
   if self.size.y == 0 then return end
   TitleView.super.on_mouse_moved(self, px, py, ...)
   self.hovered_item = nil
-  local x_min, x_max, y_min, y_max = self.size.x, 0, self.size.y, 0
   for item, x, y, w, h in self:each_control_item() do
-    x_min, x_max = math.min(x, x_min), math.max(x + w, x_max)
-    y_min, y_max = y, y + h
     if px > x and py > y and px <= x + w and py <= y + h then
       self.hovered_item = item
       return

--- a/data/core/titleview.lua
+++ b/data/core/titleview.lua
@@ -45,6 +45,10 @@ local function title_view_height()
   return style.font:get_height() + style.padding.y * 2
 end
 
+local function button_width()
+  return style.icon_font:get_width("_") * 3.2;
+end
+
 function TitleView:new()
   TitleView.super.new(self)
   self.visible = true
@@ -53,10 +57,10 @@ end
 function TitleView:configure_hit_test(borderless)
   if borderless then
     local title_height = title_view_height()
-    local icon_w = style.icon_font:get_width("_")
-    local icon_spacing = icon_w
-    local controls_width = (icon_w + icon_spacing) * #title_commands + icon_spacing
-    system.set_window_hit_test(title_height, controls_width, icon_spacing)
+    local button_w = button_width()
+    local resize_border = style.icon_font:get_width("_")
+    local controls_width = button_w * #title_commands + resize_border
+    system.set_window_hit_test(title_height, controls_width, resize_border)
     -- core.hit_test_title_height = title_height
   else
     system.set_window_hit_test()
@@ -89,17 +93,15 @@ function TitleView:draw_window_title()
 end
 
 function TitleView:each_control_item()
-  local icon_h, icon_w = style.icon_font:get_height(), style.icon_font:get_width("_")
-  local icon_spacing = icon_w
+  local button_h, button_w = title_view_height(), button_width()
   local ox, oy = self:get_content_offset()
   ox = ox + self.size.x
   local i, n = 0, #title_commands
   local iter = function()
     i = i + 1
     if i <= n then
-      local dx = - (icon_w + icon_spacing) * (n - i + 1)
-      local dy = style.padding.y
-      return title_commands[i], ox + dx, oy + dy, icon_w, icon_h
+      local dx = button_w * (n - i  + 1)
+      return title_commands[i], ox - dx, oy, button_w, button_h
     end
   end
   return iter
@@ -108,8 +110,11 @@ end
 
 function TitleView:draw_window_controls()
   for item, x, y, w, h in self:each_control_item() do
-    local color = item == self.hovered_item and style.text or style.dim
-    common.draw_text(style.icon_font, color, item.symbol, nil, x, y, 0, h)
+    -- draw an accented background for a hovered item
+    if item  == self.hovered_item then
+      renderer.draw_rect(x, y, w, h, item.accent)
+    end
+    common.draw_text(style.icon_font, style.text, item.symbol, "center", x, y, w, h)
   end
 end
 

--- a/data/core/titleview.lua
+++ b/data/core/titleview.lua
@@ -13,26 +13,22 @@ local icon_colors = {
 
 local restore_command = {
   symbol = "w",
-  accent = style.accent,
   action = function() system.set_window_mode("normal") end
 }
 
 local maximize_command = {
   symbol = "W",
-  accent = style.accent,
   action = function() system.set_window_mode("maximized") end
 }
 
 local title_commands = {
   {
     symbol = "_",
-    accent = style.accent,
     action = function() system.set_window_mode("minimized") end
   },
   maximize_command,
   {
     symbol = "X",
-    accent = style.error,
     action = function() core.quit() end
   },
 }
@@ -112,7 +108,7 @@ function TitleView:draw_window_controls()
   for item, x, y, w, h in self:each_control_item() do
     -- draw an accented background for a hovered item
     if item  == self.hovered_item then
-      renderer.draw_rect(x, y, w, h, item.accent)
+      renderer.draw_rect(x, y, w, h, style.dim)
     end
     common.draw_text(style.icon_font, style.text, item.symbol, "center", x, y, w, h)
   end


### PR DESCRIPTION
This PR changes the icons in TitleView. The current TitleView buttons are horrendous - they require pinpoint precision to click and it is hard to tell if the button is hovered.

This PR introduces Windows-style buttons - large hitboxes and the button background is highlighted instead of the icons themselves. The color is a bit off on default theme (because style.dim is absolutely blinding) but it is still acceptable.

I'm aware that other theme (Adwaita, Breeze) has smaller buttons, but the "clickable" region is clearly highlighted when the cursor hovers over it. Not only that, their hitboxes are circular, so it looks larger than the icons and seems more intuitive.

Before:
![image](https://github.com/lite-xl/lite-xl/assets/20792268/0f189807-95fb-4668-a6a5-1f6f3f7450cf)

**UPDATED**:
After:
![image](https://github.com/lite-xl/lite-xl/assets/20792268/adcf1425-1063-4a17-9306-8dea62b4da3b)

Adwaita:
![image](https://github.com/lite-xl/lite-xl/assets/20792268/e749069e-a43f-45de-93b9-5096a4effac7)

QT (Adwaita, bad because button is only highlighted when clicked):
![image](https://github.com/lite-xl/lite-xl/assets/20792268/06ca4cb5-6b69-4563-9889-3205743cfa8f)

Breeze:
![image](https://github.com/lite-xl/lite-xl/assets/20792268/ce4aa7b9-ed8b-40ac-a3f9-d48edc1f52f2)

Windows 11:
![image](https://github.com/lite-xl/lite-xl/assets/20792268/f63f0aae-37d4-441c-b55e-91baa994daff)

Windows 8:
![image](https://github.com/lite-xl/lite-xl/assets/20792268/4259a990-cf53-4129-863e-baac8bfaf659)

Chrome (Firefox looks similar but wider buttons):
![image](https://github.com/lite-xl/lite-xl/assets/20792268/e41e9b45-6400-4a84-b8f0-aa3ad0c3d7cf)

