### PR TITLE
Rendering bitmap fonts + certain emojis

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -220,7 +220,7 @@ static void font_load_glyphset(RenFont* font, int idx) {
 
     // scale blit on a 8bpp bitmap is impossible in SDL2. This probably because of SIMD.
     if (font->bitmap_scale != 1.0f)
-      bits_per_pixel = 24;
+      bits_per_pixel = max(bits_per_pixel, 24);
 
     set->surface = check_alloc(SDL_CreateRGBSurface(0,
                                                     pen_x / font->bitmap_scale, font->max_height / font->bitmap_scale,

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -290,7 +290,7 @@ static void font_load_glyphset(RenFont* font, int idx) {
       } else {
         // copy the pixels over for custom blending later
         for (unsigned int line = 0; line < slot->bitmap.rows; ++line) {
-          int target_offset = line * set->surface->pitch + set->metrics[i].x0 * set->surface->format->BytesPerPixel;
+          int target_offset = line * set->surface->pitch + set->metrics[i].x0 * bytes_per_pixel;
           int source_offset = line * slot->bitmap.pitch;
 
           if (slot->bitmap.pixel_mode == FT_PIXEL_MODE_LCD) {
@@ -302,12 +302,12 @@ static void font_load_glyphset(RenFont* font, int idx) {
               int current_source_offset = source_offset + (column / 8);
               int source_pixel = slot->bitmap.buffer[current_source_offset];
 
-              memset(pixels + target_offset, ((source_pixel >> (7 - (column % 8))) & 0x1) * 255, set->surface->format->BytesPerPixel);
-              target_offset += set->surface->format->BytesPerPixel;
+              memset(pixels + target_offset, ((source_pixel >> (7 - (column % 8))) & 0x1) * 255, bytes_per_pixel);
+              target_offset += bytes_per_pixel;
             }
           } else {
             // copy the entire row at correct bpp
-            memcpy(&pixels[target_offset], &slot->bitmap.buffer[source_offset], slot->bitmap.width * set->surface->format->BytesPerPixel);
+            memcpy(&pixels[target_offset], &slot->bitmap.buffer[source_offset], slot->bitmap.width * bytes_per_pixel);
           }
         }
       }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -223,7 +223,7 @@ static void font_load_glyphset(RenFont* font, int idx) {
       bits_per_pixel = max(bits_per_pixel, 24);
 
     set->surface = check_alloc(SDL_CreateRGBSurface(0,
-                                                    pen_x / font->bitmap_scale, font->max_height / font->bitmap_scale,
+                                                    pen_x, font->max_height,
                                                     bits_per_pixel,
                                                     0, 0, 0, 0));
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -113,7 +113,7 @@ static int font_get_load_options(RenFont* font) {
 
   hinting = font->hinting == FONT_HINTING_NONE ? FT_LOAD_NO_HINTING : FT_LOAD_FORCE_AUTOHINT;
 
-  return load_target | hinting;
+  return load_target | hinting | FT_LOAD_COLOR;
 }
 
 static int font_set_render_options(RenFont* font) {

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -28,13 +28,17 @@ static FT_Library library;
 // draw_rect_surface is used as a 1x1 surface to simplify ren_draw_rect with blending
 static SDL_Surface *draw_rect_surface;
 
-static void* check_alloc(void *ptr) {
+static void* __check_alloc(void *ptr, const char *src) {
   if (!ptr) {
-    fprintf(stderr, "Fatal error: memory allocation failed\n");
+    fprintf(stderr, "Fatal error (%s): memory allocation failed\n", src);
     exit(EXIT_FAILURE);
   }
   return ptr;
 }
+
+#define stringize(x) stringize2(x)
+#define stringize2(x) #x
+#define check_alloc(ptr) __check_alloc(ptr, __FILE__ ":" stringize(__LINE__))
 
 /************************* Fonts *************************/
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -250,7 +250,11 @@ static void font_load_glyphset(RenFont* font, int idx) {
         switch (slot->bitmap.pixel_mode) {
           case FT_PIXEL_MODE_MONO: pixel_mode = SDL_PIXELFORMAT_INDEX1MSB; bits_per_pixel = 1; break;
           case FT_PIXEL_MODE_GRAY: pixel_mode = SDL_PIXELFORMAT_INDEX8;    bits_per_pixel = 8; break;
+#ifdef SDL_LIL_ENDIAN
+          case FT_PIXEL_MODE_BGRA: pixel_mode = SDL_PIXELFORMAT_ARGB8888;  bits_per_pixel = 32; break;
+#else
           case FT_PIXEL_MODE_BGRA: pixel_mode = SDL_PIXELFORMAT_BGRA8888;  bits_per_pixel = 32; break;
+#endif
         }
         // for BGRA surfaces we need to convert it to a surface in case we need to perform a scaled blit
         SDL_Surface *glyph_surface = check_alloc(SDL_CreateRGBSurfaceWithFormatFrom(slot->bitmap.buffer,


### PR DESCRIPTION
Currently the only two 3 types of bitmaps are supported - 1bpp monochrome, 8bpp grayscale and 24bpp subpixel. This PR adds suppport for 32bpp BGRA8888 bitmaps. This means we support all (resonably) pixel mode freetype supports. This will be a precursor to COLRv0, COLRv1 and SVG support.

A side effect is bitmap fonts (why would anyone still use it) is supported.

# Performance:

## Subpixel rendering

```lua
common.bench("test", function()
  for i = 1, 100 do
    local f = renderer.font.load(DATADIR .. "/fonts/JetBrainsMono-Regular.ttf", 14 * SCALE)
    f:get_width("hello world!\n")
  end
end)
```

![image](https://github.com/lite-xl/lite-xl/assets/20792268/19dcf721-a642-4bce-aa66-99b2b369412c)

There are no differences because the subpixel code is left untouched - SDL2 doesn't have a method of blitting subpixels so the original code is retained.

## Grayscale rendering

```lua
common.bench("test", function()
  for i = 1, 100 do
    local f = renderer.font.load(DATADIR .. "/fonts/JetBrainsMono-Regular.ttf", 14 * SCALE, {
      antialiasing = "grayscale",
      hinting = "none"
    })
    f:get_width("hello world!\n")
  end
end)
```
![image](https://github.com/lite-xl/lite-xl/assets/20792268/99b22414-1dea-4348-8f41-59c799f2440f)

Minor performance differences, perhaps due to surface creation and destruction.

## Monochrome rendering

```lua
common.bench("test", function()
  for i = 1, 100 do
    local f = renderer.font.load(DATADIR .. "/fonts/JetBrainsMono-Regular.ttf", 14 * SCALE, {
      antialiasing = "none",
      hinting = "none"
    })
    f:get_width("hello world!\n")
  end
end)
```

![image](https://github.com/lite-xl/lite-xl/assets/20792268/94d5fe1a-47f2-465c-b24a-3d43ce9ab467)

Once again, some performance drops.

# Misc

Stats when loading unifont.pcf with scaling:

![image](https://github.com/lite-xl/lite-xl/assets/20792268/8a6ffbc4-e11f-458b-8b61-14a5af3f4345)

Stats when loading unifont.pcf without scaling:

![image](https://github.com/lite-xl/lite-xl/assets/20792268/ff0ab962-c159-4dec-988c-69b3ca4f75d0)

Loading and scaling unifont.pcf:

[Screencast from 2023-05-30 15-25-07.webm](https://github.com/lite-xl/lite-xl/assets/20792268/51986fcc-fe28-4cba-933a-f6b80eb5b491)

Rendering emojis:

![image](https://github.com/lite-xl/lite-xl/assets/20792268/aba40bb2-3e7a-4980-9555-6185384b9e78)

If you look closely, you'll see 😵 💫, which is actually 😵‍💫. This is an example of Emoji with ZWJ, where you combine multiple emojis with a zero-width-joiner and it forms a new emoji. **This cannot be implemented because it requires glyph shaping.**
