### PR TITLE
ci(release): use lite-xl org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     name: Linux
     needs: release
     runs-on: ubuntu-latest
-    container: ghcr.io/takase1121/lite-xl-build-box:latest
+    container: ghcr.io/lite-xl/lite-xl-build-box:latest
     env:
       CC: gcc
       CXX: g++


### PR DESCRIPTION
Since the lite-xl-build-box from our org is public, there's no point relying on my own fork.