### PR TITLE
Update linewrapping.lua: Linewrap autostarts only for specified file extensions

### DIFF
--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -376,7 +376,7 @@ function DocView:new(doc)
   if not open_files[doc] then open_files[doc] = {} end
   table.insert(open_files[doc], self)
   if config.plugins.linewrapping.enable_by_default
-  and matches_any(self.doc.filename or "", config.plugins.linewrapping.files)
+      and matches_any(self.doc.filename or "", config.plugins.linewrapping.files)
   then
     self.wrapping_enabled = true
     LineWrapping.update_docview_breaks(self)

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -23,9 +23,9 @@ config.plugins.linewrapping = common.merge({
   enable_by_default = false,
   -- Requires tokenization
   require_tokenization = false,
-  -- The config specification used by gui generators
-  files = { "%.txt$", "%.md$", "%.markdown$" },
   -- List of Lua patterns matching files extensions to linewrap.
+  files = { "%.txt$", "%.md$", "%.markdown$" },
+  -- The config specification used by gui generators
   config_spec = {
     name = "Line Wrapping",
     {
@@ -69,7 +69,7 @@ config.plugins.linewrapping = common.merge({
     },
     {
     label = "Files",
-    description = "List of Lua patterns matching files extensions to linewrap.",
+    description = "List of Lua patterns matching file names to linewrap.",
     path = "files",
     type = "list_strings",
     default = { "%.txt$", "%.md$", "%.markdown$" }

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -89,6 +89,12 @@ local function get_tokens(doc, line)
   return spew_tokens, doc, line
 end
 
+local function matches_any(filename, ptns)
+  for _, ptn in ipairs(ptns) do
+    if filename:find(ptn) then return true end
+  end
+end
+
 -- Computes the breaks for a given line, width and mode. Returns a list of columns
 -- at which the line should be broken.
 function LineWrapping.compute_line_breaks(doc, default_font, line, width, mode)

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -376,7 +376,8 @@ function DocView:new(doc)
   if not open_files[doc] then open_files[doc] = {} end
   table.insert(open_files[doc], self)
   if config.plugins.linewrapping.enable_by_default
-      and matches_any(self.doc.filename or "", config.plugins.linewrapping.files)
+      and (matches_any(self.doc.abs_filename or "", config.plugins.linewrapping.files)
+        or matches_any(self.doc.filename     or "", config.plugins.linewrapping.files))
   then
     self.wrapping_enabled = true
     LineWrapping.update_docview_breaks(self)

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -55,7 +55,7 @@ config.plugins.linewrapping = common.merge({
     },
     {
       label = "Enable by Default",
-      description = "Whether or not to enable wrapping by default when opening files.",
+      description = "Whether or not to enable wrapping by default when opening files matching with the filename pattern specified in \"Files\".",
       path = "enable_by_default",
       type = "toggle",
       default = false

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -24,6 +24,8 @@ config.plugins.linewrapping = common.merge({
   -- Requires tokenization
   require_tokenization = false,
   -- The config specification used by gui generators
+  files = { "%.txt$", "%.md$", "%.markdown$" },
+  -- List of Lua patterns matching files extensions to linewrap.
   config_spec = {
     name = "Line Wrapping",
     {
@@ -64,7 +66,14 @@ config.plugins.linewrapping = common.merge({
       path = "require_tokenization",
       type = "toggle",
       default = false
-    }
+    },
+    {
+    label = "Files",
+    description = "List of Lua patterns matching files extensions to linewrap.",
+    path = "files",
+    type = "list_strings",
+    default = { "%.txt$", "%.md$", "%.markdown$" }
+    },
   }
 }, config.plugins.linewrapping)
 
@@ -366,7 +375,9 @@ function DocView:new(doc)
   old_new(self, doc)
   if not open_files[doc] then open_files[doc] = {} end
   table.insert(open_files[doc], self)
-  if config.plugins.linewrapping.enable_by_default then
+  if config.plugins.linewrapping.enable_by_default
+  and matches_any(self.doc.filename or "", config.plugins.linewrapping.files)
+  then
     self.wrapping_enabled = true
     LineWrapping.update_docview_breaks(self)
   else


### PR DESCRIPTION
Modifications greatly inspired form the `spellcheck` plugin.

Now, any time a file is opened, the plugin checks if `linewrapping` is enabled by default *and* that the file extension match the given patterns.