### PR TITLE
Fix autoreload crash / error

### DIFF
--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -69,7 +69,7 @@ function dirwatch:check(change_callback, ...)
     for _, doc in ipairs(core.docs) do
       if doc.abs_filename and (dir == common.dirname(doc.abs_filename) or dir == doc.abs_filename) then
         local info = system.get_file_info(doc.filename or "")
-        if info and times[doc] ~= info.modified then
+        if info and info.type == "file" and times[doc] ~= info.modified then
           if not doc:is_dirty() and not config.plugins.autoreload.always_show_nagview then
             reload_doc(doc)
           else


### PR DESCRIPTION
the autoreload plugin may cause errors or crashes when a doc with a (absolute) filename is no longer backed by an actual on disk file.

steps to reproduce:
1. have lite-xl with a file open in a doc
2. delete the file, keep the doc open
3. create a folder with the same name as the file

causes an error if done from within lite-xl (e.g the treeview), a crash if done externally

The deeper issue is that docs keep their filename even when their backing files are deleted, however as far as i can make sense of the dirwatch, there doesn't seem to be a way to tell apart a rename from a deletion + creation. So clearing filenames would also make externally renamed docs dangling (which may be desired behavior?)

See:
https://github.com/lite-xl/lite-xl/blob/master/data/core/init.lua#L199