### PR TITLE
Limit `system.{sleep,wait_event}` to timeouts >= 0

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -386,6 +386,7 @@ static int f_wait_event(lua_State *L) {
   int nargs = lua_gettop(L);
   if (nargs >= 1) {
     double n = luaL_checknumber(L, 1);
+    if (n < 0) n = 0;
     lua_pushboolean(L, SDL_WaitEventTimeout(NULL, n * 1000));
   } else {
     lua_pushboolean(L, SDL_WaitEvent(NULL));
@@ -861,6 +862,7 @@ static int f_get_time(lua_State *L) {
 
 static int f_sleep(lua_State *L) {
   double n = luaL_checknumber(L, 1);
+  if (n < 0) n = 0;
   SDL_Delay(n * 1000);
   return 0;
 }


### PR DESCRIPTION
Otherwise we might wait forever by mistake.

For example this happens when a core thread yields a negative timeout.