### PR TITLE
Fix running `core.step` when receiving an event while not waiting

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1461,7 +1461,7 @@ function core.run()
           local cursor_time_to_wake = dt + 1 / config.fps
           next_step = now + cursor_time_to_wake
         end
-        if time_to_wake > 0 and system.wait_event(math.min(next_step - now, time_to_wake)) then
+        if system.wait_event(math.min(next_step - now, time_to_wake)) then
           next_step = nil -- if we've recevied an event, perform a step
         end
       else

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -61,10 +61,10 @@ function system.poll_event() end
 ---
 ---Wait until an event is triggered.
 ---
----@param timeout number Amount of seconds, also supports fractions
----of a second, eg: 0.01
+---@param timeout? number Amount of seconds, also supports fractions
+---of a second, eg: 0.01. If not provided, waits forever.
 ---
----@return boolean status True on success or false if there was an error.
+---@return boolean status True on success or false if there was an error or if no event was received.
 function system.wait_event(timeout) end
 
 ---


### PR DESCRIPTION
When `time_to_wake` was <= 0, so when a coroutine needed to be executed as soon as possible, we didn't check for events, so we only performed a `core.step` with the blink timer.
This resulted in jerky reactions to input.

To reproduce the issue, add this to the user module and try to scroll with the mouse every couple of seconds:
```lua
core.add_thread(function()
  while true do
    coroutine.yield(0)
  end
end)
```