### PR TITLE
feat(main): set minimum window size

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -181,6 +181,7 @@ int main(int argc, char **argv) {
     fprintf(stderr, "Error creating lite-xl window: %s", SDL_GetError());
     exit(1);
   }
+  SDL_SetWindowMinimumSize(window, dm.w * 0.2, dm.h * 0.2);
   ren_init(window);
 
   lua_State *L;


### PR DESCRIPTION
This is useful because:
1. If you accidentally made your window too small, it can be hard to get it back.
2. Calculations may go wrong if the window size is too small.

Currently, this doesn't work in X11 (at least on my end), which is tracked in https://github.com/libsdl-org/SDL/issues/5233. It does work on KDE Wayland tho (from my testing).
It should work on Windows and macOS too.

https://github.com/lite-xl/lite-xl/assets/20792268/6929a555-8e80-402b-a75c-e8806326cdaf

https://github.com/lite-xl/lite-xl/assets/20792268/d8732c06-1e2b-44be-ac2c-6a19242a6954



