### PR TITLE
Fix `core.redraw` when window is not focused

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1422,11 +1422,11 @@ local run_threads = coroutine.wrap(function()
 
       -- stop running threads if we're about to hit the end of frame
       if system.get_time() - core.frame_start > max_time then
-        coroutine.yield(0)
+        coroutine.yield(0, false)
       end
     end
 
-    coroutine.yield(minimal_time_to_wake)
+    coroutine.yield(minimal_time_to_wake, true)
   end
 end)
 
@@ -1434,9 +1434,13 @@ end)
 function core.run()
   local next_step
   local last_frame_time
+  local run_threads_full = 0
   while true do
     core.frame_start = system.get_time()
-    local time_to_wake = run_threads()
+    local time_to_wake, threads_done = run_threads()
+    if threads_done then
+      run_threads_full = run_threads_full + 1
+    end
     local did_redraw = false
     local did_step = false
     local force_draw = core.redraw and last_frame_time and core.frame_start - last_frame_time > (1 / config.fps)
@@ -1451,7 +1455,7 @@ function core.run()
     if core.restart_request or core.quit_request then break end
 
     if not did_redraw then
-      if system.window_has_focus() or not did_step then
+      if system.window_has_focus() or not did_step or run_threads_full < 2 then
         local now = system.get_time()
         if not next_step then -- compute the time until the next blink
           local t = now - core.blink_start
@@ -1468,6 +1472,7 @@ function core.run()
         next_step = nil -- perform a step when we're not in focus if get we an event
       end
     else -- if we redrew, then make sure we only draw at most FPS/sec
+      run_threads_full = 0
       local now = system.get_time()
       local elapsed = now - core.frame_start
       local next_frame = math.max(0, 1 / config.fps - elapsed)

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1438,6 +1438,7 @@ function core.run()
     core.frame_start = system.get_time()
     local time_to_wake = run_threads()
     local did_redraw = false
+    local did_step = false
     local force_draw = core.redraw and last_frame_time and core.frame_start - last_frame_time > (1 / config.fps)
     if force_draw or not next_step or system.get_time() >= next_step then
       if core.step() then
@@ -1445,11 +1446,12 @@ function core.run()
         last_frame_time = core.frame_start
       end
       next_step = nil
+      did_step = true
     end
     if core.restart_request or core.quit_request then break end
 
     if not did_redraw then
-      if system.window_has_focus() then
+      if system.window_has_focus() or not did_step then
         local now = system.get_time()
         if not next_step then -- compute the time until the next blink
           local t = now - core.blink_start


### PR DESCRIPTION
Fixes #1466.

Now when the window loses focus, `core.step` is executed at least once, to check if anything sets `core.redraw`.

A similar thing is done to `run_threads`, which are now executed *fully* at least once.