### PR TITLE
Fix multi-type usage in delimited patterns

### DIFF
--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -282,7 +282,8 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
     -- continue trying to match the end pattern of a pair if we have a state set
     if current_pattern_idx > 0 then
       local p = current_syntax.patterns[current_pattern_idx]
-      local s, e = find_text(text, p, i, false, true)
+      local find_results = { find_text(text, p, i, false, true) }
+      local s, e = find_results[1], find_results[2]
       -- Use the first token type specified in the type table for the "middle"
       -- part of the subsyntax.
       local token_type = type(p.type) == "table" and p.type[1] or p.type
@@ -307,7 +308,12 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
       -- continue on as normal.
       if cont then
         if s then
-          push_token(res, token_type, text:usub(i, e))
+          -- Push remaining token before the end delimiter
+          if s > i then
+            push_token(res, token_type, text:usub(i, s - 1))
+          end
+          -- Push the end delimiter
+          push_tokens(res, current_syntax, p, text, find_results)
           set_subsyntax_pattern_idx(0)
           i = e + 1
         else


### PR DESCRIPTION
In the "end" pattern we weren't considering the multiple types.

~~Creating as draft as I need to check some more cases.~~

Example:
Using
```lua
local syntax = require "core.syntax"
syntax.add({
  name = "test",
  files = { "%.TEST$" },
  patterns = {
    { pattern = { "hello()", "world()123" }, type = { "string", "number" } },
    { pattern = "[^h]+", type = "comment" }
  },
  symbols = {}
})
```

Before:
![Schermata del 2024-04-15 10-03-23](https://github.com/lite-xl/lite-xl/assets/2798487/39b930ba-d572-47fc-925c-88e2df199344)

After:
![Schermata del 2024-04-15 10-02-50](https://github.com/lite-xl/lite-xl/assets/2798487/05987c83-0695-4be4-bdc2-e4a9f840714e)
