### PR TITLE
Scale mouse coordinates by window scale

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -225,8 +225,8 @@ top:
       SDL_GetMouseState(&mx, &my);
       lua_pushstring(L, "filedropped");
       lua_pushstring(L, e.drop.file);
-      lua_pushinteger(L, mx);
-      lua_pushinteger(L, my);
+      lua_pushinteger(L, mx * window_renderer.scale_x);
+      lua_pushinteger(L, my * window_renderer.scale_y);
       SDL_free(e.drop.file);
       return 4;
 
@@ -283,8 +283,8 @@ top:
       if (e.button.button == 1) { SDL_CaptureMouse(1); }
       lua_pushstring(L, "mousepressed");
       lua_pushstring(L, button_name(e.button.button));
-      lua_pushinteger(L, e.button.x);
-      lua_pushinteger(L, e.button.y);
+      lua_pushinteger(L, e.button.x * window_renderer.scale_x);
+      lua_pushinteger(L, e.button.y * window_renderer.scale_y);
       lua_pushinteger(L, e.button.clicks);
       return 5;
 
@@ -292,8 +292,8 @@ top:
       if (e.button.button == 1) { SDL_CaptureMouse(0); }
       lua_pushstring(L, "mousereleased");
       lua_pushstring(L, button_name(e.button.button));
-      lua_pushinteger(L, e.button.x);
-      lua_pushinteger(L, e.button.y);
+      lua_pushinteger(L, e.button.x * window_renderer.scale_x);
+      lua_pushinteger(L, e.button.y * window_renderer.scale_y);
       return 4;
 
     case SDL_MOUSEMOTION:
@@ -305,10 +305,10 @@ top:
         e.motion.yrel += event_plus.motion.yrel;
       }
       lua_pushstring(L, "mousemoved");
-      lua_pushinteger(L, e.motion.x);
-      lua_pushinteger(L, e.motion.y);
-      lua_pushinteger(L, e.motion.xrel);
-      lua_pushinteger(L, e.motion.yrel);
+      lua_pushinteger(L, e.motion.x * window_renderer.scale_x);
+      lua_pushinteger(L, e.motion.y * window_renderer.scale_y);
+      lua_pushinteger(L, e.motion.xrel * window_renderer.scale_x);
+      lua_pushinteger(L, e.motion.yrel * window_renderer.scale_y);
       return 5;
 
     case SDL_MOUSEWHEEL:

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -520,6 +520,7 @@ void ren_init(SDL_Window *win) {
 
 void ren_resize_window(RenWindow *window_renderer) {
   renwin_resize_surface(window_renderer);
+  renwin_update_scale(window_renderer);
 }
 
 

--- a/src/renwindow.c
+++ b/src/renwindow.c
@@ -29,7 +29,8 @@ static void setup_renderer(RenWindow *ren, int w, int h) {
 #endif
 
 
-void renwin_init_surface(UNUSED RenWindow *ren) {
+void renwin_init_surface(RenWindow *ren) {
+  ren->scale_x = ren->scale_y = 1;
 #ifdef LITE_USE_SDL_RENDERER
   if (ren->rensurface.surface) {
     SDL_FreeSurface(ren->rensurface.surface);
@@ -96,11 +97,13 @@ void renwin_resize_surface(UNUSED RenWindow *ren) {
 }
 
 void renwin_update_scale(RenWindow *ren) {
+#ifndef LITE_USE_SDL_RENDERER
   SDL_Surface *surface = SDL_GetWindowSurface(ren->window);
   int window_w = surface->w, window_h = surface->h;
   SDL_GetWindowSize(ren->window, &window_w, &window_h);
   ren->scale_x = (float)surface->w / window_w;
   ren->scale_y = (float)surface->h / window_h;
+#endif
 }
 
 void renwin_show_window(RenWindow *ren) {

--- a/src/renwindow.c
+++ b/src/renwindow.c
@@ -95,6 +95,14 @@ void renwin_resize_surface(UNUSED RenWindow *ren) {
 #endif
 }
 
+void renwin_update_scale(RenWindow *ren) {
+  SDL_Surface *surface = SDL_GetWindowSurface(ren->window);
+  int window_w = surface->w, window_h = surface->h;
+  SDL_GetWindowSize(ren->window, &window_w, &window_h);
+  ren->scale_x = (float)surface->w / window_w;
+  ren->scale_y = (float)surface->h / window_h;
+}
+
 void renwin_show_window(RenWindow *ren) {
   SDL_ShowWindow(ren->window);
 }

--- a/src/renwindow.h
+++ b/src/renwindow.h
@@ -6,6 +6,8 @@ struct RenWindow {
   uint8_t *command_buf;
   size_t command_buf_idx;
   size_t command_buf_size;
+  float scale_x;
+  float scale_y;
 #ifdef LITE_USE_SDL_RENDERER
   SDL_Renderer *renderer;
   SDL_Texture *texture;
@@ -19,6 +21,7 @@ void renwin_init_command_buf(RenWindow *ren);
 void renwin_clip_to_surface(RenWindow *ren);
 void renwin_set_clip_rect(RenWindow *ren, RenRect rect);
 void renwin_resize_surface(RenWindow *ren);
+void renwin_update_scale(RenWindow *ren);
 void renwin_show_window(RenWindow *ren);
 void renwin_update_rects(RenWindow *ren, RenRect *rects, int count);
 void renwin_free(RenWindow *ren);


### PR DESCRIPTION
Fixes #1628.

This hasn't been tested with `LITE_USE_SDL_RENDERER`, on Windows and on macOS yet.

This scale can probably be used to set `SCALE` too.