### PR TITLE
feat(package): ad-hoc sign macOS bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,17 @@ Lite XL will load and store all your configurations and plugins in the folder.
 We provide DMG files for macOS. Simply drag the program into your Applications folder.
 
 > **Important**
-> Since Lite XL is not signed, you **must** run this command before starting Lite XL:
+> Newer versions of Lite XL is signed with a self-signed certificate,
+> so you'll have to follow these steps when running Lite XL for the first time.
+>
+> 1. Find Lite XL in Finder (do not open it in Launchpad).
+> 2. Control-click Lite XL, then choose `Open` from the shortcut menu.
+> 3. Click `Open` in the popup menu.
+>
+> The correct steps may vary between macOS versions, so you should refer to
+> the [macOS User Guide](https://support.apple.com/en-my/guide/mac-help/mh40616/mac).
+>
+> On an older version of Lite XL, you will need to run these commands instead:
 > 
 > ```sh
 > # clears attributes from the directory

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Lite XL will load and store all your configurations and plugins in the folder.
 We provide DMG files for macOS. Simply drag the program into your Applications folder.
 
 > **Important**
-> Newer versions of Lite XL is signed with a self-signed certificate,
+> Newer versions of Lite XL are signed with a self-signed certificate,
 > so you'll have to follow these steps when running Lite XL for the first time.
 >
 > 1. Find Lite XL in Finder (do not open it in Launchpad).

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -267,7 +267,7 @@ main() {
   if [[ $bundle == true ]]; then
     # https://eclecticlight.co/2019/01/17/code-signing-for-the-concerned-3-signing-an-app/
     codesign --force --deep -s - "${dest_dir}"
-  end
+  fi
 
   echo "Creating a compressed archive ${package_name}"
   if [[ $binary == true ]]; then

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -264,6 +264,11 @@ main() {
     $stripcmd "${exe_file}"
   fi
 
+  if [[ $bundle == true ]]; then
+    # https://eclecticlight.co/2019/01/17/code-signing-for-the-concerned-3-signing-an-app/
+    codesign --force --deep -s - "${dest_dir}"
+  end
+
   echo "Creating a compressed archive ${package_name}"
   if [[ $binary == true ]]; then
     rm -f "${package_name}".tar.gz


### PR DESCRIPTION
# Fuck you, Apple.

This downgrades our application from "oh this app is damaged" to "oh this app is from an unknown developer". Why do we need to go through such hoops to do this? dunno.