### PR TITLE
Fix deleting indentation with multiple cursors

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -340,10 +340,11 @@ local commands = {
         local text = dv.doc:get_text(line1, 1, line1, col1)
         if #text >= indent_size and text:find("^ *$") then
           dv.doc:delete_to_cursor(idx, 0, -indent_size)
-          return
+          goto continue
         end
       end
       dv.doc:delete_to_cursor(idx, translate.previous_char)
+      ::continue::
     end
   end,
 


### PR DESCRIPTION
To reproduce the issue, write in a doc:
```
        qwe
        asd
        123
```
and put a caret at the beginning of each "word".
Pressing backspace will only apply to one of them.