### PR TITLE
Improve font/color change detection in `language_md`

### DIFF
--- a/data/plugins/language_md.lua
+++ b/data/plugins/language_md.lua
@@ -5,23 +5,6 @@ local core = require "core"
 
 local initial_color = style.syntax["keyword2"]
 
--- Add 3 type of font styles for use on markdown files
-for _, attr in pairs({"bold", "italic", "bold_italic"}) do
-  local attributes = {}
-  if attr ~= "bold_italic" then
-    attributes[attr] = true
-  else
-    attributes["bold"] = true
-    attributes["italic"] = true
-  end
-  style.syntax_fonts["markdown_"..attr] = style.code_font:copy(
-    style.code_font:get_size(),
-    attributes
-  )
-  -- also add a color for it
-  style.syntax["markdown_"..attr] = style.syntax["keyword2"]
-end
-
 local in_squares_match = "^%[%]"
 local in_parenthesis_match = "^%(%)"
 
@@ -225,6 +208,23 @@ syntax.add {
 
 -- Adjust the color on theme changes
 core.add_thread(function()
+  -- Add 3 type of font styles for use on markdown files
+  for _, attr in pairs({"bold", "italic", "bold_italic"}) do
+    local attributes = {}
+    if attr ~= "bold_italic" then
+      attributes[attr] = true
+    else
+      attributes["bold"] = true
+      attributes["italic"] = true
+    end
+    style.syntax_fonts["markdown_"..attr] = style.code_font:copy(
+      style.code_font:get_size(),
+      attributes
+    )
+    -- also add a color for it
+    style.syntax["markdown_"..attr] = style.syntax["keyword2"]
+  end
+
   while true do
     if initial_color ~= style.syntax["keyword2"] then
       for _, attr in pairs({"bold", "italic", "bold_italic"}) do

--- a/data/plugins/language_md.lua
+++ b/data/plugins/language_md.lua
@@ -3,8 +3,6 @@ local syntax = require "core.syntax"
 local style = require "core.style"
 local core = require "core"
 
-local initial_color = style.syntax["keyword2"]
-
 local in_squares_match = "^%[%]"
 local in_parenthesis_match = "^%(%)"
 
@@ -208,8 +206,11 @@ syntax.add {
 
 -- Adjust the color on theme changes
 core.add_thread(function()
-  -- Add 3 type of font styles for use on markdown files
-  for _, attr in pairs({"bold", "italic", "bold_italic"}) do
+  local custom_fonts = { bold = {font = nil, color = nil}, italic = {}, bold_italic = {} }
+  local initial_color
+  local last_code_font
+
+  local function set_font(attr)
     local attributes = {}
     if attr ~= "bold_italic" then
       attributes[attr] = true
@@ -217,20 +218,51 @@ core.add_thread(function()
       attributes["bold"] = true
       attributes["italic"] = true
     end
-    style.syntax_fonts["markdown_"..attr] = style.code_font:copy(
+    local font = style.code_font:copy(
       style.code_font:get_size(),
       attributes
     )
-    -- also add a color for it
+    custom_fonts[attr].font = font
+    style.syntax_fonts["markdown_"..attr] = font
+  end
+
+  local function set_color(attr)
+    custom_fonts[attr].color = style.syntax["keyword2"]
     style.syntax["markdown_"..attr] = style.syntax["keyword2"]
   end
 
+  -- Add 3 type of font styles for use on markdown files
+  for attr, _ in pairs(custom_fonts) do
+    -- Only set it if the font wasn't manually customized
+    if not style.syntax_fonts["markdown_"..attr] then
+      set_font(attr)
+    end
+
+    -- Only set it if the color wasn't manually customized
+    if not style.syntax["markdown_"..attr] then
+      set_color(attr)
+    end
+  end
+
   while true do
-    if initial_color ~= style.syntax["keyword2"] then
-      for _, attr in pairs({"bold", "italic", "bold_italic"}) do
-        style.syntax["markdown_"..attr] = style.syntax["keyword2"]
+    if last_code_font ~= style.code_font then
+      last_code_font = style.code_font
+      for attr, _ in pairs(custom_fonts) do
+        -- Only set it if the font wasn't manually customized
+        if style.syntax_fonts["markdown_"..attr] == custom_fonts[attr].font then
+          set_font(attr)
+        end
       end
+    end
+
+    if initial_color ~= style.syntax["keyword2"] then
       initial_color = style.syntax["keyword2"]
+      for attr, _ in pairs(custom_fonts) do
+        -- Only set it if the color wasn't manually customized
+        if style.syntax["markdown_"..attr] == custom_fonts[attr].color then
+          set_color(attr)
+        end
+      end
     end
     coroutine.yield(1)
   end


### PR DESCRIPTION
This fixes issues for users that changed the code font from the `settings` plugin.

This should also allow manually setting the font and color for markdown specific token types.