### PR TITLE
Guldoman's Pocket Design

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -162,8 +162,7 @@ command.add(nil, {
   end,
 
   ["core:open-log"] = function()
-    local node = core.root_view:get_active_node_default()
-    node:add_view(LogView())
+    core.root_view:add_view(LogView(), "root")
   end,
 
   ["core:open-user-module"] = function()

--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -8,18 +8,6 @@ local Node = require "core.node"
 
 
 local t = {
-  ["root:close"] = function(node)
-    node:close_active_view(core.root_view.root_node)
-  end,
-
-  ["root:close-or-quit"] = function(node)
-    if node and (not node:is_empty() or not node.is_primary_node) then
-      node:close_active_view(core.root_view.root_node)
-    else
-      core.quit()
-    end
-  end,
-
   ["root:close-all"] = function()
     core.confirm_close_docs(core.docs, core.root_view.close_all_docviews, core.root_view)
   end,
@@ -44,10 +32,6 @@ local t = {
       table.remove(node.views, idx)
       table.insert(node.views, idx + 1, core.active_view)
     end
-  end,
-
-  ["root:toggle-pocket"] = function(node)
-
   end,
 
   ["root:shrink"] = function(node)
@@ -76,11 +60,7 @@ end
 
 for _, dir in ipairs { "left", "right", "up", "down" } do
   t["root:split-" .. dir] = function(node)
-    local av = node.active_view
-    node:split(dir)
-    if av:is(DocView) then
-      core.root_view:open_doc(av.doc)
-    end
+    node:split(dir, node.active_view:is(DocView) and DocView(node.active_view.doc) or nil)
   end
 
   t["root:switch-to-" .. dir] = function(node)
@@ -104,6 +84,22 @@ command.add(function()
   local node = core.root_view:get_active_node()
   return true, node
 end, t)
+
+command.add(function()
+  local node = core.root_view:get_active_node()
+  return node.active_view and node.active_view.closable, node
+end, {
+  ["root:close"] = function(node)
+    node:close_active_view(core.root_view.root_node)
+  end,
+  ["root:close-or-quit"] = function(node)
+    if node and (not node:is_empty() or not node.is_primary_node) then
+      node:close_active_view(core.root_view.root_node)
+    else
+      core.quit()
+    end
+  end,
+})
 
 command.add(nil, {
   ["root:scroll"] = function(delta)

--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -7,15 +7,30 @@ local config = require "core.config"
 local Node = require "core.node"
 
 
+local function close_docviews(keep_active)
+  local root = core.root_view.root_node
+  root:propogate(function(node)
+    local i = 1
+    while i <= #node.views do
+      local view = node.views[i]
+      if view.context == "session" and (not keep_active or view ~= node.active_view) then
+        node:close_view(root, view)
+      else
+        i = i + 1
+      end
+    end
+  end)
+end
+
 local t = {
   ["root:close-all"] = function()
-    core.confirm_close_docs(core.docs, core.root_view.close_all_docviews, core.root_view)
+    core.confirm_close_docs(core.docs, close_docviews)
   end,
 
   ["root:close-all-others"] = function()
     local active_doc, docs = core.active_view and core.active_view.doc, {}
     for i, v in ipairs(core.docs) do if v ~= active_doc then table.insert(docs, v) end end
-    core.confirm_close_docs(docs, core.root_view.close_all_docviews, core.root_view, true)
+    core.confirm_close_docs(docs, close_docviews, true)
   end,
 
   ["root:move-tab-left"] = function(node)

--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -7,30 +7,15 @@ local config = require "core.config"
 local Node = require "core.node"
 
 
-local function close_docviews(keep_active)
-  local root = core.root_view.root_node
-  root:propogate(function(node)
-    local i = 1
-    while i <= #node.views do
-      local view = node.views[i]
-      if view.context == "session" and (not keep_active or view ~= node.active_view) then
-        node:close_view(root, view)
-      else
-        i = i + 1
-      end
-    end
-  end)
-end
-
 local t = {
   ["root:close-all"] = function()
-    core.confirm_close_docs(core.docs, close_docviews)
+    core.confirm_close_docs(core.docs, core.root_view.close_session_views, core.root_view)
   end,
 
   ["root:close-all-others"] = function()
     local active_doc, docs = core.active_view and core.active_view.doc, {}
     for i, v in ipairs(core.docs) do if v ~= active_doc then table.insert(docs, v) end end
-    core.confirm_close_docs(docs, close_docviews, true)
+    core.confirm_close_docs(docs, core.close_session_views, core.root_view, true)
   end,
 
   ["root:move-tab-left"] = function(node)

--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -91,9 +91,14 @@ command.add(function()
 end, {
   ["root:close"] = function(node)
     node:close_active_view(core.root_view.root_node)
-  end,
+  end
+})
+command.add(function()
+  local node = core.root_view:get_active_node()
+  return node.active_view, node
+end, {
   ["root:close-or-quit"] = function(node)
-    if node and (not node:is_empty() or not node.is_primary_node) then
+    if node and (not node:is_empty() or not node.closable) then
       node:close_active_view(core.root_view.root_node)
     else
       core.quit()

--- a/data/core/commands/root.lua
+++ b/data/core/commands/root.lua
@@ -46,6 +46,10 @@ local t = {
     end
   end,
 
+  ["root:toggle-pocket"] = function(node)
+
+  end,
+
   ["root:shrink"] = function(node)
     local parent = node:get_parent_node(core.root_view.root_node)
     local n = (parent.a == node) and -0.1 or 0.1
@@ -98,8 +102,7 @@ end
 
 command.add(function()
   local node = core.root_view:get_active_node()
-  local sx, sy = node:get_locked_size()
-  return not sx and not sy, node
+  return true, node
 end, t)
 
 command.add(nil, {

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -266,7 +266,7 @@ config.pockets = {
   { id = "command", direction = "down", layout = "single" },
   { id = "top", direction = "up", layout = "hsplit", length = 200*SCALE },
   { id = "bottom", direction = "down", layout = "hsplit", length = 200*SCALE, tabbable = true },
-  { id = "left", direction = "left", layout = "primary", length = 200*SCALE, always_show_tabs = false },
+  { id = "left", direction = "left", layout = "primary", length = 240*SCALE, always_show_tabs = false },
   { id = "right", direction = "right", layout = "primary", length = 200*SCALE },
   { id = "drawer", direction = "down", layout = "primary", length = 200*SCALE }
 }

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -265,10 +265,10 @@ config.pockets = {
   -- { id = "status", direction = "down", layout = "single" },
   -- { id = "command", direction = "down", layout = "single" },
   -- { id = "top", direction = "up", layout = "hsplit", length = 200*SCALE },
-  -- { id = "bottom", direction = "down", layout = "hsplit", length = 200*SCALE },
-  { id = "left", direction = "left", layout = "tab", length = 200*SCALE },
-  -- { id = "right", direction = "right", layout = "tab", length = 200*SCALE },
-  -- { id = "drawer", direction = "down", layout = "tab", length = 200*SCALE }
+  -- { id = "bottom", direction = "down", layout = "hsplit", length = 200*SCALE, tabbable = true },
+     { id = "left", direction = "left", layout = "primary", length = 200*SCALE },
+  -- { id = "right", direction = "right", layout = "primary", length = 200*SCALE },
+  -- { id = "drawer", direction = "down", layout = "primary", length = 200*SCALE }
 }
 
 -- holds the plugins real config table

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -264,10 +264,10 @@ config.pockets = {
   { id = "nag", direction = "up", layout = "single" },
   { id = "status", direction = "down", layout = "single" },
   { id = "command", direction = "down", layout = "single" },
-  -- { id = "top", direction = "up", layout = "hsplit", length = 200*SCALE },
-  -- { id = "bottom", direction = "down", layout = "hsplit", length = 200*SCALE, tabbable = true },
-     { id = "left", direction = "left", layout = "primary", length = 200*SCALE, always_show_tabs = false },
-  -- { id = "right", direction = "right", layout = "primary", length = 200*SCALE },
+  { id = "top", direction = "up", layout = "hsplit", length = 200*SCALE },
+  { id = "bottom", direction = "down", layout = "hsplit", length = 200*SCALE, tabbable = true },
+  { id = "left", direction = "left", layout = "primary", length = 200*SCALE, always_show_tabs = false },
+  --{ id = "right", direction = "right", layout = "primary", length = 200*SCALE },
   -- { id = "drawer", direction = "down", layout = "primary", length = 200*SCALE }
 }
 

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -254,6 +254,23 @@ config.max_clicks = 3
 ---@type boolean
 config.skip_plugins_version = false
 
+---Sets up the system of named pockets
+---Additional pockets can be set up, or renamed here.
+---Pockets can have a direction to split off the main view from, and a preference of how to add views.
+---
+---@type table
+config.pockets = {
+  -- { id = "title", direction = "up", layout = "single" },
+  -- { id = "nag", direction = "up", layout = "single" },
+  -- { id = "status", direction = "down", layout = "single" },
+  -- { id = "command", direction = "down", layout = "single" },
+  -- { id = "top", direction = "up", layout = "hsplit", length = 200*SCALE },
+  -- { id = "bottom", direction = "down", layout = "hsplit", length = 200*SCALE },
+  { id = "left", direction = "left", layout = "tab", length = 200*SCALE },
+  -- { id = "right", direction = "right", layout = "tab", length = 200*SCALE },
+  -- { id = "drawer", direction = "down", layout = "tab", length = 200*SCALE }
+}
+
 -- holds the plugins real config table
 local plugins_config = {}
 

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -268,7 +268,7 @@ config.pockets = {
   { id = "bottom", direction = "down", layout = "hsplit", length = 200*SCALE, tabbable = true },
   { id = "left", direction = "left", layout = "primary", length = 240*SCALE, always_show_tabs = false },
   { id = "right", direction = "right", layout = "primary", length = 200*SCALE },
-  --{ id = "drawer", direction = "down", layout = "primary", length = 200*SCALE }
+  { id = "drawer", direction = "down", layout = "primary", length = 200*SCALE }
 }
 
 -- holds the plugins real config table

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -260,13 +260,13 @@ config.skip_plugins_version = false
 ---
 ---@type table
 config.pockets = {
-  -- { id = "title", direction = "up", layout = "single" },
-  -- { id = "nag", direction = "up", layout = "single" },
-  -- { id = "status", direction = "down", layout = "single" },
-  -- { id = "command", direction = "down", layout = "single" },
+  { id = "title", direction = "up", layout = "single" },
+  { id = "nag", direction = "up", layout = "single" },
+  { id = "status", direction = "down", layout = "single" },
+  { id = "command", direction = "down", layout = "single" },
   -- { id = "top", direction = "up", layout = "hsplit", length = 200*SCALE },
   -- { id = "bottom", direction = "down", layout = "hsplit", length = 200*SCALE, tabbable = true },
-     { id = "left", direction = "left", layout = "primary", length = 200*SCALE },
+     { id = "left", direction = "left", layout = "primary", length = 200*SCALE, always_show_tabs = false },
   -- { id = "right", direction = "right", layout = "primary", length = 200*SCALE },
   -- { id = "drawer", direction = "down", layout = "primary", length = 200*SCALE }
 }

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -267,8 +267,8 @@ config.pockets = {
   { id = "top", direction = "up", layout = "hsplit", length = 200*SCALE },
   { id = "bottom", direction = "down", layout = "hsplit", length = 200*SCALE, tabbable = true },
   { id = "left", direction = "left", layout = "primary", length = 200*SCALE, always_show_tabs = false },
-  --{ id = "right", direction = "right", layout = "primary", length = 200*SCALE },
-  -- { id = "drawer", direction = "down", layout = "primary", length = 200*SCALE }
+  { id = "right", direction = "right", layout = "primary", length = 200*SCALE },
+  { id = "drawer", direction = "down", layout = "primary", length = 200*SCALE }
 }
 
 -- holds the plugins real config table

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -268,7 +268,7 @@ config.pockets = {
   { id = "bottom", direction = "down", layout = "hsplit", length = 200*SCALE, tabbable = true },
   { id = "left", direction = "left", layout = "primary", length = 240*SCALE, always_show_tabs = false },
   { id = "right", direction = "right", layout = "primary", length = 200*SCALE },
-  { id = "drawer", direction = "down", layout = "primary", length = 200*SCALE }
+  --{ id = "drawer", direction = "down", layout = "primary", length = 200*SCALE }
 }
 
 -- holds the plugins real config table

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -63,6 +63,8 @@ function DocView:new(doc)
   self.last_x_offset = {}
   self.ime_selection = { from = 0, size = 0 }
   self.ime_status = false
+  self.closable = true
+  self.movable = true
   self.hovering_gutter = false
   self.v_scrollbar:set_forced_status(config.force_scrollbar_status)
   self.h_scrollbar:set_forced_status(config.force_scrollbar_status)

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -88,7 +88,7 @@ end
 
 function core.open_folder_project(dir_path_abs)
   if core.set_project_dir(dir_path_abs, core.on_quit_project) then
-    core.root_view:close_all_docviews()
+    core.root_view:close_session_views()
     reload_customizations()
     update_recents_project("add", dir_path_abs)
     core.add_project_directory(dir_path_abs)

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -853,7 +853,7 @@ function core.confirm_close_docs(docs, close_fn, ...)
       { text = "Yes", default_yes = true },
       { text = "No", default_no = true }
     }
-    core.root_view.nag_view:show("Unsaved Changes", text, opt, function(item)
+    core.nag_view:show("Unsaved Changes", text, opt, function(item)
       if item.text == "Yes" then close_fn(table.unpack(args)) end
     end)
   else

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1182,7 +1182,6 @@ end
 
 function core.custom_log(level, show, backtrace, fmt, ...)
   local text = string.format(fmt, ...)
-  print(text)
   if show then
     local s = style.log[level]
     if core.root_view.status_view then

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -736,29 +736,7 @@ function core.init()
   core.restart_request = false
   core.quit_request = false
 
-  -- We load core views before plugins that may need them.
-  ---@type core.rootview
-  core.root_view = RootView()
-  ---@type core.commandview
-  core.command_view = CommandView()
-  ---@type core.statusview
-  core.status_view = StatusView()
-  ---@type core.nagview
-  core.nag_view = NagView()
-  ---@type core.titleview
-  core.title_view = TitleView()
-
-  -- Some plugins (eg: console) require the nodes to be initialized to defaults
-  local cur_node = core.root_view.root_node
-  cur_node.is_primary_node = true
-  cur_node:split("up", core.title_view, {y = true})
-  cur_node = cur_node.b
-  cur_node:split("up", core.nag_view, {y = true})
-  cur_node = cur_node.b
-  cur_node = cur_node:split("down", core.command_view, {y = true})
-  cur_node = cur_node:split("down", core.status_view, {y = true})
-
-  -- Load defaiult commands first so plugins can override them
+  -- Load default commands first so plugins can override them
   command.add_defaults()
 
   -- Load user module, plugins and project module
@@ -785,6 +763,13 @@ function core.init()
       os.exit(1)
     end
   end
+
+  ---@type core.rootview
+  core.command_view = CommandView()
+  core.status_view = StatusView()
+  core.nag_view = NagView()
+  core.title_view = TitleView()
+  core.root_view = RootView()
 
   -- Load core plugins after user ones to let the user override them
   local plugins_success, plugins_refuse_list = core.load_plugins()
@@ -832,7 +817,7 @@ function core.init()
         msg[#msg + 1] = string.format("Plugins from directory \"%s\":\n%s", common.home_encode(entry.dir), table.concat(msg_list, "\n"))
       end
     end
-    core.nag_view:show(
+    core.root_view.nag_view:show(
       "Refused Plugins",
       string.format(
         "Some plugins are not loaded due to version mismatch. Expected version %s.\n\n%s.\n\n" ..
@@ -868,7 +853,7 @@ function core.confirm_close_docs(docs, close_fn, ...)
       { text = "Yes", default_yes = true },
       { text = "No", default_no = true }
     }
-    core.nag_view:show("Unsaved Changes", text, opt, function(item)
+    core.root_view.nag_view:show("Unsaved Changes", text, opt, function(item)
       if item.text == "Yes" then close_fn(table.unpack(args)) end
     end)
   else
@@ -1197,10 +1182,11 @@ end
 
 function core.custom_log(level, show, backtrace, fmt, ...)
   local text = string.format(fmt, ...)
+  print(text)
   if show then
     local s = style.log[level]
-    if core.status_view then
-      core.status_view:show_message(s.icon, s.color, text)
+    if core.root_view.status_view then
+      core.root_view.status_view:show_message(s.icon, s.color, text)
     end
   end
 

--- a/data/core/logview.lua
+++ b/data/core/logview.lua
@@ -1,3 +1,5 @@
+-- mod-version:3
+
 local core = require "core"
 local common = require "core.common"
 local config = require "core.config"
@@ -45,7 +47,6 @@ function LogView:new()
   self.expanding = {}
   self.scrollable = true
   self.yoffset = 0
-
   core.status_view:show_message("i", style.text, "ctrl+click to copy entry")
 end
 

--- a/data/core/logview.lua
+++ b/data/core/logview.lua
@@ -45,6 +45,7 @@ function LogView:new()
   LogView.super.new(self)
   self.last_item = core.log_items[#core.log_items]
   self.expanding = {}
+  self.closable = true
   self.scrollable = true
   self.yoffset = 0
   core.status_view:show_message("i", style.text, "ctrl+click to copy entry")

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -129,7 +129,7 @@ function Node:remove_view(root, view)
     local parent = self:get_parent_node(root)
     local is_a = (parent.a == self)
     local other = parent[is_a and "b" or "a"]
-    if root.pockets.root == self then
+    if core.root_view.pockets.root == self then
       self.views = {}
       self:add_view(EmptyView())
     else
@@ -335,7 +335,7 @@ function Node:tab_hovered_update(px, py)
   if tab_index then
     local x, y, w, h = self:get_tab_rect(tab_index)
     local cx, cw = close_button_location(x, w)
-    if px >= cx and px < cx + cw and py >= y and py < y + h and config.tab_close_button then
+    if px >= cx and px < cx + cw and py >= y and py < y + h and config.tab_close_button and self.active_view.closable then
       self.hovered_close = tab_index
     end
   elseif #self.views > self:get_visible_tabs_number() then
@@ -573,7 +573,7 @@ function Node:draw_tab(view, is_active, is_hovered, is_close_hovered, x, y, w, h
   -- Close button
   local cx, cw, cpad = close_button_location(x, w)
   local show_close_button = ((is_active or is_hovered) and not standalone and config.tab_close_button)
-  if show_close_button then
+  if show_close_button and view.closable then
     local close_style = is_close_hovered and style.text or style.dim
     common.draw_text(style.icon_font, close_style, "C", nil, cx, y, cw, h)
   end

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -306,15 +306,18 @@ function Node:get_tab_overlapping_point(px, py)
   end
 end
 
+-- Determines whether this node is "thin", i.e. it's entirely controlled by the single view within it.
+function Node:is_thin()
+  return (self.pocket and self.pocket.layout == "single") or
+    (self.parent_pocket and self.parent_pocket.pocket.layout == "primary" and self ~= self.parent_pocket.a)
+end
+
 
 function Node:should_show_tabs()
   local always_show_tabs = config.always_show_tabs
-  if self.pocket and self.pocket.layout == "single" then return false end
-  if self.parent_pocket then
-    if self.parent_pocket.pocket.layout == "primary" and self ~= self.parent_pocket.a then return false end
-    if self.parent_pocket.pocket.always_show_tabs ~= nil then
-      always_show_tabs = self.parent_pocket.pocket.always_show_tabs
-    end
+  if self:is_thin() then return false end
+  if self.parent_pocket and self.parent_pocket.pocket.always_show_tabs ~= nil then
+    always_show_tabs = self.parent_pocket.pocket.always_show_tabs
   end
   local dn = core.root_view.dragged_node
   if #self.views > 1
@@ -678,8 +681,8 @@ end
 -- 2. The node is in a pocket that does not have a layout of "primary" or "single".
 -- 3. The node is a pocket that does not have a layout of "single".
 function Node:is_resizable(axis)
+  if self:is_thin() then return false end
   if self.pocket then
-    if self.pocket.layout == "single" then return false end
     if self.pocket.layout == "root" then return true end
     return (axis == "x" and (self.pocket.direction == "left" or self.pocket.direction == "right")) or
       (axis == "y" and (self.pocket.direction == "top" or self.pocket.direction == "bottom"))

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -28,11 +28,22 @@ end
 
 
 function Node:propogate(fn, ...)
-  if self.type ~= "leaf" then
-    self.a:propogate(fn, ...)
-    self.b:propogate(fn, ...)
-  end
+  if self.type ~= "leaf" then self.a:propogate(fn, ...) end
+  if self.type ~= "leaf" then self.b:propogate(fn, ...) end
   fn(self, ...)
+end
+
+function Node:view_propogate(fn, ...)
+  self:propogate(function(node)
+    local i = 1
+    while i <= #node.views do
+      local view = node.views[i]
+      fn(node, view)
+      if view == node.views[i] then
+        i = i + 1
+      end
+    end
+  end)
 end
 
 

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -688,7 +688,7 @@ function Node:is_resizable(axis)
     return (axis == "x" and (self.pocket.direction == "left" or self.pocket.direction == "right")) or
       (axis == "y" and (self.pocket.direction == "top" or self.pocket.direction == "bottom"))
   end
-  return self.parent_pocket and self.parent_pocket.layout == "root" or (self.type ~= 'leaf' and (self.a:is_resizable(axis) and self.b:is_resizable(axis)))
+  return not self.parent_pocket or (self.parent_pocket and self.parent_pocket.layout == "root" or (self.type ~= 'leaf' and (self.a:is_resizable(axis) and self.b:is_resizable(axis))))
 end
 
 

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -279,6 +279,7 @@ function Node:get_divider_overlapping_point(px, py)
 end
 
 function Node:accepts(node, mode)
+  if self.parent_pocket and self.parent_pocket.pocket.layout == "primary" then return mode == "tab" end
   return true
 end
 

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -710,18 +710,11 @@ end
 function Node:is_resizable(axis)
   if self.pocket then
     if self.pocket.layout == "single" then return false end
+    if self.pocket.layout == "root" then return true end
     return (axis == "x" and (self.pocket.direction == "left" or self.pocket.direction == "right")) or
       (axis == "y" and (self.pocket.direction == "top" or self.pocket.direction == "bottom"))
   end
   return self.is_primary_node or (self.type ~= 'leaf' and (self.a:is_resizable(axis) and self.b:is_resizable(axis)))
-end
-
-
-function Node:resize(axis, value)
-  value = math.floor(value)
-  if self.type ~= 'leaf' and self.type == (axis == "x" and "hsplit" or "vsplit") then
-    self.length = value
-  end
 end
 
 

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -452,9 +452,9 @@ function RootView:update()
   self.root_node.size = { x = self.size.x, y = self.size.y }
   self.root_node:update()
   self.root_node:update_layout(self)
-  print("BEGIN DUMP")
-  self.root_node:dump(0)
-  print("END DUMP")
+  --print("BEGIN DUMP")
+  --self.root_node:dump(0)
+  --print("END DUMP")
 
   self:update_drag_overlay()
   self:interpolate_drag_overlay(self.drag_overlay)
@@ -574,6 +574,7 @@ function RootView:add_view(view, pocket, layout)
       target = self.pockets[pocket]
       if not target then
         core.warn("can't find pocket '%s'; defaulting to primary node", pocket)
+        layout = "tab"
         target = self:get_primary_node()
       end
     end

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -498,11 +498,11 @@ end
 function RootView:update_drag_overlay()
   if not (self.dragged_node and self.dragged_node.dragging) then return end
   local over = self.root_node:get_child_overlapping_point(self.mouse.x, self.mouse.y)
-  if over and not over.tabbable then
+  local split_type = over:get_split_type(self.mouse.x, self.mouse.y)
+  if over and over:accepts(self.dragged_node, split_type) then
     local _, _, _, tab_h = over:get_scroll_button_rect(1)
     local x, y = over.position.x, over.position.y
     local w, h = over.size.x, over.size.y
-    local split_type = over:get_split_type(self.mouse.x, self.mouse.y)
 
     if split_type == "tab" and (over ~= self.dragged_node.node or #over.views > 1) then
       local tab_index, tab_x, tab_y, tab_w, tab_h = over:get_drag_overlay_tab_position(self.mouse.x, self.mouse.y)

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -544,6 +544,9 @@ function RootView:add_view(view, pocket, layout)
     end
   else
     target = self:get_active_node_default()
+    if target:is_thin() then
+      target = self:get_active_node_default("root")
+    end
   end
   target:add_view(view, nil, layout)
   return view

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -452,9 +452,9 @@ function RootView:update()
   self.root_node.size = { x = self.size.x, y = self.size.y }
   self.root_node:update()
   self.root_node:update_layout(self)
-  --print("BEGIN DUMP")
-  --self.root_node:dump(0)
-  --print("END DUMP")
+  -- print("BEGIN DUMP")
+  -- self.root_node:dump(0)
+  -- print("END DUMP")
 
   self:update_drag_overlay()
   self:interpolate_drag_overlay(self.drag_overlay)

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -46,6 +46,7 @@ function RootView:new()
     self.pockets[v.id] = self:get_primary_node():split(v.direction, defaults_view_placement[v.id], v)
   end
   self.pockets.root = self:get_primary_node()
+  self.pockets.root.pocket = { id = "root", layout = "root" }
 end
 
 
@@ -284,16 +285,6 @@ function RootView:on_mouse_released(button, x, y, ...)
 end
 
 
-local function resize_child_node(node, axis, value, delta)
-  local accept_resize = node.a:resize(axis, value)
-  if not accept_resize then
-    accept_resize = node.b:resize(axis, node.size[axis] - value)
-  end
-  if not accept_resize then
-    node.divider = node.divider + delta / node.size[axis]
-  end
-end
-
 
 ---@param x number
 ---@param y number
@@ -318,10 +309,10 @@ function RootView:on_mouse_moved(x, y, dx, dy)
     local node = self.dragged_divider
     if node.type == "hsplit" then
       x = common.clamp(x - node.position.x, 0, self.root_node.size.x * 0.95)
-      resize_child_node(node, "x", x, dx)
+      node.length = x
     elseif node.type == "vsplit" then
       y = common.clamp(y - node.position.y, 0, self.root_node.size.y * 0.95)
-      resize_child_node(node, "y", y, dy)
+      node.length = y
     end
     node.divider = common.clamp(node.divider, 0.01, 0.99)
     return

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -550,4 +550,13 @@ function RootView:add_view(view, pocket, layout)
 end
 
 
+function RootView:close_session_views(keep_active)
+  self.root_node:view_propogate(function(node, view)
+    if view.context == "session" and (not keep_active or view ~= node.active_view) then
+      node:close_view(self.root_node, view)
+    end
+  end)
+end
+
+
 return RootView

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -472,7 +472,9 @@ function RootView:update()
   self.root_node.size = { x = self.size.x, y = self.size.y }
   self.root_node:update()
   self.root_node:update_layout(self)
+  print("BEGIN DUMP")
   self.root_node:dump(0)
+  print("END DUMP")
 
   self:update_drag_overlay()
   self:interpolate_drag_overlay(self.drag_overlay)

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -88,12 +88,6 @@ function RootView:open_doc(doc)
 end
 
 
----@param keep_active boolean
-function RootView:close_all_docviews(keep_active)
-  self.root_node:close_all_docviews(self, keep_active)
-end
-
-
 ---Obtain mouse grab.
 ---
 ---This means that mouse movements will be sent to the specified view, even when

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -472,6 +472,7 @@ function RootView:update()
   self.root_node.size = { x = self.size.x, y = self.size.y }
   self.root_node:update()
   self.root_node:update_layout(self)
+  self.root_node:dump(0)
 
   self:update_drag_overlay()
   self:interpolate_drag_overlay(self.drag_overlay)

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -19,7 +19,6 @@ local RootView = View:extend()
 function RootView:new()
   RootView.super.new(self)
   self.root_node = Node()
-  self.root_node.is_primary_node = true
   self.deferred_draws = {}
   self.mouse = { x = 0, y = 0 }
   self.drag_overlay = { x = 0, y = 0, w = 0, h = 0, visible = false, opacity = 0,
@@ -42,10 +41,11 @@ function RootView:new()
     command = core.command_view,
     status = core.status_view
   }
+  local primary_node = self.root_node
   for i,v in ipairs(config.pockets) do
-    self.pockets[v.id] = self:get_primary_node():split(v.direction, defaults_view_placement[v.id], v)
+    self.pockets[v.id], primary_node = primary_node:split(v.direction, defaults_view_placement[v.id], v)
   end
-  self.pockets.root = self:get_primary_node()
+  self.pockets.root = primary_node
   self.pockets.root.pocket = { id = "root", layout = "root" }
 end
 
@@ -64,40 +64,10 @@ RootView.get_active_node_default = RootView.get_active_node
 
 
 ---@return core.node
-local function get_primary_node(node)
-  if node.is_primary_node then
-    return node
-  end
-  if node.type ~= "leaf" then
-    return get_primary_node(node.a) or get_primary_node(node.b)
-  end
-end
-
-
-
-
----@return core.node
 function RootView:get_primary_node()
-  return get_primary_node(self.root_node)
+  return self.pockets.root
 end
 
-
----@param node core.node
----@return core.node
-local function select_next_primary_node(node)
-  if node.is_primary_node then return end
-  if node.type ~= "leaf" then
-    return select_next_primary_node(node.a) or select_next_primary_node(node.b)
-  elseif not node.pocket then
-    return node
-  end
-end
-
-
----@return core.node
-function RootView:select_next_primary_node()
-  return select_next_primary_node(self.root_node)
-end
 
 
 ---@param doc core.doc
@@ -120,7 +90,7 @@ end
 
 ---@param keep_active boolean
 function RootView:close_all_docviews(keep_active)
-  self.root_node:close_all_docviews(keep_active)
+  self.root_node:close_all_docviews(self, keep_active)
 end
 
 

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -1115,7 +1115,7 @@ function StatusView:update()
   else
     self.size.y = height
   end
-
+  
   if system.get_time() < self.message_timeout then
     self.scroll.to.y = self.size.y
   else

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -59,6 +59,8 @@ function View:new()
   self.scroll = { x = 0, y = 0, to = { x = 0, y = 0 } }
   self.cursor = "arrow"
   self.scrollable = false
+  self.closable = false
+  self.movable = false
   self.v_scrollbar = Scrollbar({direction = "v", alignment = "e"})
   self.h_scrollbar = Scrollbar({direction = "h", alignment = "e"})
   self.current_scale = SCALE

--- a/data/plugins/toolbarview.lua
+++ b/data/plugins/toolbarview.lua
@@ -4,8 +4,13 @@ local common = require "core.common"
 local command = require "core.command"
 local style = require "core.style"
 local View = require "core.view"
+local config = require "core.config"
 
 local ToolbarView = View:extend()
+
+config.plugins.toolbarview = common.merge({
+  pocket = "left"
+}, config.plugins.toolbarview)
 
 
 function ToolbarView:new()
@@ -131,7 +136,6 @@ function ToolbarView:on_mouse_moved(px, py, ...)
   end
 end
 
--- The toolbarview pane is not plugged here but it is added in the
--- treeview plugin.
+core.root_view:add_view(ToolbarView(), config.plugins.toolbarview.pocket, "vsplit")
 
 return ToolbarView

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -48,6 +48,7 @@ function TreeView:new()
   self.visible = true
   self.target_size = config.plugins.treeview.size
   self.cache = {}
+  self.closable = false
   self.tooltip = { x = 0, y = 0, begin = 0, alpha = 0 }
   self.last_scroll_y = 0
 

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -1,4 +1,4 @@
--- mod-version:3
+-- mod-version:3 -- priority:99
 local core = require "core"
 local common = require "core.common"
 local command = require "core.command"
@@ -12,12 +12,11 @@ local CommandView = require "core.commandview"
 local DocView = require "core.docview"
 
 config.plugins.treeview = common.merge({
-  -- Default treeview width
-  size = 200 * SCALE,
   highlight_focused_file = true,
   expand_dirs_to_focused_file = false,
   scroll_to_focused_file = false,
-  animate_scroll_to_focused_file = true
+  animate_scroll_to_focused_file = true,
+  pocket = "left"
 }, config.plugins.treeview)
 
 local tooltip_offset = style.font:get_height()
@@ -47,7 +46,6 @@ function TreeView:new()
   TreeView.super.new(self)
   self.scrollable = true
   self.visible = true
-  self.init_size = true
   self.target_size = config.plugins.treeview.size
   self.cache = {}
   self.tooltip = { x = 0, y = 0, begin = 0, alpha = 0 }
@@ -55,14 +53,6 @@ function TreeView:new()
 
   self.item_icon_width = 0
   self.item_text_spacing = 0
-end
-
-
-function TreeView:set_target_size(axis, value)
-  if axis == "x" then
-    self.target_size = value
-    return true
-  end
 end
 
 
@@ -100,7 +90,7 @@ end
 
 
 function TreeView:get_name()
-  return nil
+  return "Tree"
 end
 
 
@@ -288,16 +278,6 @@ end
 
 function TreeView:update()
   -- update width
-  local dest = self.visible and self.target_size or 0
-  if self.init_size then
-    self.size.x = dest
-    self.init_size = false
-  else
-    self:move_towards(self.size, "x", dest, nil, "treeview")
-  end
-
-  if self.size.x == 0 or self.size.y == 0 or not self.visible then return end
-
   local duration = system.get_time() - self.tooltip.begin
   if self.hovered_item and self.tooltip.x and duration > tooltip_delay then
     self:move_towards(self.tooltip, "alpha", tooltip_alpha, tooltip_alpha_rate, "treeview")
@@ -530,29 +510,7 @@ end
 
 
 -- init
-local view = TreeView()
-local node = core.root_view:get_active_node()
-view.node = node:split("left", view, {x = true}, true)
-
--- The toolbarview plugin is special because it is plugged inside
--- a treeview pane which is itelf provided in a plugin.
--- We therefore break the usual plugin's logic that would require each
--- plugin to be independent of each other. In addition it is not the
--- plugin module that plug itself in the active node but it is plugged here
--- in the treeview node.
-local toolbar_view = nil
-local toolbar_plugin, ToolbarView = pcall(require, "plugins.toolbarview")
-if config.plugins.toolbarview ~= false and toolbar_plugin then
-  toolbar_view = ToolbarView()
-  view.node:split("down", toolbar_view, {y = true})
-  local min_toolbar_width = toolbar_view:get_min_width()
-  view:set_target_size("x", math.max(config.plugins.treeview.size, min_toolbar_width))
-  command.add(nil, {
-    ["toolbar:toggle"] = function()
-      toolbar_view:toggle_visible()
-    end,
-  })
-end
+local view = core.root_view:add_view(TreeView(), config.plugins.treeview.pocket)
 
 -- Add a context menu to the treeview
 local menu = ContextMenu()
@@ -653,9 +611,6 @@ local previous_view = nil
 
 -- Register the TreeView commands and keymap
 command.add(nil, {
-  ["treeview:toggle"] = function()
-    view.visible = not view.visible
-  end,
 
   ["treeview:toggle-focus"] = function()
     if not core.active_view:is(TreeView) then
@@ -953,7 +908,6 @@ command.add(
 
 
 keymap.add {
-  ["ctrl+\\"]     = "treeview:toggle",
   ["up"]          = "treeview:previous",
   ["down"]        = "treeview:next",
   ["left"]        = "treeview:collapse",
@@ -978,28 +932,6 @@ keymap.add {
 
 -- The config specification used by gui generators
 config.plugins.treeview.config_spec = {
-  name = "Treeview",
-  {
-    label = "Size",
-    description = "Default treeview width.",
-    path = "size",
-    type = "number",
-    default = toolbar_view and math.ceil(toolbar_view:get_min_width() / SCALE)
-      or 200 * SCALE,
-    min = toolbar_view and toolbar_view:get_min_width() / SCALE
-      or 200 * SCALE,
-    get_value = function(value)
-      return value / SCALE
-    end,
-    set_value = function(value)
-      return value * SCALE
-    end,
-    on_apply = function(value)
-      view:set_target_size("x", math.max(
-        value, toolbar_view and toolbar_view:get_min_width() or 200 * SCALE
-      ))
-    end
-  },
   {
     label = "Hide on Startup",
     description = "Show or hide the treeview on startup.",
@@ -1012,9 +944,6 @@ config.plugins.treeview.config_spec = {
   }
 }
 
--- Return the treeview with toolbar and contextmenu to allow
--- user or plugin modifications
-view.toolbar = toolbar_view
 view.contextmenu = menu
 
 return view


### PR DESCRIPTION
Initial commit of Guldoman's pocket design, to replace locked views.

The problem as it stands is that to add views, plugins need to basically split off their own nodes. This isn't sustainable, because if you have a ton of plugins they're going to start stepping on each other, and unless they're specifically coded around each other, it devolves into chaos.

Enter, the pocket system. Where you can simply tell RootView to add your view to a specific pocket, and have the central system worry about exactly how to lay it out, and where. It's configurable by the user in `config`, and in theory should allow many plugins to  play nicely with each other.

The PR currently works for all the defaults (and saves us some SLOC); but I'm going to be testing this going forward on my IDE plugins, to see how easy it is to get them to all play nice. Will report back on this.