### PR TITLE
Allow writing to hidden files on Windows

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -103,7 +103,23 @@ function Doc:save(filename, abs_filename)
   else
     assert(self.filename or abs_filename, "calling save on unnamed doc without absolute path")
   end
-  local fp = assert(io.open(filename, "wb"))
+
+  local fp
+  if PLATFORM == "Windows" then
+    -- on Windows, opening a hidden file with wb fails with a permission error.
+    -- to get around this, we must open the file as r+b and truncate.
+    -- since r+b fails if file doesn't exist, fall back to wb.
+    fp = io.open(filename, "r+b")
+    if fp then
+      system.ftruncate(fp, 0)
+    else
+      -- file probably doesn't exist, create one
+      fp = assert ( io.open(filename, "wb") )
+    end
+  else
+    fp = assert ( io.open(filename, "wb") )
+  end
+
   for _, line in ipairs(self.lines) do
     if self.crlf then line = line:gsub("\n", "\r\n") end
     fp:write(line)

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -106,9 +106,9 @@ function Doc:save(filename, abs_filename)
 
   local fp
   if PLATFORM == "Windows" then
-    -- on Windows, opening a hidden file with wb fails with a permission error.
-    -- to get around this, we must open the file as r+b and truncate.
-    -- since r+b fails if file doesn't exist, fall back to wb.
+    -- On Windows, opening a hidden file with wb fails with a permission error.
+    -- To get around this, we must open the file as r+b and truncate.
+    -- Since r+b fails if file doesn't exist, fall back to wb.
     fp = io.open(filename, "r+b")
     if fp then
       system.ftruncate(fp, 0)

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -111,7 +111,7 @@ function Doc:save(filename, abs_filename)
     -- Since r+b fails if file doesn't exist, fall back to wb.
     fp = io.open(filename, "r+b")
     if fp then
-      system.ftruncate(fp, 0)
+      system.ftruncate(fp)
     else
       -- file probably doesn't exist, create one
       fp = assert ( io.open(filename, "wb") )

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -191,6 +191,15 @@ function system.rmdir(path) end
 function system.chdir(path) end
 
 ---
+---Truncates a file to a set length.
+---
+---@param file file* A file handle returned by io.open().
+---@param length integer Number of bytes to truncate to.
+---@return boolean success True if the operation suceeded, false otherwise
+---@return string? message An error message if the operation failed.
+function system.ftruncate(file, length) end
+
+---
 ---Create a new directory, note that this function doesn't recursively
 ---creates the directories on the given path.
 ---

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -194,7 +194,7 @@ function system.chdir(path) end
 ---Truncates a file to a set length.
 ---
 ---@param file file* A file handle returned by io.open().
----@param length integer Number of bytes to truncate to.
+---@param length integer? Number of bytes to truncate to. Defaults to 0.
 ---@return boolean success True if the operation suceeded, false otherwise
 ---@return string? message An error message if the operation failed.
 function system.ftruncate(file, length) end

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -858,7 +858,7 @@ static int f_ftruncate(lua_State *L) {
   #error luaL_Stream is not supported in this version of Lua.
 #endif
   luaL_Stream *stream = luaL_checkudata(L, 1, LUA_FILEHANDLE);
-  lua_Integer len = luaL_checkinteger(L, 2);
+  lua_Integer len = luaL_optinteger(L, 2, 0);
   if (ftruncate(fileno(stream->f), len) != 0) {
     lua_pushboolean(L, 0);
     lua_pushfstring(L, "ftruncate(): %s", strerror(errno));

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -27,6 +27,9 @@
   #if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
     #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
   #endif
+
+  #define fileno _fileno
+  #define ftruncate _chsize
 #else
 
 #include <dirent.h>
@@ -847,6 +850,26 @@ static int f_get_fs_type(lua_State *L) {
 }
 
 
+static int f_ftruncate(lua_State *L) {
+#if LUA_VERSION_NUM < 503
+  // note: it is possible to support pre 5.3 and JIT
+  //       since file handles are just FILE*  wrapped in a userdata;
+  //       but it is not standardized. YMMV.
+  #error luaL_Stream is not supported in this version of Lua.
+#endif
+  luaL_Stream *stream = luaL_checkudata(L, 1, LUA_FILEHANDLE);
+  lua_Integer len = luaL_checkinteger(L, 2);
+  if (ftruncate(fileno(stream->f), len) != 0) {
+    lua_pushboolean(L, 0);
+    lua_pushfstring(L, "ftruncate(): %s", strerror(errno));
+    return 2;
+  }
+
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
+
 static int f_mkdir(lua_State *L) {
   const char *path = luaL_checkstring(L, 1);
 
@@ -1285,6 +1308,7 @@ static const luaL_Reg lib[] = {
   { "get_fs_type",           f_get_fs_type           },
   { "text_input",            f_text_input            },
   { "setenv",                f_setenv                },
+  { "ftruncate",             f_ftruncate             },
   { NULL, NULL }
 };
 


### PR DESCRIPTION
Fixes #1366.

Sometimes Windows quirks are just beyond my understanding.

# why

You can't `fopen(path, "w")` if path is a hidden file.
Hidden files on Windows are actual file attributes and not dotfiles.

This is likely because fopen() is implemented with `CreateFile()`, and `CreateFile()` requires specifying `FILE_ATTRIBUTE_HIDDEN` to open hidden files. There's an obvious problem with that - if the files don't exist, a hidden file will be created, which is certainly what people don't want.

# Fix
To work around not being able to open hidden files on Windows, we open files with `r+b` (read write at beginning, no truncate). Why this works is beyond me, but afterwards we can call `ftruncate()` to truncate the file in order to emulate `w`. This file is now writable and hidden. Since opening file with `r+b` fails if file does not exist, we fall back to `wb`.

# why not lua patch
obvious race condition with 2 `fopen()`, and I'd rather minimize that whenever necessary.

# other possible ways
- Call CreateFile() directly: annoying to do, still needs to SetFileAttribute() so race condition still exists.
- Create temp file and move: Removes hidden attributes, but the best way.
- GetFileAttributes() + CreateFile(): now you have 2 race conditions.


