### PR TITLE
feat(subprojects): update wraps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
         run: |
           "INSTALL_NAME=lite-xl-$($env:GITHUB_REF -replace ".*/")-windows-msvc-${{ matrix.arch.name }}" >> $env:GITHUB_ENV
           "INSTALL_REF=$($env:GITHUB_REF -replace ".*/")" >> $env:GITHUB_ENV
-          "LUA_SUBPROJECT_PATH=subprojects/$(grep 'directory' subprojects/lua.wrap | sed 's/directory *= *//')" >> $env:GITHUB_ENV
+          "LUA_SUBPROJECT_PATH=subprojects/$(awk -F ' *= *' '/directory/ { printf $2 }' subprojects/lua.wrap)" >> $env:GITHUB_ENV
       - name: Download and patch subprojects
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
         run: |
           "INSTALL_NAME=lite-xl-$($env:GITHUB_REF -replace ".*/")-windows-msvc-${{ matrix.arch.name }}" >> $env:GITHUB_ENV
           "INSTALL_REF=$($env:GITHUB_REF -replace ".*/")" >> $env:GITHUB_ENV
-          "LUA_SUBPROJECT_PATH=subprojects/lua-5.4.4" >> $env:GITHUB_ENV
+          "LUA_SUBPROJECT_PATH=subprojects/$(grep 'directory' subprojects/lua.wrap | sed 's/directory *= *//')" >> $env:GITHUB_ENV
       - name: Download and patch subprojects
         shell: bash
         run: |

--- a/meson.build
+++ b/meson.build
@@ -101,7 +101,7 @@ if not get_option('source-only')
         endforeach
     else
         lua_dep = dependency('', fallback: ['lua', 'lua_dep'], required : true,
-            default_options: default_fallback_options + ['default_library=static', 'line_editing=false', 'interpreter=false']
+            default_options: default_fallback_options + ['default_library=static', 'line_editing=disabled', 'interpreter=false']
         )
     endif
 

--- a/meson.build
+++ b/meson.build
@@ -155,6 +155,7 @@ if not get_option('source-only')
     sdl_options += 'use_video_vulkan=disabled'
     sdl_options += 'use_video_offscreen=disabled'
     sdl_options += 'use_power=disabled'
+    sdl_options += 'system_iconv=disabled'
 
     sdl_dep = dependency('sdl2', fallback: ['sdl2', 'sdl2_dep'],
         default_options: default_fallback_options + sdl_options

--- a/meson.build
+++ b/meson.build
@@ -162,10 +162,15 @@ if not get_option('source-only')
         default_options: default_fallback_options + sdl_options
     )
 
-    if host_machine.system() == 'windows' and sdl_dep.type_name() == 'internal'
-        sdlmain_dep = dependency('sdl2main', fallback: ['sdl2main_dep'])
+    if host_machine.system() == 'windows'
+        if sdl_dep.type_name() == 'internal'
+            sdlmain_dep = dependency('sdl2main', fallback: ['sdl2main_dep'])
+        else
+            sdlmain_dep = cc.find_library('SDL2main')
+        endif
     else
-        sdlmain_dep = cc.find_library('SDL2main')
+        sdlmain_dep = dependency('', required: false)
+        assert(not fake_dep.found(), 'checking if fake dependency has been found')
     endif
 
     lite_deps = [lua_dep, sdl_dep, sdlmain_dep, freetype_dep, pcre2_dep, libm, libdl]

--- a/meson.build
+++ b/meson.build
@@ -123,6 +123,7 @@ if not get_option('source-only')
     sdl_options += 'use_atomic=enabled'
     sdl_options += 'use_threads=enabled'
     sdl_options += 'use_timers=enabled'
+    sdl_options += 'with_main=true'
     # investigate if this is truly needed
     # Do not remove before https://github.com/libsdl-org/SDL/issues/5413 is released
     sdl_options += 'use_events=enabled'
@@ -161,7 +162,13 @@ if not get_option('source-only')
         default_options: default_fallback_options + sdl_options
     )
 
-    lite_deps = [lua_dep, sdl_dep, freetype_dep, pcre2_dep, libm, libdl]
+    if host_machine.system() == 'windows' and sdl_dep.type_name() == 'internal'
+        sdlmain_dep = dependency('sdl2main', fallback: ['sdl2main_dep'])
+    else
+        sdlmain_dep = cc.find_library('SDL2main')
+    endif
+
+    lite_deps = [lua_dep, sdl_dep, sdlmain_dep, freetype_dep, pcre2_dep, libm, libdl]
 endif
 #===============================================================================
 # Install Configuration

--- a/meson.build
+++ b/meson.build
@@ -170,7 +170,7 @@ if not get_option('source-only')
         endif
     else
         sdlmain_dep = dependency('', required: false)
-        assert(not fake_dep.found(), 'checking if fake dependency has been found')
+        assert(not sdlmain_dep.found(), 'checking if fake dependency has been found')
     endif
 
     lite_deps = [lua_dep, sdl_dep, sdlmain_dep, freetype_dep, pcre2_dep, libm, libdl]

--- a/resources/include/lite_xl_plugin_api.h
+++ b/resources/include/lite_xl_plugin_api.h
@@ -31,9 +31,14 @@
  * An example command would be: gcc -shared -o xxxxx.so xxxxx.c
  * You must not link to ANY lua library to avoid symbol collision.
  * 
- * This file contains stock configuration for a typical installation of Lua 5.4.
+ * This file contains stock configuration for a typical installation of Lua 5.4.6.
  * DO NOT MODIFY ANYTHING. MODIFYING STUFFS IN HERE WILL BREAK
  * COMPATIBILITY WITH LITE XL AND CAUSE UNDEBUGGABLE BUGS.
+ * 
+ * For reference, here are a list of permalinks to previous version of this file that targets an older version of Lua.
+ * If you don't need functionalities offered by the new version, use the OLDEST FILE for backwards compatibility.
+ * 
+ * - Lua 5.4.4: https://github.com/lite-xl/lite-xl/blob/397973067f14420b26e3b20a238a50016c0b75e2/resources/include/lite_xl_plugin_api.h
 **/
 #ifndef LITE_XL_PLUGIN_API
 #define LITE_XL_PLUGIN_API

--- a/resources/include/lite_xl_plugin_api.h
+++ b/resources/include/lite_xl_plugin_api.h
@@ -1033,6 +1033,7 @@ extern const char lua_ident[];
 SYMBOL_DECLARE(lua_State *, lua_newstate, lua_Alloc f, void *ud)
 SYMBOL_DECLARE(void,        lua_close, lua_State *L)
 SYMBOL_DECLARE(lua_State *, lua_newthread, lua_State *L)
+SYMBOL_DECLARE(int,         lua_closethread, lua_State *L, lua_State *from)
 SYMBOL_DECLARE(int,         lua_resetthread, lua_State *L)
 
 SYMBOL_DECLARE(lua_CFunction, lua_atpanic, lua_State *L, lua_CFunction panicf)
@@ -1744,6 +1745,9 @@ SYMBOL_WRAP_DECL(void, lua_close, lua_State *L) {
 SYMBOL_WRAP_DECL(lua_State *, lua_newthread, lua_State *L) {
   return SYMBOL_WRAP_CALL(lua_newthread, L);
 }
+SYMBOL_WRAP_DECL(int, lua_closethread, lua_State *L, lua_State *from) {
+  return SYMBOL_WRAP_CALL(lua_closethread, L, from);
+}
 SYMBOL_WRAP_DECL(int, lua_resetthread, lua_State *L) {
   return SYMBOL_WRAP_CALL(lua_resetthread, L);
 }
@@ -2356,6 +2360,7 @@ void lite_xl_plugin_init(void *XL) {
   IMPORT_SYMBOL(lua_newstate, lua_State *, lua_Alloc f, void *ud);
   IMPORT_SYMBOL(lua_close, void, lua_State *L);
   IMPORT_SYMBOL(lua_newthread, lua_State *, lua_State *L);
+  IMPORT_SYMBOL(lua_closethread, int, lua_State *L, lua_State *from);
   IMPORT_SYMBOL(lua_resetthread, int, lua_State *L);
   IMPORT_SYMBOL(lua_atpanic, lua_CFunction, lua_State *L, lua_CFunction panicf);
   IMPORT_SYMBOL(lua_version, lua_Number, lua_State *L);

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,9 +1,10 @@
 [wrap-file]
-directory = freetype-2.12.1
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.12.1.tar.xz
-source_filename = freetype-2.12.1.tar.xz
-source_hash = 4766f20157cc4cf0cd292f80bf917f92d1c439b243ac3018debf6b9140c41a7f
-wrapdb_version = 2.12.1-2
+directory = freetype-2.13.1
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.13.1.tar.xz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.13.1-1/freetype-2.13.1.tar.xz
+source_filename = freetype-2.13.1.tar.xz
+source_hash = ea67e3b019b1104d1667aa274f5dc307d8cbd606b399bc32df308a77f1a564bf
+wrapdb_version = 2.13.1-1
 
 [provide]
 freetype2 = freetype_dep

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = freetype-2.13.1
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.13.1.tar.xz
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.13.1-1/freetype-2.13.1.tar.xz
-source_filename = freetype-2.13.1.tar.xz
-source_hash = ea67e3b019b1104d1667aa274f5dc307d8cbd606b399bc32df308a77f1a564bf
-wrapdb_version = 2.13.1-1
+directory = freetype-2.13.2
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.13.2.tar.xz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.13.2-1/freetype-2.13.2.tar.xz
+source_filename = freetype-2.13.2.tar.xz
+source_hash = 12991c4e55c506dd7f9b765933e62fd2be2e06d421505d7950a132e4f1bb484d
+wrapdb_version = 2.13.2-1
 
 [provide]
 freetype2 = freetype_dep

--- a/subprojects/lua.wrap
+++ b/subprojects/lua.wrap
@@ -1,12 +1,14 @@
 [wrap-file]
-directory = lua-5.4.4
-source_url = https://www.lua.org/ftp/lua-5.4.4.tar.gz
-source_filename = lua-5.4.4.tar.gz
-source_hash = 164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61
-patch_filename = lua_5.4.4-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/lua_5.4.4-1/get_patch
-patch_hash = e61cd965c629d6543176f41a9f1cb9050edfd1566cf00ce768ff211086e40bdc
+directory = lua-5.4.6
+source_url = https://www.lua.org/ftp/lua-5.4.6.tar.gz
+source_filename = lua-5.4.6.tar.gz
+source_hash = 7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
+patch_filename = lua_5.4.6-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/lua_5.4.6-2/get_patch
+patch_hash = a218f93461b1d9ba9367506f3198815f84ee25e2e4b50894679004aee9cb46f2
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/lua_5.4.6-2/lua-5.4.6.tar.gz
+wrapdb_version = 5.4.6-2
 
 [provide]
 lua-5.4 = lua_dep
-
+lua = lua_dep

--- a/subprojects/lua.wrap
+++ b/subprojects/lua.wrap
@@ -3,11 +3,11 @@ directory = lua-5.4.6
 source_url = https://www.lua.org/ftp/lua-5.4.6.tar.gz
 source_filename = lua-5.4.6.tar.gz
 source_hash = 7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
-patch_filename = lua_5.4.6-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/lua_5.4.6-2/get_patch
-patch_hash = a218f93461b1d9ba9367506f3198815f84ee25e2e4b50894679004aee9cb46f2
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/lua_5.4.6-2/lua-5.4.6.tar.gz
-wrapdb_version = 5.4.6-2
+patch_filename = lua_5.4.6-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/lua_5.4.6-3/get_patch
+patch_hash = 9b72a95422fd47f79f969d9abdb589ee95712d5512a5246f94e7e4f63d2cb7b7
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/lua_5.4.6-3/lua-5.4.6.tar.gz
+wrapdb_version = 5.4.6-3
 
 [provide]
 lua-5.4 = lua_dep

--- a/subprojects/pcre2.wrap
+++ b/subprojects/pcre2.wrap
@@ -1,12 +1,13 @@
 [wrap-file]
 directory = pcre2-10.42
-source_url = https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.bz2
+source_url = https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.bz2
 source_filename = pcre2-10.42.tar.bz2
 source_hash = 8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840
-patch_filename = pcre2_10.42-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.42-1/get_patch
-patch_hash = 06969e916dfee663c189810df57d98574f15e0754a44cd93f3f0bc7234b05d89
-wrapdb_version = 10.42-1
+patch_filename = pcre2_10.42-5_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.42-5/get_patch
+patch_hash = 7ba1730a3786c46f41735658a9884b09bc592af3840716e0ccc552e7ddf5630c
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/pcre2_10.42-5/pcre2-10.42.tar.bz2
+wrapdb_version = 10.42-5
 
 [provide]
 libpcre2-8 = libpcre2_8

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -1,12 +1,15 @@
 [wrap-file]
-directory = SDL2-2.26.0
-source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.26.0/SDL2-2.26.0.tar.gz
-source_filename = SDL2-2.26.0.tar.gz
-source_hash = 8000d7169febce93c84b6bdf376631f8179132fd69f7015d4dadb8b9c2bdb295
-patch_filename = sdl2_2.26.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.26.0-1/get_patch
-patch_hash = 6fcfd727d71cf7837332723518d5e47ffd64f1e7630681cf4b50e99f2bf7676f
-wrapdb_version = 2.26.0-1
+directory = SDL2-2.28.1
+source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.28.1/SDL2-2.28.1.tar.gz
+source_filename = SDL2-2.28.1.tar.gz
+source_hash = 4977ceba5c0054dbe6c2f114641aced43ce3bf2b41ea64b6a372d6ba129cb15d
+patch_filename = sdl2_2.28.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.28.1-1/get_patch
+patch_hash = 9b08f50670f6725d5eaeee036e805be22201ce0b487b1f9fe09feaa1090fa39d
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.28.1-1/SDL2-2.28.1.tar.gz
+wrapdb_version = 2.28.1-1
 
 [provide]
 sdl2 = sdl2_dep
+sdl2main = sdl2main_dep
+sdl2_test = sdl2_test_dep

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -3,11 +3,11 @@ directory = SDL2-2.28.1
 source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.28.1/SDL2-2.28.1.tar.gz
 source_filename = SDL2-2.28.1.tar.gz
 source_hash = 4977ceba5c0054dbe6c2f114641aced43ce3bf2b41ea64b6a372d6ba129cb15d
-patch_filename = sdl2_2.28.1-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.28.1-1/get_patch
-patch_hash = 9b08f50670f6725d5eaeee036e805be22201ce0b487b1f9fe09feaa1090fa39d
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.28.1-1/SDL2-2.28.1.tar.gz
-wrapdb_version = 2.28.1-1
+patch_filename = sdl2_2.28.1-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.28.1-2/get_patch
+patch_hash = 2dd332226ba2a4373c6d4eb29fa915e9d5414cf7bb9fa2e4a5ef3b16a06e2736
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.28.1-2/SDL2-2.28.1.tar.gz
+wrapdb_version = 2.28.1-2
 
 [provide]
 sdl2 = sdl2_dep


### PR DESCRIPTION
SDL 2.28.0 contains some bugfixes and stuff, but most of them aren't relevant to us. However, it does contain `system_iconv` which we need to not use iconv on MSYS2.