### PR TITLE
Fix editing after undo not clearing the change id

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -487,6 +487,10 @@ end
 
 function Doc:insert(line, col, text)
   self.redo_stack = { idx = 1 }
+  -- Reset the clean id when we're pushing something new before it
+  if self:get_change_id() < self.clean_change_id then
+    self.clean_change_id = -1
+  end
   line, col = self:sanitize_position(line, col)
   self:raw_insert(line, col, text, self.undo_stack, system.get_time())
   self:on_text_change("insert")


### PR DESCRIPTION
To reproduce:
1. Open a doc
2. Write `a`
3. Save
4. Undo
5. Write `b`

The doc will say it's not dirty.

I don't like this change too much because of how we're exposing the undo stack. But it is what it is.