### PR TITLE
Set SDL hint to prefer software render driver

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -160,6 +160,8 @@ int main(int argc, char **argv) {
   SDL_SetHint("SDL_MOUSE_DOUBLE_CLICK_RADIUS", "4");
 #endif
 
+  SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+
   SDL_DisplayMode dm;
   SDL_GetCurrentDisplayMode(0, &dm);
 


### PR DESCRIPTION
As proposed by @Jan200101, supposedly reducing startup times.

Needs to be tested for performance regressions and effects on platforms that use the `RENDERER` code path.