### PR TITLE
Mark unsaved named files as dirty

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -123,6 +123,7 @@ end
 
 function Doc:is_dirty()
   if self.new_file then
+    if self.filename then return true end
     return #self.lines > 1 or #self.lines[1] > 1
   else
     return self.clean_change_id ~= self:get_change_id()


### PR DESCRIPTION
Unnamed files are marked as not dirty when empty to avoid unnecessary prompts when closing them.
New unsaved named files should be marked as dirty as the user probably created the file for a reason, even if they haven't added anything in there yet, and should be asked to save it to create the actual file.