### PR TITLE
feat(core): support force plugin loading

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1040,7 +1040,7 @@ function core.load_plugins(plugins, force)
 
   local load_start = system.get_time()
   for _, plugin in ipairs(plugins) do
-    if plugin.valid then
+    if plugin.valid and config.plugins[plugin.name] ~= false then
       if not force and not config.skip_plugins_version and not plugin.version_match then
         core.log_quiet(
           "Version mismatch for plugin %q[%s] from %s",
@@ -1053,7 +1053,7 @@ function core.load_plugins(plugins, force)
         end
         local list = refused_list[plugin.dir]
         table.insert(list, plugin)
-      elseif config.plugins[plugin.name] ~= false then
+      else
         local start = system.get_time()
         local ok, loaded_plugin = core.try(require, "plugins." .. plugin.name)
         if ok then

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -838,7 +838,7 @@ function core.init()
       string.format(
         "Some plugins are not loaded due to version mismatch. Expected version %s.\n\n%s.\n\n" ..
         "Please download a recent version from https://github.com/lite-xl/lite-xl-plugins.\n" ..
-        "To silence this warning, set config.skip_plugins_version to true.",
+        "To silence this warning, set config.skip_plugins_version to true or disable broken plugins.",
         MOD_VERSION_STRING, table.concat(msg, ".\n\n")),
       opt, function(item)
         if item.text == "Exit" then


### PR DESCRIPTION
This fixes #717.

The plugin version is already printed, `config.skip_plugins_version` has been added to disable version checks, and now we have a nagview option that forces plugin loading.

I've also added a note at the bottom about `config.skip_plugins_version`.