### PR TITLE
Remove DPI detection for default `SCALE`

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -5,7 +5,7 @@ MOD_VERSION_MINOR = 0
 MOD_VERSION_PATCH = 0
 MOD_VERSION_STRING = string.format("%d.%d.%d", MOD_VERSION_MAJOR, MOD_VERSION_MINOR, MOD_VERSION_PATCH)
 
-SCALE = tonumber(os.getenv("LITE_SCALE") or os.getenv("GDK_SCALE") or os.getenv("QT_SCALE_FACTOR")) or SCALE
+SCALE = tonumber(os.getenv("LITE_SCALE") or os.getenv("GDK_SCALE") or os.getenv("QT_SCALE_FACTOR")) or 1
 PATHSEP = package.config:sub(1, 1)
 
 EXEDIR = EXEFILE:match("^(.+)[/\\][^/\\]+$")

--- a/src/main.c
+++ b/src/main.c
@@ -20,16 +20,6 @@
 
 static SDL_Window *window;
 
-static double get_scale(void) {
-#ifndef __APPLE__
-  float dpi;
-  if (SDL_GetDisplayDPI(0, NULL, &dpi, NULL) == 0)
-    return dpi / 96.0;
-#endif
-  return 1.0;
-}
-
-
 static void get_exe_filename(char *buf, int sz) {
 #if _WIN32
   int len;
@@ -202,9 +192,6 @@ init_lua:
 
   lua_pushstring(L, LITE_ARCH_TUPLE);
   lua_setglobal(L, "ARCH");
-
-  lua_pushnumber(L, get_scale());
-  lua_setglobal(L, "SCALE");
 
   char exename[2048];
   get_exe_filename(exename, sizeof(exename));


### PR DESCRIPTION
This often leads to `SCALE` values that are way off, and makes Lite XL  unusable, so we now just default it to 1.

This is a re-proposition of #1248.