### PR TITLE
scripts: not hardcode MSYSTEM

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -77,11 +77,17 @@ get_platform_arch() {
   platform=$(get_platform_name)
   arch=${CROSS_ARCH:-$(uname -m)}
   if [[ $MSYSTEM != "" ]]; then
-    if [[ $MSYSTEM == "MINGW64" ]]; then
+    case "$MSYSTEM" in
+      MINGW64|UCRT64|CLANG64)
       arch=x86_64
-    else
+      ;;
+      MINGW32|CLANG32)
       arch=i686
-    fi
+      ;;
+      CLANGARM64)
+      arch=aarch64
+      ;;
+    esac
   fi
   echo "$arch"
 }

--- a/scripts/innosetup/innosetup.iss.in
+++ b/scripts/innosetup/innosetup.iss.in
@@ -26,12 +26,16 @@ AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 
-#if Arch=="x64"
-  ArchitecturesAllowed=x64
-  ArchitecturesInstallIn64BitMode=x64
-  #define ArchInternal "x86_64"
-#else
+#if Arch=="x86"
   #define ArchInternal "i686"
+#else
+  ArchitecturesAllowed={#Arch}
+  ArchitecturesInstallIn64BitMode={#Arch}
+  #if Arch=="x64"
+    #define ArchInternal "x86_64"
+  #elif Arch=="arm64"
+    #define ArchInternal "aarch64"
+  #endif
 #endif
 
 AllowNoIcons=yes

--- a/scripts/innosetup/innosetup.sh
+++ b/scripts/innosetup/innosetup.sh
@@ -29,13 +29,24 @@ main() {
   local version
   local output
 
-  if [[ $MSYSTEM == "MINGW64" ]]; then
+  case "$MSYSTEM" in
+    MINGW64|UCRT64|CLANG64)
     arch=x64
     arch_file=x86_64
-  else
-    arch=i686;
+    ;;
+    MINGW32|CLANG32)
+    arch=x86
     arch_file=i686
-  fi
+    ;;
+    CLANGARM64)
+    arch=arm64
+    arch_file=aarch64
+    ;;
+    *)
+    echo "error: unsupported MSYSTEM type: $MSYSTEM"
+    exit 1
+    ;;
+  esac
 
   initial_arg_count=$#
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -213,14 +213,18 @@ main() {
     if [[ $platform == "windows" ]]; then
       exe_file="${exe_file}.exe"
       stripcmd="strip --strip-all"
-      # Copy MinGW libraries dependencies.
-      # MSYS2 ldd command seems to be only 64bit, so use ntldd
-      # see https://github.com/msys2/MINGW-packages/issues/4164
-      ntldd -R "${exe_file}" \
-        | grep mingw \
-        | awk '{print $3}' \
-        | sed 's#\\#/#g' \
-        | xargs -I '{}' cp -v '{}' "$(pwd)/${dest_dir}/"
+      if command -v ntldd >/dev/null 2>&1; then
+        # Copy MinGW libraries dependencies.
+        # MSYS2 ldd command seems to be only 64bit, so use ntldd
+        # see https://github.com/msys2/MINGW-packages/issues/4164
+        ntldd -R "${exe_file}" \
+          | grep mingw \
+          | awk '{print $3}' \
+          | sed 's#\\#/#g' \
+          | xargs -I '{}' cp -v '{}' "$(pwd)/${dest_dir}/"
+      else
+        echo "WARNING: ntldd not found; assuming program is static"
+      fi
     else
       # Windows archive is always portable
       package_name+="-portable"


### PR DESCRIPTION
Various parts of the script hardcodes `MSYSTEM`. This means once you switched MINGW64 out for something like UCRT64 hell breaks loose.

Fixes #1737.