### PR TITLE
Fixed C++ "static constexpr/consteval/constinit" highlighting.

### DIFF
--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -27,7 +27,7 @@ syntax.add {
     { pattern = "static()%s+()inline",
       type = { "keyword", "normal", "keyword" }
     },
-    { pattern = "static()%s+()const",
+    { pattern = "static()%s+()const()%s+",
       type = { "keyword", "normal", "keyword" }
     },
     { pattern = "static()%s+()[%a_][%w_]*",


### PR DESCRIPTION
The current pattern matching setup in `language_cpp.lua` results in highlighting stopping on the first match of `static const`. This results in the following streams not properly highlighting:

- `static constexpr`
- `static constinit`
- `static consteval`

Changing the pattern matching to continue to the end of the word fixes this issue.

Before:
![image](https://github.com/lite-xl/lite-xl/assets/105571100/b41540b0-7c07-44a3-a126-bc32e1727d2e)

After:
![image](https://github.com/lite-xl/lite-xl/assets/105571100/4702cfc5-48ad-4e53-87c5-7bd5116b8511)

It could be worth restricting the match to the specific aforementioned keywords, however the patterns stated later on in the file prevent false positives regardless so it would be unnecessary. Doing so would also introduce future maintenance requirements should additional similar keywords be introduced to the C++ spec.