### PR TITLE
feat(src/renderer): unify fontgroup baseline

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -202,15 +202,6 @@ static RenFont* font_group_get_glyph(GlyphSet** set, GlyphMetric** metric, RenFo
   return fonts[0];
 }
 
-static unsigned short font_group_get_baseline(RenFont **fonts) {
-  unsigned short max_baseline = 0;
-  for (int i = 0; i < FONT_FALLBACK_MAX && fonts[i]; ++i) {
-    if (fonts[i]->baseline > max_baseline)
-      max_baseline = fonts[i]->baseline;
-  }
-  return max_baseline;
-}
-
 static void font_clear_glyph_cache(RenFont* font) {
   for (int i = 0; i < SUBPIXEL_BITMAPS_CACHED; ++i) {
     for (int j = 0; j < MAX_LOADABLE_GLYPHSETS; ++j) {
@@ -405,7 +396,6 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
   double last_pen_x = x;
   bool underline = fonts[0]->style & FONT_STYLE_UNDERLINE;
   bool strikethrough = fonts[0]->style & FONT_STYLE_STRIKETHROUGH;
-  unsigned short baseline = font_group_get_baseline(fonts);
 
   while (text < end) {
     unsigned int codepoint, r, g, b;
@@ -422,7 +412,7 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
     if (set->surface && color.a > 0 && end_x >= clip.x && start_x < clip_end_x) {
       uint8_t* source_pixels = set->surface->pixels;
       for (int line = metric->y0; line < metric->y1; ++line) {
-        int target_y = line + y - metric->bitmap_top + baseline * surface_scale;
+        int target_y = line + y - metric->bitmap_top + fonts[0]->baseline * surface_scale;
         if (target_y < clip.y)
           continue;
         if (target_y >= clip_end_y)

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -202,6 +202,15 @@ static RenFont* font_group_get_glyph(GlyphSet** set, GlyphMetric** metric, RenFo
   return fonts[0];
 }
 
+static unsigned short font_group_get_baseline(RenFont **fonts) {
+  unsigned short max_baseline = 0;
+  for (int i = 0; i < FONT_FALLBACK_MAX && fonts[i]; ++i) {
+    if (fonts[i]->baseline > max_baseline)
+      max_baseline = fonts[i]->baseline;
+  }
+  return max_baseline;
+}
+
 static void font_clear_glyph_cache(RenFont* font) {
   for (int i = 0; i < SUBPIXEL_BITMAPS_CACHED; ++i) {
     for (int j = 0; j < MAX_LOADABLE_GLYPHSETS; ++j) {
@@ -396,6 +405,7 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
   double last_pen_x = x;
   bool underline = fonts[0]->style & FONT_STYLE_UNDERLINE;
   bool strikethrough = fonts[0]->style & FONT_STYLE_STRIKETHROUGH;
+  unsigned short baseline = font_group_get_baseline(fonts);
 
   while (text < end) {
     unsigned int codepoint, r, g, b;
@@ -412,7 +422,7 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
     if (set->surface && color.a > 0 && end_x >= clip.x && start_x < clip_end_x) {
       uint8_t* source_pixels = set->surface->pixels;
       for (int line = metric->y0; line < metric->y1; ++line) {
-        int target_y = line + y - metric->bitmap_top + font->baseline * surface_scale;
+        int target_y = line + y - metric->bitmap_top + baseline * surface_scale;
         if (target_y < clip.y)
           continue;
         if (target_y >= clip_end_y)


### PR DESCRIPTION
This PR unifies font group baseline by choosing the max baseline value. This would be useful for the emoji PR.

Before:
![image](https://github.com/lite-xl/lite-xl/assets/20792268/1305f883-f2f9-4c36-9dc3-85fe86490a75)

After:
![image](https://github.com/lite-xl/lite-xl/assets/20792268/3928ead2-414d-4a25-bf5b-53f28c6efa38)


This can break stuff if your font has weird baselines, but it works in my case. I'd like to know if its bad or it should be a configurable value.
