### PR TITLE
Update action dependencies

### DIFF
--- a/.github/workflows/auto_labeler_pr.yml
+++ b/.github/workflows/auto_labeler_pr.yml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: ""  # works around actions/labeler#104
+          sync-labels: false

--- a/.github/workflows/auto_labeler_pr.yml
+++ b/.github/workflows/auto_labeler_pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply Type Label
-        uses: actions/labeler@v3
+        uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: ""  # works around actions/labeler#104

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,11 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-linux-$(uname -m)-portable" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Python Setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.11'
       - name: Update Packages
         run: sudo apt-get update
       - name: Install Dependencies
@@ -47,11 +47,12 @@ jobs:
         if: ${{ matrix.config.cc == 'gcc' }}
         run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.config.cc == 'gcc' }}
         with:
           name: Linux Artifacts
           path: ${{ env.INSTALL_NAME }}.tar.gz
+          compression-level: 0
 
   build_macos:
     name: macOS
@@ -75,11 +76,11 @@ jobs:
           echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
           if [[ $(uname -m) != ${{ matrix.arch }} ]]; then echo "ARCH=--cross-arch ${{ matrix.arch }}" >> "$GITHUB_ENV"; fi
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Python Setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.11'
       - name: Install Dependencies
              # --lhelper will eliminate a warning with arm64 and libusb
         run: bash scripts/install-dependencies.sh --debug --lhelper
@@ -90,10 +91,11 @@ jobs:
       - name: Create DMG Image
         run: bash scripts/package.sh --version ${INSTALL_REF} $ARCH --debug --dmg
       - name: Upload DMG Image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: macOS DMG Images
+          name: macOS DMG Images (${{ matrix.arch }})
           path: ${{ env.INSTALL_NAME }}.dmg
+          compression-level: 0
 
   build_macos_universal:
     name: macOS (Universal)
@@ -111,27 +113,29 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-macos-universal" >> "$GITHUB_ENV"
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install dmgbuild
         run: pip install dmgbuild
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
-          name: macOS DMG Images
+          name: macOS DMG Images *
+          merge-multiple: true
           path: dmgs-original
       - name: Make universal bundles
         run: |
           bash --version
           bash scripts/make-universal-binaries.sh ${{ steps.download.outputs.download-path }} "${INSTALL_NAME}"
       - name: Upload DMG Image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: macOS Universal DMG Images
+          name: macOS DMG Images (Universal)
           path: ${{ env.INSTALL_NAME }}.dmg
+          compression-level: 0
 
   build_windows_msys2:
     name: Windows
@@ -145,7 +149,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.config.msystem }}
@@ -177,10 +181,11 @@ jobs:
     - name: Package
       run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: Windows Artifacts
+        name: Windows Artifacts (${{ matrix.config.msystem }}-${{ matrix.config.arch }})
         path: ${{ env.INSTALL_NAME }}.zip
+        compression-level: 0
 
   build_windows_msvc:
     name: Windows (MSVC)
@@ -191,13 +196,13 @@ jobs:
           - { target: x86, name: i686 }
           - { target: x64, name: x86_64 }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch.target }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install meson and ninja
         run: pip install meson ninja
       - name: Set up environment variables
@@ -221,7 +226,8 @@ jobs:
           Remove-Item -Recurse -Force -Path "lite-xl/lib","lite-xl/include"
           Compress-Archive -Path lite-xl -DestinationPath "$env:INSTALL_NAME.zip"
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: Windows Artifacts (MSVC)
+          name: Windows Artifacts (MSVC ${{ matrix.arch.target }})
           path: ${{ env.INSTALL_NAME }}.zip
+          compression-level: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
         uses: actions/download-artifact@v4
         id: download
         with:
-          name: macOS DMG Images *
+          pattern: macOS DMG Images *
           merge-multiple: true
           path: dmgs-original
       - name: Make universal bundles
@@ -183,7 +183,7 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: Windows Artifacts (${{ matrix.config.msystem }}-${{ matrix.config.arch }})
+        name: Windows Artifacts (${{ matrix.config.msystem }})
         path: ${{ env.INSTALL_NAME }}.zip
         compression-level: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       CC: ${{ matrix.config.cc }}
       CXX: ${{ matrix.config.cxx }}
+
     steps:
       - name: Set Environment Variables
         if: ${{ matrix.config.cc == 'gcc' }}
@@ -30,22 +31,30 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-linux-$(uname -m)-portable" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v4
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Update Packages
         run: sudo apt-get update
+
       - name: Install Dependencies
         run: bash scripts/install-dependencies.sh --debug
+
       - name: Build
         run: |
           bash --version
           bash scripts/build.sh --debug --forcefallback --portable
+
       - name: Package
         if: ${{ matrix.config.cc == 'gcc' }}
         run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: ${{ matrix.config.cc == 'gcc' }}
@@ -63,6 +72,7 @@ jobs:
     strategy:
       matrix:
         arch: ['x86_64', 'arm64']
+
     steps:
       - name: System Information
         run: |
@@ -70,26 +80,34 @@ jobs:
           bash --version
           gcc -v
           xcodebuild -version
+
       - name: Set Environment Variables
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
           if [[ $(uname -m) != ${{ matrix.arch }} ]]; then echo "ARCH=--cross-arch ${{ matrix.arch }}" >> "$GITHUB_ENV"; fi
-      - uses: actions/checkout@v4
+      
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Install Dependencies
              # --lhelper will eliminate a warning with arm64 and libusb
         run: bash scripts/install-dependencies.sh --debug --lhelper
+
       - name: Build
         run: |
           bash --version
           bash scripts/build.sh --bundle --debug --forcefallback $ARCH
+
       - name: Create DMG Image
         run: bash scripts/package.sh --version ${INSTALL_REF} $ARCH --debug --dmg
+
       - name: Upload DMG Image
         uses: actions/upload-artifact@v4
         with:
@@ -101,6 +119,7 @@ jobs:
     name: macOS (Universal)
     runs-on: macos-11
     needs: build_macos
+
     steps:
       - name: System Information
         run: |
@@ -108,17 +127,23 @@ jobs:
           bash --version
           gcc -v
           xcodebuild -version
+
       - name: Set Environment Variables
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-macos-universal" >> "$GITHUB_ENV"
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Install dmgbuild
         run: pip install dmgbuild
-      - uses: actions/checkout@v4
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         id: download
@@ -126,10 +151,12 @@ jobs:
           pattern: macOS DMG Images *
           merge-multiple: true
           path: dmgs-original
+
       - name: Make universal bundles
         run: |
           bash --version
           bash scripts/make-universal-binaries.sh ${{ steps.download.outputs.download-path }} "${INSTALL_NAME}"
+
       - name: Upload DMG Image
         uses: actions/upload-artifact@v4
         with:
@@ -148,9 +175,13 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
+
     steps:
-    - uses: actions/checkout@v4
-    - uses: msys2/setup-msys2@v2
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup MSYS2
+      uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.config.msystem }}
         install: >-
@@ -162,6 +193,7 @@ jobs:
           mingw-w64-${{ matrix.config.arch }}-ninja
           mingw-w64-${{ matrix.config.arch }}-ca-certificates
           mingw-w64-${{ matrix.config.arch }}-ntldd
+
     - name: Set Environment Variables
       run: |
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -171,15 +203,19 @@ jobs:
         else
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-i686" >> "$GITHUB_ENV"
         fi
+
     - name: Install Dependencies
       if: false
       run: bash scripts/install-dependencies.sh --debug
+
     - name: Build
       run: |
         bash --version
         bash scripts/build.sh -U --debug --forcefallback
+
     - name: Package
       run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary
+
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -195,36 +231,49 @@ jobs:
         arch:
           - { target: x86, name: i686 }
           - { target: x64, name: x86_64 }
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch.target }}
-      - uses: actions/setup-python@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Install meson and ninja
         run: pip install meson ninja
+
       - name: Set up environment variables
         run: |
           "INSTALL_NAME=lite-xl-$($env:GITHUB_REF -replace ".*/")-windows-msvc-${{ matrix.arch.name }}" >> $env:GITHUB_ENV
           "INSTALL_REF=$($env:GITHUB_REF -replace ".*/")" >> $env:GITHUB_ENV
           "LUA_SUBPROJECT_PATH=subprojects/$(awk -F ' *= *' '/directory/ { printf $2 }' subprojects/lua.wrap)" >> $env:GITHUB_ENV
+
       - name: Download and patch subprojects
         shell: bash
         run: |
           meson subprojects download
           cat resources/windows/001-lua-unicode.diff | patch -Np1 -d "$LUA_SUBPROJECT_PATH"
+
       - name: Configure
         run: |
           meson setup --wrap-mode=forcefallback build
+
       - name: Build
         run: |
           meson install -C build --destdir="../lite-xl"
+
       - name: Package
         run: |
           Remove-Item -Recurse -Force -Path "lite-xl/lib","lite-xl/include"
           Compress-Archive -Path lite-xl -DestinationPath "$env:INSTALL_NAME.zip"
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches:
-      - '*'
+      - "*"
 
   pull_request:
     branches:
-      - '*'
+      - "*"
 
   workflow_dispatch:
 
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         config:
-        - { name: "GCC", cc: gcc, cxx: g++ }
-        - { name: "clang", cc: clang, cxx: clang++ }
+          - { name: "GCC", cc: gcc, cxx: g++ }
+          - { name: "clang", cc: clang, cxx: clang++ }
     env:
       CC: ${{ matrix.config.cc }}
       CXX: ${{ matrix.config.cxx }}
@@ -38,7 +38,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Update Packages
         run: sudo apt-get update
@@ -71,7 +71,7 @@ jobs:
       CXX: clang++
     strategy:
       matrix:
-        arch: ['x86_64', 'arm64']
+        arch: ["x86_64", "arm64"]
 
     steps:
       - name: System Information
@@ -87,17 +87,17 @@ jobs:
           echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
           echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
           if [[ $(uname -m) != ${{ matrix.arch }} ]]; then echo "ARCH=--cross-arch ${{ matrix.arch }}" >> "$GITHUB_ENV"; fi
-      
+
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
+      # --lhelper will eliminate a warning with arm64 and libusb
       - name: Install Dependencies
-             # --lhelper will eliminate a warning with arm64 and libusb
         run: bash scripts/install-dependencies.sh --debug --lhelper
 
       - name: Build
@@ -136,7 +136,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dmgbuild
         run: pip install dmgbuild
@@ -170,58 +170,58 @@ jobs:
     strategy:
       matrix:
         config:
-          - {msystem: MINGW32, arch: i686}
-          - {msystem: MINGW64, arch: x86_64}
+          - { msystem: MINGW32, arch: i686 }
+          - { msystem: MINGW64, arch: x86_64 }
     defaults:
       run:
         shell: msys2 {0}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Setup MSYS2
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: ${{ matrix.config.msystem }}
-        install: >-
-          base-devel
-          git
-          zip
-          mingw-w64-${{ matrix.config.arch }}-gcc
-          mingw-w64-${{ matrix.config.arch }}-meson
-          mingw-w64-${{ matrix.config.arch }}-ninja
-          mingw-w64-${{ matrix.config.arch }}-ca-certificates
-          mingw-w64-${{ matrix.config.arch }}-ntldd
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.config.msystem }}
+          install: >-
+            base-devel
+            git
+            zip
+            mingw-w64-${{ matrix.config.arch }}-gcc
+            mingw-w64-${{ matrix.config.arch }}-meson
+            mingw-w64-${{ matrix.config.arch }}-ninja
+            mingw-w64-${{ matrix.config.arch }}-ca-certificates
+            mingw-w64-${{ matrix.config.arch }}-ntldd
 
-    - name: Set Environment Variables
-      run: |
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
-        if [[ "${MSYSTEM}" == "MINGW64" ]]; then
-          echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-x86_64" >> "$GITHUB_ENV"
-        else
-          echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-i686" >> "$GITHUB_ENV"
-        fi
+      - name: Set Environment Variables
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
+          if [[ "${MSYSTEM}" == "MINGW64" ]]; then
+            echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-x86_64" >> "$GITHUB_ENV"
+          else
+            echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-windows-i686" >> "$GITHUB_ENV"
+          fi
 
-    - name: Install Dependencies
-      if: false
-      run: bash scripts/install-dependencies.sh --debug
+      - name: Install Dependencies
+        if: false
+        run: bash scripts/install-dependencies.sh --debug
 
-    - name: Build
-      run: |
-        bash --version
-        bash scripts/build.sh -U --debug --forcefallback
+      - name: Build
+        run: |
+          bash --version
+          bash scripts/build.sh -U --debug --forcefallback
 
-    - name: Package
-      run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary
+      - name: Package
+        run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary
 
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: Windows Artifacts (${{ matrix.config.msystem }})
-        path: ${{ env.INSTALL_NAME }}.zip
-        compression-level: 0
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Windows Artifacts (${{ matrix.config.msystem }})
+          path: ${{ env.INSTALL_NAME }}.zip
+          compression-level: 0
 
   build_windows_msvc:
     name: Windows (MSVC)
@@ -244,7 +244,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install meson and ninja
         run: pip install meson ninja

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,22 +93,25 @@ jobs:
           sudo apt-get install -y ccache
 
       - name: Build Portable
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.3
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.2.0
         with:
+          entrypoint: /entrypoint.sh
           args: |
             bash --version
             bash scripts/build.sh --debug --forcefallback --portable --release
 
       - name: Package Portables
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.3
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.2.0
         with:
+          entrypoint: /entrypoint.sh
           args: |
             bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release
             bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
 
       - name: Build AppImages
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.3
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.2.0
         with:
+          entrypoint: /entrypoint.sh
           args: |
             bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release
             bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
         id: tag
         run: |
           if [[ "${{ github.event.inputs.version }}" != "" ]]; then
-            echo ::set-output name=version::${{ github.event.inputs.version }}
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+            echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
           fi
       - name: Update Tag
         uses: richardsimko/update-tag@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,23 +90,29 @@ jobs:
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
-            bash -c "
+            bash -c '
+            export CCACHE_DIR="$PWD/.ccache" &&
+            ccache --set-config=sloppiness=locale,time_macros &&
             bash --version &&
-            bash scripts/build.sh --debug --forcefallback --portable --release"
+            bash scripts/build.sh --debug --forcefallback --portable --release'
       - name: Package Portables
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
-            bash -c "
+            bash -c '
+            export CCACHE_DIR="$PWD/.ccache" &&
+            ccache --set-config=sloppiness=locale,time_macros &&
             bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release &&
-            bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release"
+            bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release'
       - name: Build AppImages
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
-            bash -c "
+            bash -c '
+            export CCACHE_DIR="$PWD/.ccache" &&
+            ccache --set-config=sloppiness=locale,time_macros &&
             bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release &&
-            bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}"
+            bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}'
       - name: Upload Files
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,8 +258,11 @@ jobs:
         shell: msys2 {0}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: msys2/setup-msys2@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
           update: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,6 @@ jobs:
     name: Linux
     needs: release
     runs-on: ubuntu-latest
-    container: ghcr.io/lite-xl/lite-xl-build-box:latest
     env:
       CC: gcc
       CXX: g++
@@ -88,17 +87,23 @@ jobs:
           sudo apt-get install -y ccache
 
       - name: Build Portable
-        run: |
-          bash --version
-          bash scripts/build.sh --debug --forcefallback --portable --release
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
+        with:
+          args: |
+            bash --version
+            bash scripts/build.sh --debug --forcefallback --portable --release
       - name: Package Portables
-        run: |
-          bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release
-          bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
+        with:
+          args: |
+            bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release
+            bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
       - name: Build AppImages
-        run: |
-          bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release
-          bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
+        with:
+          args: |
+            bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release
+            bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}
       - name: Upload Files
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,9 @@ jobs:
           echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
           echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
           if [[ $(uname -m) != ${{ matrix.arch }} ]]; then echo "ARCH=--cross-arch ${{ matrix.arch }}" >> "$GITHUB_ENV"; fi
-      - uses: actions/checkout@v4
+      
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Python Setup
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,6 +330,7 @@ jobs:
       - name: Update Release
         uses: ncipollo/release-action@v1
         with:
+          tag: ${{ needs.release.outputs.version }}
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitNameDuringUpdate: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,14 +57,13 @@ jobs:
     name: Linux
     needs: release
     runs-on: ubuntu-latest
-    env:
-      CC: gcc
-      CXX: g++
     steps:
       - name: Set Environment Variables
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
+          echo "CCACHE_DIR=$PWD/.ccache" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
 
       # disabled because this will break our own Python install
@@ -91,28 +90,25 @@ jobs:
         with:
           args: >-
             bash -c "
-            export CCACHE_DIR=$PWD/.ccache &&
-            ccache --set-config=sloppiness=locale,time_macros &&
             bash --version &&
             bash scripts/build.sh --debug --forcefallback --portable --release"
+
       - name: Package Portables
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
             bash -c "
-            export CCACHE_DIR=$PWD/.ccache &&
-            ccache --set-config=sloppiness=locale,time_macros &&
             bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release &&
             bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release"
+          
       - name: Build AppImages
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
             bash -c "
-            export CCACHE_DIR=$PWD/.ccache &&
-            ccache --set-config=sloppiness=locale,time_macros &&
             bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release &&
             bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}"
+
       - name: Upload Files
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,28 +93,25 @@ jobs:
           sudo apt-get install -y ccache
 
       - name: Build Portable
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.2
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.3
         with:
-          args: >-
-            bash -c "
-            bash --version &&
-            bash scripts/build.sh --debug --forcefallback --portable --release"
+          args: |
+            bash --version
+            bash scripts/build.sh --debug --forcefallback --portable --release
 
       - name: Package Portables
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.2
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.3
         with:
-          args: >-
-            bash -c "
-            bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release &&
-            bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release"
+          args: |
+            bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release
+            bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
 
       - name: Build AppImages
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.2
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.3
         with:
-          args: >-
-            bash -c "
-            bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release &&
-            bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}"
+          args: |
+            bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release
+            bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Fetch Version
         id: tag
         run: |
@@ -34,24 +35,26 @@ jobs:
           else
             echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
           fi
+
       - name: Update Tag
         uses: richardsimko/update-tag@v1
         with:
           tag_name: ${{ steps.tag.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate Release Notes
         run: bash scripts/generate-release-notes.sh --version ${{ steps.tag.outputs.version }}
+
       - name: Create Release
         id: create_release
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v2
         with:
-          tag: ${{ steps.tag.outputs.version }}
           name: Lite XL ${{ steps.tag.outputs.version }}
+          tag_name: ${{ steps.tag.outputs.version }}
           draft: true
-          bodyFile: release-notes.md
-          generateReleaseNotes: true
-          allowUpdates: true
+          body_path: release-notes.md
+          generate_release_notes: true
 
   build_linux:
     name: Linux
@@ -110,12 +113,10 @@ jobs:
             bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}"
 
       - name: Upload Files
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v2
         with:
-          tag: ${{ needs.release.outputs.version }}
-          draft: true
-          allowUpdates: true
-          artifacts: |
+          tag_name: ${{ steps.tag.outputs.version }}
+          files: |
             lite-xl-${{ env.INSTALL_REF }}-linux-x86_64-portable.tar.gz
             lite-xl-${{ env.INSTALL_REF }}-addons-linux-x86_64-portable.tar.gz
             LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
@@ -168,12 +169,10 @@ jobs:
             ${{ env.INSTALL_NAME }}.dmg
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
       - name: Upload Files
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v2
         with:
-          tag: ${{ needs.release.outputs.version }}
-          draft: true
-          allowUpdates: true
-          artifacts: |
+          tag_name: ${{ steps.tag.outputs.version }}
+          files: |
             ${{ env.INSTALL_NAME }}.dmg
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
 
@@ -218,12 +217,10 @@ jobs:
           bash scripts/make-universal-binaries.sh dmgs-normal "$INSTALL_BASE-universal"
           bash scripts/make-universal-binaries.sh dmgs-addons "$INSTALL_BASE_ADDONS-universal"
       - name: Upload Files
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v2
         with:
-          tag: ${{ needs.release.outputs.version }}
-          draft: true
-          allowUpdates: true
-          artifacts: |
+          tag_name: ${{ steps.tag.outputs.version }}
+          files: |
             ${{ env.INSTALL_BASE }}-universal.dmg
             ${{ env.INSTALL_BASE_ADDONS }}-universal.dmg
 
@@ -275,12 +272,10 @@ jobs:
       - name: Build Installer With Addons
         run: bash scripts/innosetup/innosetup.sh --debug --version ${INSTALL_REF} --addons
       - name: Upload Files
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v2
         with:
-          tag: ${{ needs.release.outputs.version }}
-          draft: true
-          allowUpdates: true
-          artifacts: |
+          tag_name: ${{ steps.tag.outputs.version }}
+          files: |
             ${{ env.INSTALL_NAME }}.zip
             ${{ env.INSTALL_NAME_ADDONS }}.zip
             LiteXL-${{ env.INSTALL_REF }}-${{ env.BUILD_ARCH }}-setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         if: false
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       # disabled because the container has up-to-date packages
       - name: Update Packages
@@ -106,7 +106,7 @@ jobs:
             bash -c "
             bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release &&
             bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release"
-          
+
       - name: Build AppImages
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.2
         with:
@@ -151,14 +151,14 @@ jobs:
           echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
           echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
           if [[ $(uname -m) != ${{ matrix.arch }} ]]; then echo "ARCH=--cross-arch ${{ matrix.arch }}" >> "$GITHUB_ENV"; fi
-      
+
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install Dependencies
         run: bash scripts/install-dependencies.sh --debug
@@ -221,7 +221,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dmgbuild
         run: pip install dmgbuild

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,20 +89,20 @@ jobs:
       - name: Build Portable
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
-          args: |
-            bash --version
+          args: >-
+            bash --version &&
             bash scripts/build.sh --debug --forcefallback --portable --release
       - name: Package Portables
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
-          args: |
-            bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release
+          args: >-
+            bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release &&
             bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
       - name: Build AppImages
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
-          args: |
-            bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release
+          args: >-
+            bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release &&
             bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}
       - name: Upload Files
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,9 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        msystem: [MINGW32, MINGW64]
+        config:
+          - { msystem: MINGW32, arch: i686}
+          - { msystem: MINGW64, arch: x86_64}
     defaults:
       run:
         shell: msys2 {0}
@@ -264,28 +266,33 @@ jobs:
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
-          msystem: ${{ matrix.msystem }}
+          msystem: ${{ matrix.config.msystem }}
           update: true
           install: >-
             base-devel
             git
             zip
+            unzip
+            mingw-w64-${{ matrix.config.arch }}-gcc
+            mingw-w64-${{ matrix.config.arch }}-meson
+            mingw-w64-${{ matrix.config.arch }}-ninja
+            mingw-w64-${{ matrix.config.arch }}-ca-certificates
+            mingw-w64-${{ matrix.config.arch }}-ntldd
 
       - name: Set Environment Variables
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
           if [[ "${MSYSTEM}" == "MINGW64" ]]; then
-            echo "BUILD_ARCH=x86_64" >> "$GITHUB_ENV"
             echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-x86_64" >> "$GITHUB_ENV"
             echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-windows-x86_64" >> "$GITHUB_ENV"
           else
-            echo "BUILD_ARCH=i686" >> "$GITHUB_ENV"
             echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-i686" >> "$GITHUB_ENV"
             echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-windows-i686" >> "$GITHUB_ENV"
           fi
 
       - name: Install Dependencies
+        if: false
         run: bash scripts/install-dependencies.sh --debug
 
       - name: Build
@@ -312,5 +319,5 @@ jobs:
           files: |
             ${{ env.INSTALL_NAME }}.zip
             ${{ env.INSTALL_NAME_ADDONS }}.zip
-            LiteXL-${{ env.INSTALL_REF }}-${{ env.BUILD_ARCH }}-setup.exe
-            LiteXL-${{ env.INSTALL_REF }}-addons-${{ env.BUILD_ARCH }}-setup.exe
+            LiteXL-${{ env.INSTALL_REF }}-${{ matrix.config.arch }}-setup.exe
+            LiteXL-${{ env.INSTALL_REF }}-addons-${{ matrix.config.arch }}-setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           sudo apt-get install -y ccache
 
       - name: Build Portable
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.2
         with:
           args: >-
             bash -c "
@@ -94,7 +94,7 @@ jobs:
             bash scripts/build.sh --debug --forcefallback --portable --release"
 
       - name: Package Portables
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.2
         with:
           args: >-
             bash -c "
@@ -102,7 +102,7 @@ jobs:
             bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release"
           
       - name: Build AppImages
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.2
         with:
           args: >-
             bash -c "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.release.outputs.version }}
+          allowUpdates: true
           artifacts: |
             lite-xl-${{ env.INSTALL_REF }}-linux-x86_64-portable.tar.gz
             lite-xl-${{ env.INSTALL_REF }}-addons-linux-x86_64-portable.tar.gz
@@ -186,6 +187,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.release.outputs.version }}
+          allowUpdates: true
           artifacts: |
             ${{ env.INSTALL_NAME }}.dmg
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
@@ -243,6 +245,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.release.outputs.version }}
+          allowUpdates: true
           artifacts: |
             ${{ env.INSTALL_BASE }}-universal.dmg
             ${{ env.INSTALL_BASE_ADDONS }}-universal.dmg
@@ -317,6 +320,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.release.outputs.version }}
+          allowUpdates: true
           artifacts: |
             ${{ env.INSTALL_NAME }}.zip
             ${{ env.INSTALL_NAME_ADDONS }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,7 +316,7 @@ jobs:
             LiteXL-${{ env.INSTALL_REF }}-addons-${{ matrix.config.arch }}-setup.exe
 
   upload_artifacts:
-    name: Create Release
+    name: Upload Release Artifacts
     runs-on: ubuntu-latest
     needs:
       [build_linux, build_macos, build_macos_universal, build_windows_msys2]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,12 +116,11 @@ jobs:
             bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release &&
             bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}"
 
-      - name: Upload Files
-        uses: ncipollo/release-action@v1
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
         with:
-          tag: ${{ needs.release.outputs.version }}
-          allowUpdates: true
-          artifacts: |
+          name: Linux Artifacts
+          path: |
             lite-xl-${{ env.INSTALL_REF }}-linux-x86_64-portable.tar.gz
             lite-xl-${{ env.INSTALL_REF }}-addons-linux-x86_64-portable.tar.gz
             LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
@@ -183,18 +182,9 @@ jobs:
             ${{ env.INSTALL_NAME }}.dmg
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
 
-      - name: Upload Files
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ needs.release.outputs.version }}
-          allowUpdates: true
-          artifacts: |
-            ${{ env.INSTALL_NAME }}.dmg
-            ${{ env.INSTALL_NAME_ADDONS }}.dmg
-
   build_macos_universal:
     name: macOS (Universal)
-    needs: [release, build_macos]
+    needs: [build_macos]
     runs-on: macos-11
 
     steps:
@@ -241,12 +231,11 @@ jobs:
           bash scripts/make-universal-binaries.sh dmgs-normal "$INSTALL_BASE-universal"
           bash scripts/make-universal-binaries.sh dmgs-addons "$INSTALL_BASE_ADDONS-universal"
 
-      - name: Upload Files
-        uses: ncipollo/release-action@v1
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
         with:
-          tag: ${{ needs.release.outputs.version }}
-          allowUpdates: true
-          artifacts: |
+          name: macOS DMG Images (Universal)
+          path: |
             ${{ env.INSTALL_BASE }}-universal.dmg
             ${{ env.INSTALL_BASE_ADDONS }}-universal.dmg
 
@@ -257,8 +246,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - { msystem: MINGW32, arch: i686}
-          - { msystem: MINGW64, arch: x86_64}
+          - { msystem: MINGW32, arch: i686 }
+          - { msystem: MINGW64, arch: x86_64 }
     defaults:
       run:
         shell: msys2 {0}
@@ -316,13 +305,34 @@ jobs:
       - name: Build Installer With Addons
         run: bash scripts/innosetup/innosetup.sh --debug --version ${INSTALL_REF} --addons
 
-      - name: Upload Files
-        uses: ncipollo/release-action@v1
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
         with:
-          tag: ${{ needs.release.outputs.version }}
-          allowUpdates: true
-          artifacts: |
+          name: Windows Builds (${{ matrix.config.msystem }})
+          path: |
             ${{ env.INSTALL_NAME }}.zip
             ${{ env.INSTALL_NAME_ADDONS }}.zip
             LiteXL-${{ env.INSTALL_REF }}-${{ matrix.config.arch }}-setup.exe
             LiteXL-${{ env.INSTALL_REF }}-addons-${{ matrix.config.arch }}-setup.exe
+
+  upload_artifacts:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs:
+      [build_linux, build_macos, build_macos_universal, build_windows_msys2]
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Update Release
+        uses: ncipollo/release-action@v1
+        with:
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          allowUpdates: true
+          artifacts: "*.exe,*.zip,*.tar.gz,*.dmg,*.AppImage"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,14 +90,14 @@ jobs:
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
-            bash --version &&
-            bash scripts/build.sh --debug --forcefallback --portable --release
+            bash -c "bash --version &&
+            bash scripts/build.sh --debug --forcefallback --portable --release"
       - name: Package Portables
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
-            bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release &&
-            bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
+            bash -c "bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release &&
+            bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release"
       - name: Build AppImages
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,6 @@ jobs:
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
-          name: Lite XL ${{ steps.tag.outputs.version }}
           tag_name: ${{ steps.tag.outputs.version }}
           files: |
             lite-xl-${{ env.INSTALL_REF }}-linux-x86_64-portable.tar.gz
@@ -172,7 +171,6 @@ jobs:
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
-          name: Lite XL ${{ steps.tag.outputs.version }}
           tag_name: ${{ steps.tag.outputs.version }}
           files: |
             ${{ env.INSTALL_NAME }}.dmg
@@ -221,7 +219,6 @@ jobs:
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
-          name: Lite XL ${{ steps.tag.outputs.version }}
           tag_name: ${{ steps.tag.outputs.version }}
           files: |
             ${{ env.INSTALL_BASE }}-universal.dmg
@@ -277,7 +274,6 @@ jobs:
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
-          name: Lite XL ${{ steps.tag.outputs.version }}
           tag_name: ${{ steps.tag.outputs.version }}
           files: |
             ${{ env.INSTALL_NAME }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
+          name: Lite XL ${{ steps.tag.outputs.version }}
           tag_name: ${{ steps.tag.outputs.version }}
           files: |
             lite-xl-${{ env.INSTALL_REF }}-linux-x86_64-portable.tar.gz
@@ -171,6 +172,7 @@ jobs:
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
+          name: Lite XL ${{ steps.tag.outputs.version }}
           tag_name: ${{ steps.tag.outputs.version }}
           files: |
             ${{ env.INSTALL_NAME }}.dmg
@@ -219,6 +221,7 @@ jobs:
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
+          name: Lite XL ${{ steps.tag.outputs.version }}
           tag_name: ${{ steps.tag.outputs.version }}
           files: |
             ${{ env.INSTALL_BASE }}-universal.dmg
@@ -274,6 +277,7 @@ jobs:
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
+          name: Lite XL ${{ steps.tag.outputs.version }}
           tag_name: ${{ steps.tag.outputs.version }}
           files: |
             ${{ env.INSTALL_NAME }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,14 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@v1
         with:
           name: Lite XL ${{ steps.tag.outputs.version }}
-          tag_name: ${{ steps.tag.outputs.version }}
+          tag: ${{ steps.tag.outputs.version }}
           draft: true
-          body_path: release-notes.md
-          generate_release_notes: true
+          bodyFile: release-notes.md
+          generateReleaseNotes: true
+          allowUpdates: true
 
   build_linux:
     name: Linux
@@ -116,10 +117,10 @@ jobs:
             bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}"
 
       - name: Upload Files
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ needs.release.outputs.version }}
-          files: |
+          tag: ${{ needs.release.outputs.version }}
+          artifacts: |
             lite-xl-${{ env.INSTALL_REF }}-linux-x86_64-portable.tar.gz
             lite-xl-${{ env.INSTALL_REF }}-addons-linux-x86_64-portable.tar.gz
             LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
@@ -182,10 +183,10 @@ jobs:
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
 
       - name: Upload Files
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ needs.release.outputs.version }}
-          files: |
+          tag: ${{ needs.release.outputs.version }}
+          artifacts: |
             ${{ env.INSTALL_NAME }}.dmg
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
 
@@ -239,10 +240,10 @@ jobs:
           bash scripts/make-universal-binaries.sh dmgs-addons "$INSTALL_BASE_ADDONS-universal"
 
       - name: Upload Files
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ needs.release.outputs.version }}
-          files: |
+          tag: ${{ needs.release.outputs.version }}
+          artifacts: |
             ${{ env.INSTALL_BASE }}-universal.dmg
             ${{ env.INSTALL_BASE_ADDONS }}-universal.dmg
 
@@ -313,10 +314,10 @@ jobs:
         run: bash scripts/innosetup/innosetup.sh --debug --version ${INSTALL_REF} --addons
 
       - name: Upload Files
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ needs.release.outputs.version }}
-          files: |
+          tag: ${{ needs.release.outputs.version }}
+          artifacts: |
             ${{ env.INSTALL_NAME }}.zip
             ${{ env.INSTALL_NAME_ADDONS }}.zip
             LiteXL-${{ env.INSTALL_REF }}-${{ matrix.config.arch }}-setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
 
   build_macos_universal:
     name: macOS (Universal)
-    needs: [build_macos]
+    needs: [release, build_macos]
     runs-on: macos-11
 
     steps:
@@ -319,7 +319,7 @@ jobs:
     name: Upload Release Artifacts
     runs-on: ubuntu-latest
     needs:
-      [build_linux, build_macos, build_macos_universal, build_windows_msys2]
+      [release, build_linux, build_macos, build_macos_universal, build_windows_msys2]
 
     steps:
       - name: Download Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,20 +90,23 @@ jobs:
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
-            bash -c "bash --version &&
+            bash -c "
+            bash --version &&
             bash scripts/build.sh --debug --forcefallback --portable --release"
       - name: Package Portables
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
-            bash -c "bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release &&
+            bash -c "
+            bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release &&
             bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release"
       - name: Build AppImages
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
+            bash -c "
             bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release &&
-            bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}
+            bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}"
       - name: Upload Files
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ steps.tag.outputs.version }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -60,6 +61,7 @@ jobs:
     name: Linux
     needs: release
     runs-on: ubuntu-latest
+
     steps:
       - name: Set Environment Variables
         run: |
@@ -115,7 +117,7 @@ jobs:
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.version }}
+          tag_name: ${{ needs.release.outputs.version }}
           files: |
             lite-xl-${{ env.INSTALL_REF }}-linux-x86_64-portable.tar.gz
             lite-xl-${{ env.INSTALL_REF }}-addons-linux-x86_64-portable.tar.gz
@@ -132,6 +134,7 @@ jobs:
     env:
       CC: clang
       CXX: clang++
+
     steps:
       - name: System Information
         run: |
@@ -139,6 +142,7 @@ jobs:
           bash --version
           gcc -v
           xcodebuild -version
+
       - name: Set Environment Variables
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -147,20 +151,25 @@ jobs:
           echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
           if [[ $(uname -m) != ${{ matrix.arch }} ]]; then echo "ARCH=--cross-arch ${{ matrix.arch }}" >> "$GITHUB_ENV"; fi
       - uses: actions/checkout@v4
+
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Install Dependencies
         run: bash scripts/install-dependencies.sh --debug
+
       - name: Build
         run: |
           bash --version
           bash scripts/build.sh --bundle --debug --forcefallback --release $ARCH
+
       - name: Create DMG Image
         run: |
           bash scripts/package.sh --version ${INSTALL_REF} $ARCH --debug --dmg --release
           bash scripts/package.sh --version ${INSTALL_REF} $ARCH --debug --addons --dmg --release
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -168,10 +177,11 @@ jobs:
           path: |
             ${{ env.INSTALL_NAME }}.dmg
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
+
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.version }}
+          tag_name: ${{ needs.release.outputs.version }}
           files: |
             ${{ env.INSTALL_NAME }}.dmg
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
@@ -180,6 +190,7 @@ jobs:
     name: macOS (Universal)
     needs: [release, build_macos]
     runs-on: macos-11
+
     steps:
       - name: System Information
         run: |
@@ -187,12 +198,15 @@ jobs:
           bash --version
           gcc -v
           xcodebuild -version
+
       - name: Set Environment Variables
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_BASE=lite-xl-${{ needs.release.outputs.version }}-macos" >> "$GITHUB_ENV"
           echo "INSTALL_BASE_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
+
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         id: download
@@ -200,26 +214,31 @@ jobs:
           pattern: macOS DMG Images *
           merge-multiple: true
           path: dmgs-original
+
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Install dmgbuild
         run: pip install dmgbuild
+
       - name: Prepare DMG Images
         run: |
           mkdir -p dmgs-addons dmgs-normal
           mv -v "${{ steps.download.outputs.download-path }}/$INSTALL_BASE-"{x86_64,arm64}.dmg dmgs-normal
           mv -v "${{ steps.download.outputs.download-path }}/$INSTALL_BASE_ADDONS-"{x86_64,arm64}.dmg dmgs-addons
+
       - name: Create Universal DMGs
         run: |
           bash --version
           bash scripts/make-universal-binaries.sh dmgs-normal "$INSTALL_BASE-universal"
           bash scripts/make-universal-binaries.sh dmgs-addons "$INSTALL_BASE_ADDONS-universal"
+
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.version }}
+          tag_name: ${{ needs.release.outputs.version }}
           files: |
             ${{ env.INSTALL_BASE }}-universal.dmg
             ${{ env.INSTALL_BASE_ADDONS }}-universal.dmg
@@ -234,6 +253,7 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
+
     steps:
       - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
@@ -244,6 +264,7 @@ jobs:
             base-devel
             git
             zip
+
       - name: Set Environment Variables
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -257,24 +278,31 @@ jobs:
             echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-windows-i686" >> "$GITHUB_ENV"
             echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-windows-i686" >> "$GITHUB_ENV"
           fi
+
       - name: Install Dependencies
         run: bash scripts/install-dependencies.sh --debug
+
       - name: Build
         run: |
           bash --version
           bash scripts/build.sh -U --debug --forcefallback --release
+
       - name: Package
         run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release
+
       - name: Build Installer
         run: bash scripts/innosetup/innosetup.sh --debug --version ${INSTALL_REF}
+
       - name: Package With Addons
         run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
+
       - name: Build Installer With Addons
         run: bash scripts/innosetup/innosetup.sh --debug --version ${INSTALL_REF} --addons
+
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.version }}
+          tag_name: ${{ needs.release.outputs.version }}
           files: |
             ${{ env.INSTALL_NAME }}.zip
             ${{ env.INSTALL_NAME_ADDONS }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,8 @@ jobs:
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
           echo "CCACHE_DIR=$PWD/.ccache" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       # disabled because this will break our own Python install
       - name: Python Setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Fetch Version
@@ -44,12 +44,14 @@ jobs:
         run: bash scripts/generate-release-notes.sh --version ${{ steps.tag.outputs.version }}
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.tag.outputs.version }}
+          tag: ${{ steps.tag.outputs.version }}
           name: Lite XL ${{ steps.tag.outputs.version }}
           draft: true
-          body_path: release-notes.md
+          bodyFile: release-notes.md
+          generateReleaseNotes: true
+          allowUpdates: true
 
   build_linux:
     name: Linux
@@ -64,14 +66,14 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # disabled because this will break our own Python install
       - name: Python Setup
         if: false
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.11'
 
       # disabled because the container has up-to-date packages
       - name: Update Packages
@@ -98,11 +100,12 @@ jobs:
           bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release
           bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}
       - name: Upload Files
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ needs.release.outputs.version }}
+          tag: ${{ needs.release.outputs.version }}
           draft: true
-          files: |
+          allowUpdates: true
+          artifacts: |
             lite-xl-${{ env.INSTALL_REF }}-linux-x86_64-portable.tar.gz
             lite-xl-${{ env.INSTALL_REF }}-addons-linux-x86_64-portable.tar.gz
             LiteXL-${{ env.INSTALL_REF }}-x86_64.AppImage
@@ -132,11 +135,11 @@ jobs:
           echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
           echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
           if [[ $(uname -m) != ${{ matrix.arch }} ]]; then echo "ARCH=--cross-arch ${{ matrix.arch }}" >> "$GITHUB_ENV"; fi
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Python Setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.11'
       - name: Install Dependencies
         run: bash scripts/install-dependencies.sh --debug
       - name: Build
@@ -148,18 +151,19 @@ jobs:
           bash scripts/package.sh --version ${INSTALL_REF} $ARCH --debug --dmg --release
           bash scripts/package.sh --version ${INSTALL_REF} $ARCH --debug --addons --dmg --release
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: macOS DMG Images
+          name: macOS DMG Images (${{ matrix.arch }})
           path: |
             ${{ env.INSTALL_NAME }}.dmg
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
       - name: Upload Files
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ needs.release.outputs.version }}
+          tag: ${{ needs.release.outputs.version }}
           draft: true
-          files: |
+          allowUpdates: true
+          artifacts: |
             ${{ env.INSTALL_NAME }}.dmg
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
 
@@ -179,17 +183,18 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_BASE=lite-xl-${{ needs.release.outputs.version }}-macos" >> "$GITHUB_ENV"
           echo "INSTALL_BASE_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
-          name: macOS DMG Images
+          pattern: macOS DMG Images *
+          merge-multiple: true
           path: dmgs-original
       - name: Python Setup
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.11'
       - name: Install dmgbuild
         run: pip install dmgbuild
       - name: Prepare DMG Images
@@ -203,11 +208,12 @@ jobs:
           bash scripts/make-universal-binaries.sh dmgs-normal "$INSTALL_BASE-universal"
           bash scripts/make-universal-binaries.sh dmgs-addons "$INSTALL_BASE_ADDONS-universal"
       - name: Upload Files
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ needs.release.outputs.version }}
+          tag: ${{ needs.release.outputs.version }}
           draft: true
-          files: |
+          allowUpdates: true
+          artifacts: |
             ${{ env.INSTALL_BASE }}-universal.dmg
             ${{ env.INSTALL_BASE_ADDONS }}-universal.dmg
 
@@ -222,7 +228,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
@@ -259,11 +265,12 @@ jobs:
       - name: Build Installer With Addons
         run: bash scripts/innosetup/innosetup.sh --debug --version ${INSTALL_REF} --addons
       - name: Upload Files
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ needs.release.outputs.version }}
+          tag: ${{ needs.release.outputs.version }}
           draft: true
-          files: |
+          allowUpdates: true
+          artifacts: |
             ${{ env.INSTALL_NAME }}.zip
             ${{ env.INSTALL_NAME_ADDONS }}.zip
             LiteXL-${{ env.INSTALL_REF }}-${{ env.BUILD_ARCH }}-setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,29 +90,29 @@ jobs:
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
-            bash -c '
-            export CCACHE_DIR="$PWD/.ccache" &&
+            bash -c "
+            export CCACHE_DIR=$PWD/.ccache &&
             ccache --set-config=sloppiness=locale,time_macros &&
             bash --version &&
-            bash scripts/build.sh --debug --forcefallback --portable --release'
+            bash scripts/build.sh --debug --forcefallback --portable --release"
       - name: Package Portables
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
-            bash -c '
-            export CCACHE_DIR="$PWD/.ccache" &&
+            bash -c "
+            export CCACHE_DIR=$PWD/.ccache &&
             ccache --set-config=sloppiness=locale,time_macros &&
             bash scripts/package.sh --version ${INSTALL_REF} --debug --binary --release &&
-            bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release'
+            bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release"
       - name: Build AppImages
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.1.1
         with:
           args: >-
-            bash -c '
-            export CCACHE_DIR="$PWD/.ccache" &&
+            bash -c "
+            export CCACHE_DIR=$PWD/.ccache &&
             ccache --set-config=sloppiness=locale,time_macros &&
             bash scripts/appimage.sh --debug --static --version ${INSTALL_REF} --release &&
-            bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}'
+            bash scripts/appimage.sh --debug --nobuild --addons --version ${INSTALL_REF}"
       - name: Upload Files
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
This PR does a few things:

1. Update the labeler action to remove warnings
2. Make `actions/setup-python` fetch Python 3.11 instead of any 3.x.
3. Update `actions/upload-artifact` and `actions/download-artifact` to v4, which requires some changes on artifact naming because you can no longer modify artifacts.
4. Upload other artifacts as well

Is there any actual performance improvements from switching to v4? Not really, we don't upload alot of stuff anyway. I don't know if GitHub plans to deprecate v3 in the future, so I'm trying to future-proof this. It does make downloading artifacts better tho (now the zip files you downloaded won't be corrupt).