### PR TITLE
Autocomplete plugin improvements

### DIFF
--- a/data/plugins/autocomplete.lua
+++ b/data/plugins/autocomplete.lua
@@ -507,8 +507,12 @@ local function draw_suggestions_box(av)
       if icon and autocomplete.icons[icon] then
         local ifont = autocomplete.icons[icon].font
         local itext = autocomplete.icons[icon].char
-        local icolor = (i == suggestions_idx) and style.accent
-          or style.syntax[autocomplete.icons[icon].color]
+        local icolor = autocomplete.icons[icon].color
+        if i == suggestions_idx then
+          icolor = style.accent
+        elseif type(icolor) == "string" then
+          icolor = style.syntax[icolor]
+        end
         if config.plugins.autocomplete.icon_position == "left" then
           common.draw_text(
             ifont, icolor, itext, "left", rx + style.padding.x, y, rw, lh
@@ -698,8 +702,13 @@ end
 ---@param name string
 ---@param character string
 ---@param font? renderer.font
----@param color? string One of the color names from style.syntax
+---@param color? string | renderer.color A style.syntax[] name or specific color
 function autocomplete.add_icon(name, character, font, color)
+  local color_type = type(color)
+  assert(
+    not color or color_type == "table" or color_type == "string",
+    "invalid icon color given"
+  )
   autocomplete.icons[name] = {
     char = character,
     font = font or style.code_font,

--- a/data/plugins/autocomplete.lua
+++ b/data/plugins/autocomplete.lua
@@ -493,7 +493,6 @@ local function draw_suggestions_box(av)
   local show_count = #suggestions <= ah and #suggestions or ah
   local start_index = suggestions_idx > ah and (suggestions_idx-(ah-1)) or 1
   local hide_info = config.plugins.autocomplete.hide_info
-  local hide_icons = config.plugins.autocomplete.hide_icons
 
   for i=start_index, start_index+show_count-1, 1 do
     if not suggestions[i] then
@@ -503,7 +502,7 @@ local function draw_suggestions_box(av)
 
     local icon_l_padding, icon_r_padding = 0, 0
 
-    if not hide_icons and has_icons then
+    if has_icons then
       local icon = s.icon or s.info
       if icon and autocomplete.icons[icon] then
         local ifont = autocomplete.icons[icon].font

--- a/data/plugins/autocomplete.lua
+++ b/data/plugins/autocomplete.lua
@@ -706,7 +706,8 @@ end
 function autocomplete.add_icon(name, character, font, color)
   local color_type = type(color)
   assert(
-    not color or color_type == "table" or color_type == "string",
+    not color or color_type == "table"
+      or (color_type == "string" and style.syntax[color]),
     "invalid icon color given"
   )
   autocomplete.icons[name] = {


### PR DESCRIPTION
* Support suggestion symbols scoping
  - global: all open documents
  - local: current document
  - related: all open documents with same syntax
  - none: language syntax symbols only
* Register style.syntax[] entries as icons
* Other related fixes

![autocomplete-scope](https://github.com/lite-xl/lite-xl/assets/1702572/3e6dee80-93ec-439a-8c30-3a8306b074ff)

![autocomplete-symbols](https://github.com/lite-xl/lite-xl/assets/1702572/b32213ae-f31a-4132-bf36-1e3e93e2f6ef)

Depends on #1515