### PR TITLE
docs: fix prebuilt install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ If `$HOME/.local/bin` is not in PATH:
 echo -e 'export PATH=$PATH:$HOME/.local/bin' >> $HOME/.bashrc
 ```
 
-On recent versions of GNOME and KDE Plasma,
+Alternatively on recent versions of GNOME and KDE Plasma,
 you can add `$HOME/.local/bin` to PATH via `~/.config/environment.d/envvars.conf`:
 
 ```ini

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Alternatively, we provide ZIP archives that you can download and extract anywher
 
 To make Lite XL portable (e.g. running Lite XL from a thumb drive),
 simply create a `user` folder where `lite-xl.exe` is located.
+Lite XL will load and store all your configurations and plugins in the folder.
 
 ### macOS
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Lite XL will load and store all your configurations and plugins in the folder.
 We provide DMG files for macOS. Simply drag the program into your Applications folder.
 
 > **Important**
-> Since Lite XL is no longer signed, you **must** run this command before starting Lite XL:
+> Since Lite XL is not signed, you **must** run this command before starting Lite XL:
 > 
 > ```sh
 > # clears attributes from the directory

--- a/README.md
+++ b/README.md
@@ -81,6 +81,27 @@ affects only the place where the application is actually installed.
 
 Head over to [releases](https://github.com/lite-xl/lite-xl/releases) and download the version for your operating system.
 
+### Windows
+
+Lite XL comes with installers on Windows for typical installations.
+Alternatively, we provide ZIP archives that you can download and extract it anywhere and run directly.
+
+To make the installation portable, simply create a `user` folder where `lite-xl.exe` is located.
+
+### macOS
+
+We provide DMG files for macOS. Simply drag the program into your Applications folder.
+
+> **Important**
+> Since Lite XL is no longer signed, you **must** run this command before starting Lite XL:
+> 
+> ```sh
+> # clears attributes from the directory
+> xattr -cr /Applications/Lite\ XL.app
+> ```
+>
+> Otherwise, macOS will display a **very misleading error** saying that the application is damaged.
+
 ### Linux
 
 Unzip the file and `cd` into the `lite-xl` directory:
@@ -103,21 +124,50 @@ mkdir -p $HOME/.local/bin && cp lite-xl $HOME/.local/bin/
 mkdir -p $HOME/.local/share/lite-xl && cp -r data/* $HOME/.local/share/lite-xl/
 ```
 
+#### Add Lite XL to PATH
+
 If `$HOME/.local/bin` is not in PATH:
 
 ```sh
 echo -e 'export PATH=$PATH:$HOME/.local/bin' >> $HOME/.bashrc
 ```
 
-To get the icon to show up in app launcher:
+> **Note**
+> Some systems might not load `.bashrc` when logging in.
+> This can cause problems with launching applications from the desktop / menu.
+
+#### Add Lite XL to application launchers
+
+To get the icon to show up in app launcher, you need to create a desktop
+entry and put it into `/usr/share/applications` or `~/.local/share/applications`.
+
+Here is an example of the desktop entry, assuming Lite XL is in PATH:
+
+```ini
+# com.lite_xl.LiteXL.desktop
+[Desktop Entry]
+Type=Application
+Name=Lite XL
+Comment=A lightweight text editor written in Lua
+Exec=lite-xl %F
+Icon=lite-xl
+Terminal=false
+StartupWMClass=lite-xl
+Categories=Development;IDE;
+MimeType=text/plain;inode/directory;
+```
+
+To get the icon to show up in app launcher immediately, run:
 
 ```sh
 xdg-desktop-menu forceupdate
 ```
 
-You may need to logout and login again to see icon in app launcher.
+Alternatively, you may log out and log in again for the icon to show up.
 
-To uninstall just run:
+#### Uninstall
+
+To uninstall Lite XL, just run:
 
 ```sh
 rm -f $HOME/.local/bin/lite-xl
@@ -126,7 +176,6 @@ rm -rf $HOME/.local/share/icons/hicolor/scalable/apps/lite-xl.svg \
           $HOME/.local/share/metainfo/com.lite_xl.LiteXL.appdata.xml \
           $HOME/.local/share/lite-xl
 ```
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ Head over to [releases](https://github.com/lite-xl/lite-xl/releases) and downloa
 ### Windows
 
 Lite XL comes with installers on Windows for typical installations.
-Alternatively, we provide ZIP archives that you can download and extract it anywhere and run directly.
+Alternatively, we provide ZIP archives that you can download and extract anywhere and run directly.
 
-To make the installation portable, simply create a `user` folder where `lite-xl.exe` is located.
+To make Lite XL portable (e.g. running Lite XL from a thumb drive),
+simply create a `user` folder where `lite-xl.exe` is located.
 
 ### macOS
 
@@ -112,6 +113,7 @@ cd lite-xl
 ```
 
 To run lite-xl without installing:
+
 ```sh
 ./lite-xl
 ```
@@ -126,10 +128,19 @@ mkdir -p $HOME/.local/share/lite-xl && cp -r data/* $HOME/.local/share/lite-xl/
 
 #### Add Lite XL to PATH
 
+To run Lite XL from the command line, you must add it to PATH.
+
 If `$HOME/.local/bin` is not in PATH:
 
 ```sh
 echo -e 'export PATH=$PATH:$HOME/.local/bin' >> $HOME/.bashrc
+```
+
+On recent versions of GNOME and KDE Plasma,
+you can add `$HOME/.local/bin` to PATH via `~/.config/environment.d/envvars.conf`:
+
+```ini
+PATH=$HOME/.local/bin:$PATH
 ```
 
 > **Note**
@@ -141,10 +152,10 @@ echo -e 'export PATH=$PATH:$HOME/.local/bin' >> $HOME/.bashrc
 To get the icon to show up in app launcher, you need to create a desktop
 entry and put it into `/usr/share/applications` or `~/.local/share/applications`.
 
-Here is an example of the desktop entry, assuming Lite XL is in PATH:
+Here is an example for a desktop entry in `~/.local/share/applications/com.lite_xl.LiteXL.desktop`,
+assuming Lite XL is in PATH:
 
 ```ini
-# com.lite_xl.LiteXL.desktop
 [Desktop Entry]
 Type=Application
 Name=Lite XL
@@ -163,11 +174,11 @@ To get the icon to show up in app launcher immediately, run:
 xdg-desktop-menu forceupdate
 ```
 
-Alternatively, you may log out and log in again for the icon to show up.
+Alternatively, you may log out and log in again.
 
 #### Uninstall
 
-To uninstall Lite XL, just run:
+To uninstall Lite XL, run:
 
 ```sh
 rm -f $HOME/.local/bin/lite-xl


### PR DESCRIPTION
Added missing documentation for Windows and macOS. Also updated the Linux instruction for creating desktop entries.