### PR TITLE
Update font scale on monitor scale change for `RENDERER` backend (macOS)

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -54,6 +54,9 @@ typedef struct RenFont {
   FT_StreamRec stream;
   GlyphSet* sets[SUBPIXEL_BITMAPS_CACHED][MAX_LOADABLE_GLYPHSETS];
   float size, space_advance, tab_advance;
+#ifdef LITE_USE_SDL_RENDERER
+  int scale;
+#endif
   unsigned short max_height, baseline, height;
   ERenFontAntialiasing antialiasing;
   ERenFontHinting hinting;
@@ -61,6 +64,14 @@ typedef struct RenFont {
   unsigned short underline_thickness;
   char path[];
 } RenFont;
+
+#ifdef LITE_USE_SDL_RENDERER
+void update_font_scale(RenWindow *window_renderer, RenFont **fonts) {
+  const int surface_scale = renwin_get_surface(window_renderer).scale;
+  if (fonts[0]->scale != surface_scale)
+    ren_font_group_set_size(window_renderer, fonts, fonts[0]->size);
+}
+#endif
 
 static const char* utf8_to_codepoint(const char *p, unsigned *dst) {
   const unsigned char *up = (unsigned char*)p;
@@ -336,6 +347,9 @@ void ren_font_group_set_size(RenWindow *window_renderer, RenFont **fonts, float 
     FT_Face face = fonts[i]->face;
     FT_Set_Pixel_Sizes(face, 0, (int)(size*surface_scale));
     fonts[i]->size = size;
+#ifdef LITE_USE_SDL_RENDERER
+    fonts[i]->scale = surface_scale;
+#endif
     fonts[i]->height = (short)((face->height / (float)face->units_per_EM) * size);
     fonts[i]->baseline = (short)((face->ascender / (float)face->units_per_EM) * size);
     FT_Load_Char(face, ' ', font_set_load_options(fonts[i]));

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -68,8 +68,12 @@ typedef struct RenFont {
 #ifdef LITE_USE_SDL_RENDERER
 void update_font_scale(RenWindow *window_renderer, RenFont **fonts) {
   const int surface_scale = renwin_get_surface(window_renderer).scale;
-  if (fonts[0]->scale != surface_scale)
-    ren_font_group_set_size(window_renderer, fonts, fonts[0]->size);
+  for (int i = 0; i < FONT_FALLBACK_MAX && fonts[i]; ++i) {
+    if (fonts[i]->scale != surface_scale) {
+      ren_font_group_set_size(window_renderer, fonts, fonts[0]->size);
+      return;
+    }
+  }
 }
 #endif
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -33,6 +33,9 @@ int ren_font_group_get_tab_size(RenFont **font);
 int ren_font_group_get_height(RenFont **font);
 float ren_font_group_get_size(RenFont **font);
 void ren_font_group_set_size(RenWindow *window_renderer, RenFont **font, float size);
+#ifdef LITE_USE_SDL_RENDERER
+void update_font_scale(RenWindow *window_renderer, RenFont **fonts);
+#endif
 void ren_font_group_set_tab_size(RenFont **font, int n);
 double ren_font_group_get_width(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, int *x_offset);
 double ren_draw_text(RenSurface *rs, RenFont **font, const char *text, size_t len, float x, int y, RenColor color);

--- a/src/renwindow.c
+++ b/src/renwindow.c
@@ -83,12 +83,15 @@ RenSurface renwin_get_surface(RenWindow *ren) {
 #endif
 }
 
-void renwin_resize_surface(UNUSED RenWindow *ren) {
+void renwin_resize_surface(RenWindow *ren) {
 #ifdef LITE_USE_SDL_RENDERER
-  int new_w, new_h;
+  int new_w, new_h, new_scale;
   SDL_GL_GetDrawableSize(ren->window, &new_w, &new_h);
+  new_scale = query_surface_scale(ren);
   /* Note that (w, h) may differ from (new_w, new_h) on retina displays. */
-  if (new_w != ren->rensurface.surface->w || new_h != ren->rensurface.surface->h) {
+  if (new_scale != ren->rensurface.scale ||
+      new_w != ren->rensurface.surface->w ||
+      new_h != ren->rensurface.surface->h) {
     renwin_init_surface(ren);
     renwin_clip_to_surface(ren);
     setup_renderer(ren, new_w, new_h);


### PR DESCRIPTION
Fixes #1282.

This needs testing on macOS.
This also needs performance regression testing.