### PR TITLE
Add support for relative `require`s

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -1,6 +1,6 @@
 local Object = require "core.object"
-local Highlighter = require "core.doc.highlighter"
-local translate = require "core.doc.translate"
+local Highlighter = require ".highlighter"
+local translate = require ".translate"
 local core = require "core"
 local syntax = require "core.syntax"
 local config = require "core.config"


### PR DESCRIPTION
This keeps a stack of `require` "paths", and uses the topmost one when resolving relative requires to calculate the "absolute path".

From inside `"path_1.path_2"`:
* Calling `require ".b"` will require `"path_1.path_2.b"`.
* Calling `require "..b"` will require `"path_1.b"`.

This has a few caveats:
1. The relative `require` must be called "inside" the parent `require`; this means that `require`s called "later" will have the wrong path.
   So:
   ```lua
   require ".b" -- OK
   
   local function blabla()
     require ".c" -- Not OK
   end
   ```
3. The path traversal is limited by the parent path; so if the parent path is `core.plugins` and the relative path is `.......plugin_name`, the resulting path is `plugin_name`.

(2) might be considered a feature, to limit the require range and not go outside our managed directories (even thought a plugin could still add its own custom search path).

To provide a workaround for (1), I added `get_current_require_path` which will return the topmost path in the stack. This still needs to be called inside the parent `require`, but its result can be used later.
So:
```lua
require ".b" -- OK
local path = get_current_require_path() -- OK

local function blabla()
  require ".c" -- Not OK
  require(path .. ".c") -- OK
  get_current_require_path() -- Not OK
end
```


Suggestions for a better name for `get_current_require_path` are welcome.
Should we also add a `level` parameter to `get_current_require_path`, so that path traversal doesn't need to be implemented by each plugin that uses it?

EDIT: If we want to avoid using `pcall`, we could use a to-be-closed object that does the stack popping.