### PR TITLE
Normalize strokes in fixed order

### DIFF
--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -40,15 +40,19 @@ local modkeys = modkeys_os.keys
 ---@return string
 local function normalize_stroke(stroke)
   local stroke_table = {}
-  for modkey in stroke:gmatch("(%w+)%+") do
-    table.insert(stroke_table, modkey)
+  for key in stroke:gmatch("[^+]+") do
+    table.insert(stroke_table, key)
   end
-  if not next(stroke_table) then
-    return stroke
-  end
-  table.sort(stroke_table)
-  local new_stroke = table.concat(stroke_table, "+") .. "+"
-  return new_stroke .. stroke:sub(new_stroke:len() + 1)
+  table.sort(stroke_table, function(a, b)
+    if a == b then return false end
+    for _, mod in ipairs(modkeys) do
+      if a == mod or b == mod then
+        return a == mod
+      end
+    end
+    return a < b
+  end)
+  return table.concat(stroke_table, "+")
 end
 
 
@@ -56,14 +60,15 @@ end
 ---@param key string
 ---@return string
 local function key_to_stroke(key)
-  local stroke = ""
+  local keys = { key }
   for _, mk in ipairs(modkeys) do
     if keymap.modkeys[mk] then
-      stroke = stroke .. mk .. "+"
+      table.insert(keys, mk)
     end
   end
-  return normalize_stroke(stroke) .. key
+  return normalize_stroke(table.concat(keys, "+"))
 end
+
 
 ---Remove the given value from an array associated to a key in a table.
 ---@param tbl table<string, string> The table containing the key
@@ -118,7 +123,7 @@ end
 function keymap.add_direct(map)
   for stroke, commands in pairs(map) do
     stroke = normalize_stroke(stroke)
-  
+
     if type(commands) == "string" or type(commands) == "function" then
       commands = { commands }
     end

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -90,12 +90,12 @@ end
 ---@param map keymap.map
 local function remove_duplicates(map)
   for stroke, commands in pairs(map) do
-    stroke = normalize_stroke(stroke)
+    local normalized_stroke = normalize_stroke(stroke)
     if type(commands) == "string" or type(commands) == "function" then
       commands = { commands }
     end
-    if keymap.map[stroke] then
-      for _, registered_cmd in ipairs(keymap.map[stroke]) do
+    if keymap.map[normalized_stroke] then
+      for _, registered_cmd in ipairs(keymap.map[normalized_stroke]) do
         local j = 0
         for i=1, #commands do
           while commands[i + j] == registered_cmd do

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -172,7 +172,8 @@ end
 ---@param shortcut string
 ---@param cmd string
 function keymap.unbind(shortcut, cmd)
-  remove_only(keymap.map, normalize_stroke(shortcut), cmd)
+  shortcut = normalize_stroke(shortcut)
+  remove_only(keymap.map, shortcut, cmd)
   remove_only(keymap.reverse_map, cmd, shortcut)
 end
 

--- a/data/core/modkeys-generic.lua
+++ b/data/core/modkeys-generic.lua
@@ -9,6 +9,6 @@ modkeys.map = {
   ["right alt"]   = "altgr",
 }
 
-modkeys.keys = { "ctrl", "alt", "altgr", "shift" }
+modkeys.keys = { "ctrl", "shift", "alt", "altgr" }
 
 return modkeys

--- a/data/core/modkeys-macos.lua
+++ b/data/core/modkeys-macos.lua
@@ -13,6 +13,6 @@ modkeys.map = {
   ["right alt"]      = "altgr",
 }
 
-modkeys.keys = { "cmd", "ctrl", "alt", "option", "altgr", "shift" }
+modkeys.keys = { "ctrl", "alt", "option", "altgr", "shift", "cmd" }
 
 return modkeys


### PR DESCRIPTION
Continuing from #1334.

This fixes a couple issues with `key_to_stroke`, `remove_duplicates` and `keymap.unbind`.

This also sorts the MacOS modifiers (kinda) according to https://developer.apple.com/design/human-interface-guidelines/keyboards (under `List modifier keys in the correct order.`) and the generic modifiers according to a poll on Discord (again, kinda).