### PR TITLE
Fix `scrollbar` misinterpreting `percent`

### DIFF
--- a/data/core/scrollbar.lua
+++ b/data/core/scrollbar.lua
@@ -121,7 +121,7 @@ function Scrollbar:_get_thumb_rect_normal()
   across_size = across_size + (expanded_scrollbar_size - scrollbar_size) * self.expand_percent
   return
     nr.across + nr.across_size - across_size,
-    nr.along + self.percent * nr.scrollable * (nr.along_size - along_size) / (sz - nr.along_size),
+    nr.along + self.percent * (nr.along_size - along_size),
     across_size,
     along_size
 end
@@ -237,7 +237,8 @@ end
 function Scrollbar:_on_mouse_moved_normal(x, y, dx, dy)
   if self.dragging then
     local nr = self.normal_rect
-    return common.clamp((y - nr.along + self.drag_start_offset) / nr.along_size, 0, 1)
+    local _, _, _, along_size = self:_get_thumb_rect_normal()
+    return common.clamp((y - nr.along + self.drag_start_offset) / (nr.along_size - along_size), 0, 1)
   end
   return self:_update_hover_status_normal(x, y)
 end
@@ -280,7 +281,7 @@ function Scrollbar:set_size(x, y, w, h, scrollable)
 end
 
 ---Updates the scrollbar location
----@param percent number @number between 0 and 1 representing the position of the middle part of the thumb
+---@param percent number @number between 0 and 1 where 0 means thumb at the top and 1 at the bottom
 function Scrollbar:set_percent(percent)
   self.percent = percent
 end

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -142,14 +142,14 @@ function View:on_mouse_pressed(button, x, y, clicks)
   local result = self.v_scrollbar:on_mouse_pressed(button, x, y, clicks)
   if result then
     if result ~= true then
-      self.scroll.to.y = result * self:get_scrollable_size()
+      self.scroll.to.y = result * (self:get_scrollable_size() - self.size.y)
     end
     return true
   end
   result = self.h_scrollbar:on_mouse_pressed(button, x, y, clicks)
   if result then
     if result ~= true then
-      self.scroll.to.x = result * self:get_h_scrollable_size()
+      self.scroll.to.x = result * (self:get_h_scrollable_size() - self.size.x)
     end
     return true
   end
@@ -177,7 +177,7 @@ function View:on_mouse_moved(x, y, dx, dy)
   result = self.v_scrollbar:on_mouse_moved(x, y, dx, dy)
   if result then
     if result ~= true then
-      self.scroll.to.y = result * self:get_scrollable_size()
+      self.scroll.to.y = result * (self:get_scrollable_size() - self.size.y)
       if not config.animate_drag_scroll then
         self:clamp_scroll_position()
         self.scroll.y = self.scroll.to.y
@@ -191,7 +191,7 @@ function View:on_mouse_moved(x, y, dx, dy)
   result = self.h_scrollbar:on_mouse_moved(x, y, dx, dy)
   if result then
     if result ~= true then
-      self.scroll.to.x = result * self:get_h_scrollable_size()
+      self.scroll.to.x = result * (self:get_h_scrollable_size() - self.size.x)
       if not config.animate_drag_scroll then
         self:clamp_scroll_position()
         self.scroll.x = self.scroll.to.x
@@ -287,12 +287,12 @@ end
 function View:update_scrollbar()
   local v_scrollable = self:get_scrollable_size()
   self.v_scrollbar:set_size(self.position.x, self.position.y, self.size.x, self.size.y, v_scrollable)
-  self.v_scrollbar:set_percent(self.scroll.y/v_scrollable)
+  self.v_scrollbar:set_percent(self.scroll.y/(v_scrollable - self.size.y))
   self.v_scrollbar:update()
 
   local h_scrollable = self:get_h_scrollable_size()
   self.h_scrollbar:set_size(self.position.x, self.position.y, self.size.x, self.size.y, h_scrollable)
-  self.h_scrollbar:set_percent(self.scroll.x/h_scrollable)
+  self.h_scrollbar:set_percent(self.scroll.x/(h_scrollable - self.size.x))
   self.h_scrollbar:update()
 end
 


### PR DESCRIPTION
Probably needs a modversion bump.

With this we should now be able to properly fix the minimap issue lite-xl/lite-xl-plugins#169.