### PR TITLE
Limit `language_js` regex avoidance to numbers, and fix starting `/*` comments

### DIFF
--- a/data/plugins/language_js.lua
+++ b/data/plugins/language_js.lua
@@ -20,10 +20,10 @@ local syntax = require "core.syntax"
 --                                followed by pattern options, and anything that can
 --                                be after a pattern.
 --
--- Demo with some unit tests (click on the Unit Tests entry): https://regex101.com/r/R0w8Qw/1
+-- Demo with some unit tests (click on the Unit Tests entry): https://regex101.com/r/Vx5L5V/1
 -- Note that it has a couple of changes to make it work on that platform.
 local regex_pattern = {
-  [=[/(?=(?!/)(?:(?>[^\\[\/]++|\\.|\[(?:[^\\\]]++|\\.)*+\])*+)++/[gmiyuvsd]*\s*[\n,;\)\]\}\.])()]=],
+  [=[\/(?=(?!\/)(?:(?>[^\\[\/]++|\\.|\[(?:[^\\\]]++|\\.)*+\])*+)++\/[gmiyuvsd]*\s*(?:[\n,;\)\]\}\.]|\/[\/*]))()]=],
   "/()[gmiyuvsd]*", "\\"
 }
 
@@ -57,19 +57,19 @@ syntax.add {
   comment = "//",
   block_comment = { "/*", "*/" },
   patterns = {
-    { pattern = "//.*",                                            type = "comment"  },
-    { pattern = { "/%*", "%*/" },                                  type = "comment"  },
-    { regex = regex_pattern, syntax = inner_regex_syntax,          type = {"string", "string"}  },
-    { pattern = { '"', '"', '\\' },                                type = "string"   },
-    { pattern = { "'", "'", '\\' },                                type = "string"   },
-    { pattern = { "`", "`", '\\' },                                type = "string"   },
-    -- Use (?:\/(?!\/))? to avoid that a regex can start after a number, while also allowing // comments
-    { regex   = [[-?0[xXbBoO][\da-fA-F_]+n?()\s*()(?:\/(?!\/))?]], type = {"number", "normal", "operator"}   },
-    { regex   = [[-?\d+[0-9.eE_n]*()\s*()(?:\/(?!\/))?]],          type = {"number", "normal", "operator"}   },
-    { regex   = [[-?\.?\d+()\s*()(?:\/(?!\/))?]],                  type = {"number", "normal", "operator"}   },
-    { pattern = "[%+%-=/%*%^%%<>!~|&]",                            type = "operator" },
-    { pattern = "[%a_][%w_]*%f[(]",                                type = "function" },
-    { pattern = "[%a_][%w_]*",                                     type = "symbol"   },
+    { pattern = "//.*",                                               type = "comment"  },
+    { pattern = { "/%*", "%*/" },                                     type = "comment"  },
+    { regex = regex_pattern, syntax = inner_regex_syntax,             type = {"string", "string"}  },
+    { pattern = { '"', '"', '\\' },                                   type = "string"   },
+    { pattern = { "'", "'", '\\' },                                   type = "string"   },
+    { pattern = { "`", "`", '\\' },                                   type = "string"   },
+    -- Use (?:\/(?!\/|\*))? to avoid that a regex can start after a number, while also allowing // and /* comments
+    { regex   = [[-?0[xXbBoO][\da-fA-F_]+n?()\s*()(?:\/(?!\/|\*))?]], type = {"number", "normal", "operator"}   },
+    { regex   = [[-?\d+[0-9.eE_n]*()\s*()(?:\/(?!\/|\*))?]],          type = {"number", "normal", "operator"}   },
+    { regex   = [[-?\.?\d+()\s*()(?:\/(?!\/|\*))?]],                  type = {"number", "normal", "operator"}   },
+    { pattern = "[%+%-=/%*%^%%<>!~|&]",                               type = "operator" },
+    { pattern = "[%a_][%w_]*%f[(]",                                   type = "function" },
+    { pattern = "[%a_][%w_]*",                                        type = "symbol"   },
   },
   symbols = {
     ["async"]      = "keyword",

--- a/data/plugins/language_js.lua
+++ b/data/plugins/language_js.lua
@@ -69,7 +69,7 @@ syntax.add {
     { regex   = [[-?\.?\d+()\s*()(?:\/(?!\/))?]],                  type = {"number", "normal", "operator"}   },
     { pattern = "[%+%-=/%*%^%%<>!~|&]",                            type = "operator" },
     { pattern = "[%a_][%w_]*%f[(]",                                type = "function" },
-    { regex   = [=[[a-zA-Z_]\w*()\s*()(?:\/(?!\/))?]=],            type = {"symbol", "normal", "operator"}   },
+    { pattern = "[%a_][%w_]*",                                     type = "symbol"   },
   },
   symbols = {
     ["async"]      = "keyword",


### PR DESCRIPTION
Edit:

Before:
![Schermata del 2024-03-16 02-28-19](https://github.com/lite-xl/lite-xl/assets/2798487/52bcb4c2-5d62-4cfc-b806-345e870ccb28)

After:
![Schermata del 2024-03-16 02-28-01](https://github.com/lite-xl/lite-xl/assets/2798487/97750616-2692-494e-a68f-26e8c65f3a4e)