### PR TITLE
`language_js` Shebang pattern `#!`

### DIFF
--- a/data/plugins/language_js.lua
+++ b/data/plugins/language_js.lua
@@ -59,6 +59,7 @@ syntax.add {
   patterns = {
     { pattern = "//.*",                                               type = "comment"  },
     { pattern = { "/%*", "%*/" },                                     type = "comment"  },
+    { pattern = "^#!.*",                                              type = "comment"  },
     { regex = regex_pattern, syntax = inner_regex_syntax,             type = {"string", "string"}  },
     { pattern = { '"', '"', '\\' },                                   type = "string"   },
     { pattern = { "'", "'", '\\' },                                   type = "string"   },


### PR DESCRIPTION
To support nodejs special shebang:
![before](https://github.com/lite-xl/lite-xl/assets/52936496/2109633d-10fb-4e02-90a1-71d7a16d950f)

The pattern is `^#!.*` which is similar to the one used in https://www.npmjs.com/package/shebang-regex

![after](https://github.com/lite-xl/lite-xl/assets/52936496/6045183c-6918-4858-8efc-653584dd6e5c)