### PR TITLE
ci: fix diff files having "wrong" path separator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,12 +201,13 @@ jobs:
           "INSTALL_NAME=lite-xl-$($env:GITHUB_REF -replace ".*/")-windows-msvc-${{ matrix.arch.name }}" >> $env:GITHUB_ENV
           "INSTALL_REF=$($env:GITHUB_REF -replace ".*/")" >> $env:GITHUB_ENV
           "LUA_SUBPROJECT_PATH=subprojects/lua-5.4.4" >> $env:GITHUB_ENV
+      - name: Download and configure subprojects
+        shell: bash
+        run: |
+          meson subprojects download
+          cat resources/windows/001-lua-unicode.diff | patch -Np1 -d "$LUA_SUBPROJECT_PATH"
       - name: Configure
         run: |
-          # Download the subprojects first so we can patch it before configuring.
-          # This avoids reconfiguring the subprojects when compiling.
-          meson subprojects download
-          Get-Content -Path resources/windows/001-lua-unicode.diff -Raw | patch -d $env:LUA_SUBPROJECT_PATH -p1 --forward
           meson setup --wrap-mode=forcefallback build
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
           "INSTALL_NAME=lite-xl-$($env:GITHUB_REF -replace ".*/")-windows-msvc-${{ matrix.arch.name }}" >> $env:GITHUB_ENV
           "INSTALL_REF=$($env:GITHUB_REF -replace ".*/")" >> $env:GITHUB_ENV
           "LUA_SUBPROJECT_PATH=subprojects/lua-5.4.4" >> $env:GITHUB_ENV
-      - name: Download and configure subprojects
+      - name: Download and patch subprojects
         shell: bash
         run: |
           meson subprojects download

--- a/resources/windows/001-lua-unicode.diff
+++ b/resources/windows/001-lua-unicode.diff
@@ -1,6 +1,6 @@
-diff -ruN lua-5.4.4\meson.build lua-5.4.4-patched\meson.build
---- lua-5.4.4\meson.build	Wed Feb 22 18:16:56 2023
-+++ lua-5.4.4-patched\meson.build	Wed Feb 22 04:10:01 2023
+diff -ruN lua-5.4.4/meson.build lua-5.4.4-patched/meson.build
+--- lua-5.4.4/meson.build	Wed Feb 22 18:16:56 2023
++++ lua-5.4.4-patched/meson.build	Wed Feb 22 04:10:01 2023
 @@ -85,6 +85,7 @@
    'src/lutf8lib.c',
    'src/lvm.c',
@@ -9,9 +9,9 @@ diff -ruN lua-5.4.4\meson.build lua-5.4.4-patched\meson.build
    dependencies: lua_lib_deps,
    version: meson.project_version(),
    soversion: lua_versions[0] + '.' + lua_versions[1],
-diff -ruN lua-5.4.4\src\luaconf.h lua-5.4.4-patched\src\luaconf.h
---- lua-5.4.4\src\luaconf.h	Thu Jan 13 19:24:43 2022
-+++ lua-5.4.4-patched\src\luaconf.h	Wed Feb 22 04:10:02 2023
+diff -ruN lua-5.4.4/src/luaconf.h lua-5.4.4-patched/src/luaconf.h
+--- lua-5.4.4/src/luaconf.h	Thu Jan 13 19:24:43 2022
++++ lua-5.4.4-patched/src/luaconf.h	Wed Feb 22 04:10:02 2023
 @@ -782,5 +782,15 @@
  
  
@@ -28,9 +28,9 @@ diff -ruN lua-5.4.4\src\luaconf.h lua-5.4.4-patched\src\luaconf.h
 +
  #endif
  
-diff -ruN lua-5.4.4\src\Makefile lua-5.4.4-patched\src\Makefile
---- lua-5.4.4\src\Makefile	Thu Jul 15 22:01:52 2021
-+++ lua-5.4.4-patched\src\Makefile	Wed Feb 22 04:10:02 2023
+diff -ruN lua-5.4.4/src/Makefile lua-5.4.4-patched/src/Makefile
+--- lua-5.4.4/src/Makefile	Thu Jul 15 22:01:52 2021
++++ lua-5.4.4-patched/src/Makefile	Wed Feb 22 04:10:02 2023
 @@ -33,7 +33,7 @@
  PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
  
@@ -40,9 +40,9 @@ diff -ruN lua-5.4.4\src\Makefile lua-5.4.4-patched\src\Makefile
  LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
  BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
  
-diff -ruN lua-5.4.4\src\utf8_wrappers.c lua-5.4.4-patched\src\utf8_wrappers.c
---- lua-5.4.4\src\utf8_wrappers.c	Thu Jan 01 08:00:00 1970
-+++ lua-5.4.4-patched\src\utf8_wrappers.c	Wed Feb 22 18:13:45 2023
+diff -ruN lua-5.4.4/src/utf8_wrappers.c lua-5.4.4-patched/src/utf8_wrappers.c
+--- lua-5.4.4/src/utf8_wrappers.c	Thu Jan 01 08:00:00 1970
++++ lua-5.4.4-patched/src/utf8_wrappers.c	Wed Feb 22 18:13:45 2023
 @@ -0,0 +1,129 @@
 +/**
 + * Wrappers to provide Unicode (UTF-8) support on Windows.
@@ -173,9 +173,9 @@ diff -ruN lua-5.4.4\src\utf8_wrappers.c lua-5.4.4-patched\src\utf8_wrappers.c
 +  return env_value;
 +}
 +#endif
-diff -ruN lua-5.4.4\src\utf8_wrappers.h lua-5.4.4-patched\src\utf8_wrappers.h
---- lua-5.4.4\src\utf8_wrappers.h	Thu Jan 01 08:00:00 1970
-+++ lua-5.4.4-patched\src\utf8_wrappers.h	Wed Feb 22 18:09:48 2023
+diff -ruN lua-5.4.4/src/utf8_wrappers.h lua-5.4.4-patched/src/utf8_wrappers.h
+--- lua-5.4.4/src/utf8_wrappers.h	Thu Jan 01 08:00:00 1970
++++ lua-5.4.4-patched/src/utf8_wrappers.h	Wed Feb 22 18:09:48 2023
 @@ -0,0 +1,46 @@
 +/**
 + * Wrappers to provide Unicode (UTF-8) support on Windows.


### PR DESCRIPTION
Apparently a recent update in the runner image uses `patch` from Strawberry Perl, and this version of `patch` does not support backslashes as path separators. This is stupid and should not happen.

EDIT: Turns out the `patch` tool straight up don't work. We just use Git bash's `patch` instead.