### PR TITLE
reorder nagview options on doc:save error

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -44,8 +44,8 @@ local function save(filename)
   else
     core.error(err)
     core.nag_view:show("Saving failed", string.format("Couldn't save file \"%s\". Do you want to save to another location?", doc().filename), {
-      { text = "No", default_no = true },
-      { text = "Yes", default_yes = true }
+      { text = "Yes", default_yes = true },
+      { text = "No", default_no = true }
     }, function(item)
       if item.text == "Yes" then
         core.add_thread(function()


### PR DESCRIPTION
other nagview confirmation dialogs offer 'yes / no', while this one shows 'no / yes'

e.g
https://github.com/lite-xl/lite-xl/blob/master/data/core/init.lua#L867
https://github.com/lite-xl/lite-xl/blob/master/data/plugins/autoreload.lua#L49