### PR TITLE
Fix #1538 log scrolls automatically (the real PR)

### DIFF
--- a/data/core/logview.lua
+++ b/data/core/logview.lua
@@ -129,12 +129,9 @@ function LogView:update()
     local lh = style.font:get_height() + style.padding.y
     if 0 < self.scroll.to.y then
       local index = #core.log_items
-      repeat
-        if self.last_item == core.log_items[index] then
-          break
-        end
+      while index > 1 and self.last_item ~= core.log_items[index] do
         index = index - 1
-      until 0 == index
+      end
       local diff_index = #core.log_items - index
       self.scroll.to.y = self.scroll.to.y + diff_index * lh
       self.scroll.y = self.scroll.to.y

--- a/data/core/logview.lua
+++ b/data/core/logview.lua
@@ -128,7 +128,6 @@ function LogView:update()
   if self.last_item ~= item then
     local lh = style.font:get_height() + style.padding.y
     if 0 < self.scroll.to.y then
-      user_scroll = true
       local index = #core.log_items
       repeat
         if self.last_item == core.log_items[index] then
@@ -154,9 +153,7 @@ function LogView:update()
     end
   end
 
-  if not user_scroll then
-    self:move_towards("yoffset", 0, nil, "logview")
-  end
+  self:move_towards("yoffset", 0, nil, "logview")
 
   LogView.super.update(self)
 end

--- a/data/core/logview.lua
+++ b/data/core/logview.lua
@@ -123,7 +123,6 @@ end
 
 
 function LogView:update()
-  local user_scroll
   local item = core.log_items[#core.log_items]
   if self.last_item ~= item then
     local lh = style.font:get_height() + style.padding.y

--- a/data/core/logview.lua
+++ b/data/core/logview.lua
@@ -123,29 +123,18 @@ function LogView:on_mouse_pressed(button, px, py, clicks)
 end
 
 
-function LogView:on_mouse_wheel(y, x)
-  if 0 < self.scroll.to.y then
-    if not self.user_scroll then
-      self.user_scroll = { x = self.scroll.to.x, y = self.scroll.to.y }
-    else
-      self.user_scroll.y = self.scroll.to.y
-    end
-  else
-    self.user_scroll = nil
-  end
-end
-
-
 function LogView:update()
+  local user_scroll
   local item = core.log_items[#core.log_items]
   if self.last_item ~= item then
     local lh = style.font:get_height() + style.padding.y
     local diff_index = #core.log_items - self.last_item.index
     self.last_item = item
     self.last_item.index = #core.log_items
-    if self.user_scroll then
-      self.user_scroll.y = self.user_scroll.y + diff_index * lh
-      self.scroll.to.y = self.user_scroll.y
+    if 0 < self.scroll.to.y then
+      user_scroll = true
+      self.scroll.to.y = self.scroll.to.y + diff_index * lh
+      self.scroll.y = self.scroll.to.y
     else
       self.scroll.to.y = 0
       self.yoffset = -lh
@@ -160,7 +149,7 @@ function LogView:update()
     end
   end
 
-  if not self.user_scroll then
+  if not user_scroll then
     self:move_towards("yoffset", 0, nil, "logview")
   end
 

--- a/data/core/logview.lua
+++ b/data/core/logview.lua
@@ -42,7 +42,6 @@ LogView.context = "session"
 function LogView:new()
   LogView.super.new(self)
   self.last_item = core.log_items[#core.log_items]
-  self.last_item.index = #core.log_items
   self.expanding = {}
   self.scrollable = true
   self.yoffset = 0
@@ -128,17 +127,23 @@ function LogView:update()
   local item = core.log_items[#core.log_items]
   if self.last_item ~= item then
     local lh = style.font:get_height() + style.padding.y
-    local diff_index = #core.log_items - self.last_item.index
-    self.last_item = item
-    self.last_item.index = #core.log_items
     if 0 < self.scroll.to.y then
       user_scroll = true
+      local index = #core.log_items
+      repeat
+        if self.last_item == core.log_items[index] then
+          break
+        end
+        index = index - 1
+      until 0 == index
+      local diff_index = #core.log_items - index
       self.scroll.to.y = self.scroll.to.y + diff_index * lh
       self.scroll.y = self.scroll.to.y
     else
       self.scroll.to.y = 0
       self.yoffset = -lh
     end
+    self.last_item = item
   end
 
   local expanding = self.expanding[1]

--- a/data/core/logview.lua
+++ b/data/core/logview.lua
@@ -136,7 +136,6 @@ function LogView:update()
       self.scroll.to.y = self.scroll.to.y + diff_index * lh
       self.scroll.y = self.scroll.to.y
     else
-      self.scroll.to.y = 0
       self.yoffset = -lh
     end
     self.last_item = item


### PR DESCRIPTION
adds:
- when user scrolls, position is kept no matter how many new entries arrive
- when user scrolls up to last entry, autoscroll is enabled again
    
 does not add buttons to jump up/down
 see #1538