### PR TITLE
Use x offset to define render command rect in `rencache_draw_text`

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -198,7 +198,7 @@ static int f_font_get_width(lua_State *L) {
   size_t len;
   const char *text = luaL_checklstring(L, 2, &len);
 
-  lua_pushnumber(L, ren_font_group_get_width(&window_renderer, fonts, text, len));
+  lua_pushnumber(L, ren_font_group_get_width(&window_renderer, fonts, text, len, NULL));
   return 1;
 }
 

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -191,7 +191,7 @@ void rencache_draw_rect(RenWindow *window_renderer, RenRect rect, RenColor color
 
 double rencache_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, double x, int y, RenColor color)
 {
-  double width = ren_font_group_get_width(window_renderer, fonts, text, len);
+  double width = ren_font_group_get_width(window_renderer, fonts, text, len, NULL);
   RenRect rect = { x, y, (int)width, ren_font_group_get_height(fonts) };
   if (rects_overlap(last_clip_rect, rect)) {
     int sz = len + 1;

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -191,8 +191,9 @@ void rencache_draw_rect(RenWindow *window_renderer, RenRect rect, RenColor color
 
 double rencache_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, double x, int y, RenColor color)
 {
-  double width = ren_font_group_get_width(window_renderer, fonts, text, len, NULL);
-  RenRect rect = { x, y, (int)width, ren_font_group_get_height(fonts) };
+  int x_offset;
+  double width = ren_font_group_get_width(window_renderer, fonts, text, len, &x_offset);
+  RenRect rect = { x + x_offset, y, (int)(width - x_offset), ren_font_group_get_height(fonts) };
   if (rects_overlap(last_clip_rect, rect)) {
     int sz = len + 1;
     DrawTextCommand *cmd = push_command(window_renderer, DRAW_TEXT, sizeof(DrawTextCommand) + sz);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -348,10 +348,11 @@ int ren_font_group_get_height(RenFont **fonts) {
   return fonts[0]->height;
 }
 
-double ren_font_group_get_width(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len) {
+double ren_font_group_get_width(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, int *x_offset) {
   double width = 0;
   const char* end = text + len;
   GlyphMetric* metric = NULL; GlyphSet* set = NULL;
+  bool set_x_offset = x_offset == NULL;
   while (text < end) {
     unsigned int codepoint;
     text = utf8_to_codepoint(text, &codepoint);
@@ -359,8 +360,15 @@ double ren_font_group_get_width(RenWindow *window_renderer, RenFont **fonts, con
     if (!metric)
       break;
     width += (!font || metric->xadvance) ? metric->xadvance : fonts[0]->space_advance;
+    if (!set_x_offset) {
+      set_x_offset = true;
+      *x_offset = metric->bitmap_left; // TODO: should this be scaled by the surface scale?
+    }
   }
   const int surface_scale = renwin_get_surface(window_renderer).scale;
+  if (!set_x_offset) {
+    *x_offset = 0;
+  }
   return width / surface_scale;
 }
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -34,7 +34,7 @@ int ren_font_group_get_height(RenFont **font);
 float ren_font_group_get_size(RenFont **font);
 void ren_font_group_set_size(RenWindow *window_renderer, RenFont **font, float size);
 void ren_font_group_set_tab_size(RenFont **font, int n);
-double ren_font_group_get_width(RenWindow *window_renderer, RenFont **font, const char *text, size_t len);
+double ren_font_group_get_width(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, int *x_offset);
 double ren_draw_text(RenSurface *rs, RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
 
 void ren_draw_rect(RenSurface *rs, RenRect rect, RenColor color);


### PR DESCRIPTION
When using antialiasing the text can be drawn "outside" the command rect.
This causes some rencache rects not being updated.

I wonder if we should only consider `x_offset` when it's negative, and ignore it otherwise.