### PR TITLE
fix: problem with reloading doc too quickly

### DIFF
--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -53,7 +53,9 @@ local function reload_doc_watch(doc)
   -- more than 2 seconds.
   local known_content
   local iter = 0
-  while iter <= 6 do
+  local start_time = system.get_time()
+  local max_iter = 6
+  while iter <= max_iter do
     local fp = io.open(doc.abs_filename, "rb")
     local new_content = fp and fp:read("*a")
     if new_content and new_content ~= known_content then
@@ -61,10 +63,17 @@ local function reload_doc_watch(doc)
       -- update the known content we store.
       reload_doc(doc)
       known_content = new_content
+      start_time = system.get_time()
       iter = 0
     end
-    coroutine.yield(wait_base_time * math.pow(2, iter))
-    iter = iter + 1
+    local now = system.get_time()
+    local new_time
+    -- increase iter until its associated time is greater than the present instant
+    repeat
+      iter = iter + 1
+      new_time = start_time + wait_base_time * math.pow(2, iter)
+    until new_time > now
+    coroutine.yield(new_time - now)
   end
 end
 


### PR DESCRIPTION
This problem fix a problem occurring sometimes when a file change of content.

What happens is that when the file changes the OS send a signal to the directory watch to say the file changed. In turns the application immediately update the document's content by reading the file. The problem is sometimes the file is initially truncated and the content is added afterward. Currently the application can reload the file content too quickly and get an empty file because the content was added only later.

With this fix we install a watcher thread for the documents that checks periodically for changes in the file content for a period of approximatively two seconds. In the normal case it will load the document's content only once but if required it will update it multiple times as soon as changes are observed.