### PR TITLE
fix(core): defer core:open-log until everything is loaded

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -810,6 +810,8 @@ function core.init()
   end
 
   if not plugins_success or got_user_error or got_project_error then
+    -- defer LogView to after everything is initialized,
+    -- so that EmptyView won't be added after LogView.
     core.add_thread(function()
       command.perform("core:open-log")
     end)

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -810,7 +810,9 @@ function core.init()
   end
 
   if not plugins_success or got_user_error or got_project_error then
-    command.perform("core:open-log")
+    core.add_thread(function()
+      command.perform("core:open-log")
+    end)
   end
 
   core.configure_borderless_window()


### PR DESCRIPTION
Complements #1569.

If a plugin / user module fails to load, the LogView is opened immediately, causing EmptyView to come later and adds a tab to the current Node. This prevents it by just opening LogView after EmptyView is displayed.