### PR TITLE
feat(core.emptyview): add name to emptyview

### DIFF
--- a/data/core/emptyview.lua
+++ b/data/core/emptyview.lua
@@ -6,6 +6,10 @@ local View = require "core.view"
 ---@field super core.view
 local EmptyView = View:extend()
 
+function EmptyView:get_name()
+  return "Get Started"
+end
+
 local function draw_text(x, y, color)
   local lines = {
     { fmt = "%s to run a command", cmd = "core:find-command" },

--- a/data/core/emptyview.lua
+++ b/data/core/emptyview.lua
@@ -10,6 +10,10 @@ function EmptyView:get_name()
   return "Get Started"
 end
 
+function EmptyView:get_filename()
+  return ""
+end
+
 local function draw_text(x, y, color)
   local lines = {
     { fmt = "%s to run a command", cmd = "core:find-command" },


### PR DESCRIPTION
This has always been a nit for me; When plugins fail to load it always shows `---` for `EmptyView`.
This PR changes it to `Get Started`. Maybe there are more suitable names, but I think this one's just fine.

As a side effect, it also says `Get Started` when nothing is opened now. Perhaps it should return the current project name, etc. but I think this looks okay.
![image](https://github.com/lite-xl/lite-xl/assets/20792268/5ec9f849-45fd-4282-bb54-7f10ac87d033)
