### PR TITLE
UCRT releases for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
           path: ${{ env.INSTALL_NAME }}.dmg
 
   build_windows_msys2:
-    name: Windows
+    name: Windows (MINGW)
     runs-on: windows-2019
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,11 +149,12 @@ jobs:
           base-devel
           git
           zip
-          mingw-w64-${{ matrix.config.arch }}-${{ matrix.config.cc }}
-          mingw-w64-${{ matrix.config.arch }}-meson
-          mingw-w64-${{ matrix.config.arch }}-ninja
-          mingw-w64-${{ matrix.config.arch }}-ca-certificates
-          mingw-w64-${{ matrix.config.arch }}-ntldd
+        pacboy: >-
+          ${{ matrix.config.cc }}:p
+          meson:p
+          ninja:p
+          ca-certificates:p
+          ntldd:p
     - name: Set Environment Variables
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,11 +159,7 @@ jobs:
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
-        if [[ "${MSYSTEM}" == *64 ]]; then
-          echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-x86_64" >> "$GITHUB_ENV"
-        else
-          echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-i686" >> "$GITHUB_ENV"
-        fi
+        echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-${{ matrix.config.arch }}" >> "$GITHUB_ENV"
     - name: Install Dependencies
       if: false
       run: bash scripts/install-dependencies.sh --debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - {msystem: CLANG32, arch: i686, cc: clang}
-          - {msystem: UCRT64, arch: x86_64, cc: gcc}
+          - { msystem: CLANG32, arch: i686 }
+          - { msystem: CLANG64, arch: x86_64 }
     defaults:
       run:
         shell: msys2 {0}
@@ -150,7 +150,7 @@ jobs:
           git
           zip
         pacboy: >-
-          ${{ matrix.config.cc }}:p
+          clang:p
           meson:p
           ninja:p
           ca-certificates:p

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
-        if [[ "${MSYSTEM}" == "MINGW64" ]]; then
+        if [[ "${MSYSTEM}" == *64 ]]; then
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-x86_64" >> "$GITHUB_ENV"
         else
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-i686" >> "$GITHUB_ENV"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - {msystem: MINGW32, arch: i686}
-          - {msystem: MINGW64, arch: x86_64}
+          - {msystem: CLANG32, arch: i686, cc: clang}
+          - {msystem: UCRT64, arch: x86_64, cc: gcc}
     defaults:
       run:
         shell: msys2 {0}
@@ -149,7 +149,7 @@ jobs:
           base-devel
           git
           zip
-          mingw-w64-${{ matrix.config.arch }}-gcc
+          mingw-w64-${{ matrix.config.arch }}-${{ matrix.config.cc }}
           mingw-w64-${{ matrix.config.arch }}-meson
           mingw-w64-${{ matrix.config.arch }}-ninja
           mingw-w64-${{ matrix.config.arch }}-ca-certificates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,7 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-          echo "BUILD_ARCH=${{ matrix.config.arch }} >> "$GITHUB_ENV"
+          echo "BUILD_ARCH=${{ matrix.config.arch }}" >> "$GITHUB_ENV"
           echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-${{ matrix.config.arch }}" >> "$GITHUB_ENV"
           echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-windows-${{ matrix.config.arch }}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        msystem: [MINGW32, MINGW64]
+        msystem: [UCRT64]
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,9 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        msystem: [UCRT64]
+        config:
+          - { msystem: CLANG32, arch: i686 }
+          - { msystem: CLANG64, arch: x86_64 }
     defaults:
       run:
         shell: msys2 {0}
@@ -220,27 +222,37 @@ jobs:
       - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: ${{ matrix.msystem }}
+          msystem: ${{ matrix.config.msystem }}
           update: true
           install: >-
             base-devel
             git
             zip
+            unzip
+          pacboy:
+            ca-certificates:p
+            clang:p
+            meson:p
+            ninja:p
+            ntldd:p
+            pkg-config:p
+            mesa:p
+            freetype:p
+            pcre2:p
+            SDL2:p
       - name: Set Environment Variables
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-          if [[ "${MSYSTEM}" == "MINGW64" ]]; then
-            echo "BUILD_ARCH=x86_64" >> "$GITHUB_ENV"
-            echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-x86_64" >> "$GITHUB_ENV"
-            echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-windows-x86_64" >> "$GITHUB_ENV"
-          else
-            echo "BUILD_ARCH=i686" >> "$GITHUB_ENV"
-            echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-i686" >> "$GITHUB_ENV"
-            echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-windows-i686" >> "$GITHUB_ENV"
-          fi
+          echo "BUILD_ARCH=${{ matrix.config.arch }} >> "$GITHUB_ENV"
+          echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-${{ matrix.config.arch }}" >> "$GITHUB_ENV"
+          echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-windows-${{ matrix.config.arch }}" >> "$GITHUB_ENV"
+
+      # disabled because dependencies are already installed in setup
       - name: Install Dependencies
+        if: false
         run: bash scripts/install-dependencies.sh --debug
+
       - name: Build
         run: |
           bash --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
         id: tag
         run: |
           if [[ "${{ github.event.inputs.version }}" != "" ]]; then
-            echo ::set-output name=version::${{ github.event.inputs.version }}
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
           else
-            echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+            echo "version=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
           fi
       - name: Update Tag
         uses: richardsimko/update-tag@v1

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -77,7 +77,7 @@ get_platform_arch() {
   platform=$(get_platform_name)
   arch=${CROSS_ARCH:-$(uname -m)}
   if [[ $MSYSTEM != "" ]]; then
-    if [[ $MSYSTEM == "MINGW64" ]]; then
+    if [[ $MSYSTEM == *64 ]]; then
       arch=x86_64
     else
       arch=i686

--- a/scripts/innosetup/innosetup.sh
+++ b/scripts/innosetup/innosetup.sh
@@ -29,7 +29,7 @@ main() {
   local version
   local output
 
-  if [[ $MSYSTEM == "MINGW64" ]]; then
+  if [[ $MSYSTEM == *64 ]]; then
     arch=x64
     arch_file=x86_64
   else

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -63,10 +63,10 @@ main() {
   elif [[ "$OSTYPE" == "msys" ]]; then
     if [[ $lhelper == true ]]; then
       pacman --noconfirm -S \
-        ${MINGW_PACKAGE_PREFIX}-{ca-certificates,gcc,meson,ninja,ntldd,pkg-config,mesa} unzip
+        ${MINGW_PACKAGE_PREFIX}-{ca-certificates,clang,meson,ninja,ntldd,pkg-config,mesa} unzip
     else
       pacman --noconfirm -S \
-        ${MINGW_PACKAGE_PREFIX}-{ca-certificates,gcc,meson,ninja,ntldd,pkg-config,mesa,freetype,pcre2,SDL2} unzip
+        ${MINGW_PACKAGE_PREFIX}-{ca-certificates,clang,meson,ninja,ntldd,pkg-config,mesa,freetype,pcre2,SDL2} unzip
     fi
   fi
 }


### PR DESCRIPTION
UCRT is the default C runtime library since Visual Studio 2015. CRT is like libc in Linux but not quite. Previously, each version of Visual Studio ships with their own CRT. MSYS2 recently supports UCRT so we should switch to it too.

From [MSYS2](https://www.msys2.org/docs/environments/):
> MSVCRT (Microsoft Visual C++ Runtime) is available by default on all Microsoft Windows versions, but due to backwards compatibility issues is stuck in the past, not C99 compatible and is missing some features.
>
> 1. It isn't C99 compatible, for example the printf() function family, but... mingw-w64 provides replacement functions to make things C99 compatible in many cases
> 2. It doesn't support the UTF-8 locale
> 3. Binaries linked with MSVCRT should not be mixed with UCRT ones because the internal structures and data types are different. (More strictly, object files or static libraries built for different targets shouldn't be mixed. DLLs built for different CRTs can be mixed as long as they don't share CRT objects, e.g. FILE*, across DLL boundaries.) Same rule is applied for MSVC compiled binaries because MSVC uses UCRT by default (if not changed).
> 4. Works out of the box on every version of Microsoft Windows.
>
> UCRT (Universal C Runtime) is a newer version which is also used by Microsoft Visual Studio by default. It should work and behave as if the code was compiled with MSVC.
>
> 1. Better compatibility with MSVC, both at build time and at run time.
> 2. It only ships by default on Windows 10 and for older versions you have to provide it yourself or depend on the user having it installed.

For more context about UCRT in previous versions of Windows - it is available via Windows update, or simply installing a recent version of VC redistributables which provides an old version of UCRT.

Currently, the CI is still stuck on MINGW because UCRT doesn't support 32-bit targets. Please let me know if I should change it to UCRT.