### PR TITLE
Ignore keypresses during IME composition

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1274,6 +1274,9 @@ function core.on_event(type, ...)
   elseif type == "textediting" then
     ime.on_text_editing(...)
   elseif type == "keypressed" then
+    -- In some cases during IME composition input is still sent to us
+    -- so we just ignore it.
+    if ime.editing then return false end
     did_keymap = keymap.on_key_pressed(...)
   elseif type == "keyreleased" then
     keymap.on_key_released(...)

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -197,10 +197,6 @@ end
 -- Events listening
 --------------------------------------------------------------------------------
 function keymap.on_key_pressed(k, ...)
-  -- In MacOS and Windows during IME composition input is still sent to us
-  -- so we just ignore it
-  if PLATFORM ~= "Linux" and ime.editing then return false end
-
   local mk = modkey_map[k]
   if mk then
     keymap.modkeys[mk] = true


### PR DESCRIPTION
Some IMEs continue sending keypresses even during composition, so we just ignore them.

I'm moving this to be more generic (cause even some IMEs on Linux send the events, need to investigate more, might be an SDL issue), while still retaining mouse commands like scroll.

This is still not enough, as we're receiving some `textinput` events too while we should not, but we can't disable those because that's how we receive the final IME composition...