### PR TITLE
Use `\r\n` for new files on Windows

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -153,6 +153,12 @@ config.tab_type = "soft"
 ---@type boolean
 config.keep_newline_whitespace = false
 
+---Default line endings for new files.
+---
+---Defaults to `crlf` (`\r\n`) on Windows and `lf` (`\n`) on everything else.
+---@type "crlf" | "lf"
+config.line_endings = PLATFORM == "Windows" and "crlf" or "lf"
+
 ---Maximum number of characters per-line for the line guide.
 ---
 ---Defaults to 80.

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -27,6 +27,9 @@ function Doc:new(filename, abs_filename, new_file)
       self:load(filename)
     end
   end
+  if new_file then
+    self.crlf = PLATFORM == "Windows"
+  end
 end
 
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -28,7 +28,7 @@ function Doc:new(filename, abs_filename, new_file)
     end
   end
   if new_file then
-    self.crlf = PLATFORM == "Windows"
+    self.crlf = config.line_endings == "crlf"
   end
 end
 


### PR DESCRIPTION
I wonder if this should be an option.