### PR TITLE
Fix `language_js` regex constant detection

### DIFF
--- a/data/plugins/language_js.lua
+++ b/data/plugins/language_js.lua
@@ -6,22 +6,24 @@ local syntax = require "core.syntax"
 --
 -- (?!/) Don't match empty regexes.
 --
--- (?>[^\\[\/]*) is an atomic group, this matches anything that's not "special";
---               this is using an atomic group to minimize backtracking,
---               as that'd cause "Catastrophic Backtracking" in some cases.
+-- (?>...) this is using an atomic group to minimize backtracking, as that'd
+--         cause "Catastrophic Backtracking" in some cases.
 --
--- \\(?:\\{2})*. will match anything that's escaped, so that we can ignore it.
+-- [^\\[\/]+ will match anything that's isn't an escape, a start of character
+--           class or an end of pattern.
 --
--- (?:\\{2})*\[.*?(?<!\\)(?:\\{2})*\] will match character classes.
+-- \\. will match anything that's escaped.
 --
--- /[gmiyuvsd]*\s*[\n,;\)]) will match the end of pattern delimiter, optionally
---                          followed by pattern options, and anything that can
---                          be after a pattern.
+-- \[(?:[^\\\]]|\\.)*\] will match character classes.
 --
--- Demo with some unit tests (click on the Unit Tests entry): https://regex101.com/r/EDgjPH/1
+-- /[gmiyuvsd]*\s*[\n,;\)\]\}]) will match the end of pattern delimiter, optionally
+--                              followed by pattern options, and anything that can
+--                              be after a pattern.
+--
+-- Demo with some unit tests (click on the Unit Tests entry): https://regex101.com/r/YjDBh4/1
 -- Note that it has a couple of changes to make it work on that platform.
 local regex_pattern = {
-  [=[/(?=(?!/)(?:(?>[^\\[\/]*)(?:\\(?:\\{2})*.|(?:\\{2})*\[.*?(?<!\\)(?:\\{2})*\])*)+/[gmiyuvsd]*\s*[\n,;\)])()]=],
+  [=[/(?=(?!/)(?:(?>[^\\[\/]+|\\.|\[(?:[^\\\]]|\\.)*\])*)+/[gmiyuvsd]*\s*[\n,;\)\]\}])()]=],
   "/()[gmiyuvsd]*", "\\"
 }
 

--- a/data/plugins/language_js.lua
+++ b/data/plugins/language_js.lua
@@ -1,24 +1,72 @@
 -- mod-version:3
 local syntax = require "core.syntax"
 
+-- Regex pattern explanation:
+-- This will match / and will look ahead for something that looks like a regex.
+--
+-- (?!/) Don't match empty regexes.
+--
+-- (?>[^\\[\/]*) is an atomic group, this matches anything that's not "special";
+--               this is using an atomic group to minimize backtracking,
+--               as that'd cause "Catastrophic Backtracking" in some cases.
+--
+-- \\(?:\\{2})*. will match anything that's escaped, so that we can ignore it.
+--
+-- (?:\\{2})*\[.*?(?<!\\)(?:\\{2})*\] will match character classes.
+--
+-- /[gmiyuvsd]*\s*[\n,;\)]) will match the end of pattern delimiter, optionally
+--                          followed by pattern options, and anything that can
+--                          be after a pattern.
+--
+-- Demo with some unit tests (click on the Unit Tests entry): https://regex101.com/r/EDgjPH/1
+-- Note that it has a couple of changes to make it work on that platform.
+local regex_pattern = {
+  [=[/(?=(?!/)(?:(?>[^\\[\/]*)(?:\\(?:\\{2})*.|(?:\\{2})*\[.*?(?<!\\)(?:\\{2})*\])*)+/[gmiyuvsd]*\s*[\n,;\)])()]=],
+  "/()[gmiyuvsd]*", "\\"
+}
+
+-- For the moment let's not actually differentiate the insides of the regex,
+-- as this will need new token types...
+local inner_regex_syntax = {
+  patterns = {
+    { pattern = "%(()%?[:!=><]", type = { "string", "string" } },
+    { pattern = "[.?+*%(%)|]", type = "string" },
+    { pattern = "{%d*,?%d*}", type = "string" },
+    { regex = { [=[\[()\^?]=], [=[(?:\]|(?=\n))()]=], "\\" },
+      type = { "string", "string" },
+      syntax = { -- Inside character class
+        patterns = {
+          { pattern = "\\\\", type = "string" },
+          { pattern = "\\%]", type = "string" },
+          { pattern = "[^%]\n]", type = "string" }
+        },
+        symbols = {}
+      }
+    },
+    { regex = "\\/", type = "string" },
+    { regex = "[^/\n]", type = "string" },
+  },
+  symbols = {}
+}
+
 syntax.add {
   name = "JavaScript",
   files = { "%.js$", "%.json$", "%.cson$", "%.mjs$", "%.cjs$" },
   comment = "//",
   block_comment = { "/*", "*/" },
   patterns = {
-    { pattern = "//.*",                 type = "comment"  },
-    { pattern = { "/%*", "%*/" },       type = "comment"  },
-    { pattern = { '/[^= ]', '/', '\\' },type = "string"   },
-    { pattern = { '"', '"', '\\' },     type = "string"   },
-    { pattern = { "'", "'", '\\' },     type = "string"   },
-    { pattern = { "`", "`", '\\' },     type = "string"   },
-    { pattern = "0x[%da-fA-F_]+n?",     type = "number"   },
-    { pattern = "-?%d+[%d%.eE_n]*",     type = "number"   },
-    { pattern = "-?%.?%d+",             type = "number"   },
-    { pattern = "[%+%-=/%*%^%%<>!~|&]", type = "operator" },
-    { pattern = "[%a_][%w_]*%f[(]",     type = "function" },
-    { pattern = "[%a_][%w_]*",          type = "symbol"   },
+    { pattern = "//.*",                      type = "comment"  },
+    { pattern = { "/%*", "%*/" },            type = "comment"  },
+    { regex = regex_pattern, syntax = inner_regex_syntax, type = {"string", "string"}  },
+    { pattern = { '"', '"', '\\' },          type = "string"   },
+    { pattern = { "'", "'", '\\' },          type = "string"   },
+    { pattern = { "`", "`", '\\' },          type = "string"   },
+    { pattern = "0x[%da-fA-F_]+n?()%s*()/?", type = {"number", "normal", "operator"}   },
+    { pattern = "-?%d+[%d%.eE_n]*()%s*()/?", type = {"number", "normal", "operator"}   },
+    { pattern = "-?%.?%d+()%s*()/?",         type = {"number", "normal", "operator"}   },
+    { pattern = "[%+%-=/%*%^%%<>!~|&]",      type = "operator" },
+    { pattern = "[%a_][%w_]*%f[(]",          type = "function" },
+    { pattern = "[%a_][%w_]*()%s*()/?",      type = {"symbol", "normal", "operator"}   },
   },
   symbols = {
     ["async"]      = "keyword",

--- a/data/plugins/language_js.lua
+++ b/data/plugins/language_js.lua
@@ -9,21 +9,21 @@ local syntax = require "core.syntax"
 -- (?>...) this is using an atomic group to minimize backtracking, as that'd
 --         cause "Catastrophic Backtracking" in some cases.
 --
--- [^\\[\/]+ will match anything that's isn't an escape, a start of character
---           class or an end of pattern.
+-- [^\\[\/]++ will match anything that's isn't an escape, a start of character
+--           class or an end of pattern, without backtracking (the second +).
 --
 -- \\. will match anything that's escaped.
 --
--- \[(?:[^\\\]]|\\.)*\] will match character classes.
+-- \[(?:[^\\\]++]|\\.)*+\] will match character classes.
 --
 -- /[gmiyuvsd]*\s*[\n,;\)\]\}]) will match the end of pattern delimiter, optionally
 --                              followed by pattern options, and anything that can
 --                              be after a pattern.
 --
--- Demo with some unit tests (click on the Unit Tests entry): https://regex101.com/r/YjDBh4/1
+-- Demo with some unit tests (click on the Unit Tests entry): https://regex101.com/r/R0w8Qw/1
 -- Note that it has a couple of changes to make it work on that platform.
 local regex_pattern = {
-  [=[/(?=(?!/)(?:(?>[^\\[\/]+|\\.|\[(?:[^\\\]]|\\.)*\])*)+/[gmiyuvsd]*\s*[\n,;\)\]\}])()]=],
+  [=[/(?=(?!/)(?:(?>[^\\[\/]++|\\.|\[(?:[^\\\]]++|\\.)*+\])*+)++/[gmiyuvsd]*\s*[\n,;\)\]\}])()]=],
   "/()[gmiyuvsd]*", "\\"
 }
 

--- a/data/plugins/language_js.lua
+++ b/data/plugins/language_js.lua
@@ -16,14 +16,14 @@ local syntax = require "core.syntax"
 --
 -- \[(?:[^\\\]++]|\\.)*+\] will match character classes.
 --
--- /[gmiyuvsd]*\s*[\n,;\)\]\}]) will match the end of pattern delimiter, optionally
---                              followed by pattern options, and anything that can
---                              be after a pattern.
+-- /[gmiyuvsd]*\s*[\n,;\)\]\}\.]) will match the end of pattern delimiter, optionally
+--                                followed by pattern options, and anything that can
+--                                be after a pattern.
 --
 -- Demo with some unit tests (click on the Unit Tests entry): https://regex101.com/r/R0w8Qw/1
 -- Note that it has a couple of changes to make it work on that platform.
 local regex_pattern = {
-  [=[/(?=(?!/)(?:(?>[^\\[\/]++|\\.|\[(?:[^\\\]]++|\\.)*+\])*+)++/[gmiyuvsd]*\s*[\n,;\)\]\}])()]=],
+  [=[/(?=(?!/)(?:(?>[^\\[\/]++|\\.|\[(?:[^\\\]]++|\\.)*+\])*+)++/[gmiyuvsd]*\s*[\n,;\)\]\}\.])()]=],
   "/()[gmiyuvsd]*", "\\"
 }
 


### PR DESCRIPTION
This should improve regex constant detection in js.

Before:
![Schermata del 2023-08-13 18-31-41](https://github.com/lite-xl/lite-xl/assets/2798487/72631bb1-dd4b-4503-b586-f68cff484f3f)

After:
![Schermata del 2023-08-13 18-32-22](https://github.com/lite-xl/lite-xl/assets/2798487/2af4d48c-8780-41dc-b2da-2414acbf8b9b)

Fixes #1580.

The initial `(?<=^|[(,;=])` doesn't really work, because #860 makes the regex engine only receive the part we're trying to match, so the lookbehind doesn't work properly.
We could solve this by using subsyntaxes, but this would make the plugin way more complex, or by reverting #860, but we'd need to find a different solution for the problem it fixes.