### PR TITLE
feat(src/renderer): implement FT_Face caching

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -72,6 +72,10 @@ struct RenFaceID {
   char path[];
 };
 
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 #ifdef _WIN32
 // used to store the handle and data so that the file is protected when it is used
 typedef struct {

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -24,6 +24,8 @@
 typedef struct RenFaceID RenFaceID;
 
 RenWindow window_renderer = {0};
+
+// FIXME: will not work if multiple threads are using the library and manager
 static FT_Library library;
 static FTC_Manager manager;
 static RenFaceID** face_ids = NULL;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -148,8 +148,8 @@ static FT_Error open_face(FTC_FaceID face_id, FT_Library library, FT_Pointer req
   err = FT_New_Face(library, id->path, 0, aface);
 #endif
 
-cleanup:
 #ifdef _WIN32
+cleanup:
   free(wpath);
   if (err != FT_Err_Ok) {
     free(file);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -621,21 +621,6 @@ void ren_free_window_resources(RenWindow *window_renderer) {
   free(window_renderer->command_buf);
   window_renderer->command_buf = NULL;
   window_renderer->command_buf_size = 0;
-
-  for (int i = 0; i < face_ids_capacity; ++i) {
-    if (face_ids[i])
-      FTC_Manager_RemoveFaceID(manager, (FTC_FaceID) face_ids[i]);
-    free(face_ids[i]);
-  }
-  free(face_ids);
-  FTC_Manager_Done(manager);
-  FT_Done_FreeType(library);
-
-  face_ids = NULL;
-  face_ids_capacity = 0;
-  face_ids_max_idx = -1;
-  manager = NULL;
-  library = NULL;
 }
 
 // TODO remove global and return RenWindow*

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -621,6 +621,20 @@ void ren_free_window_resources(RenWindow *window_renderer) {
   free(window_renderer->command_buf);
   window_renderer->command_buf = NULL;
   window_renderer->command_buf_size = 0;
+
+  for (int i = 0; i < face_ids_capacity; ++i) {
+    if (face_ids[i])
+      FTC_Manager_RemoveFaceID(manager, (FTC_FaceID) face_ids[i]);
+    free(face_ids[i]);
+  }
+  free(face_ids);
+  FTC_Manager_Done(manager);
+  FT_Done_FreeType(library);
+
+  face_ids = NULL;
+  face_ids_capacity = face_ids_max_idx = 0;
+  manager = NULL;
+  library = NULL;
 }
 
 // TODO remove global and return RenWindow*

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -30,7 +30,7 @@ static FT_Library library;
 static FTC_Manager manager;
 static RenFaceID** face_ids = NULL;
 static int face_ids_capacity = 0;
-static int face_ids_max_idx = 0;
+static int face_ids_max_idx = -1;
 
 // draw_rect_surface is used as a 1x1 surface to simplify ren_draw_rect with blending
 static SDL_Surface *draw_rect_surface;
@@ -176,7 +176,7 @@ static RenFaceID* get_face_id(const char* path) {
   }
 
   // if no unused slots are found we need to create a new slot
-  if (free_face_id_idx == -1)
+  if (!id && free_face_id_idx == -1)
     free_face_id_idx = ++face_ids_max_idx;
 
   if (!id) {
@@ -632,7 +632,8 @@ void ren_free_window_resources(RenWindow *window_renderer) {
   FT_Done_FreeType(library);
 
   face_ids = NULL;
-  face_ids_capacity = face_ids_max_idx = 0;
+  face_ids_capacity = 0;
+  face_ids_max_idx = -1;
   manager = NULL;
   library = NULL;
 }


### PR DESCRIPTION
This allows FT_Face to be created or destroyed on demand, which makes memory consumption better.

We use FTC_Manager which caches FT_Face with MRU which limits the number of faces and sizes loaded in memory. This helps tremendeously on Windows because we need to read the entire font file into memory (#1201). Performance wise, this is a bit faster because we no longer re-read and parse the entire font when it is copied. Fonts with different styles, AA, and size will share the same face.

EDIT:
Tested on Linux, the memory savings is negligible since we don't read the entire font file anyway.

Fixes #1529.