### PR TITLE
build: fix dirmonitor backend selection

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -16,40 +16,44 @@ lite_sources += 'api/dirmonitor.c'
 if get_option('dirmonitor_backend') == ''
     if cc.has_function('inotify_init', prefix : '#include<sys/inotify.h>')
         dirmonitor_backend = 'inotify'
-        lite_sources += 'api/dirmonitor/inotify.c'
     elif host_machine.system() == 'darwin' and cc.check_header('CoreServices/CoreServices.h')
         dirmonitor_backend = 'fsevents'
-        lite_sources += 'api/dirmonitor/fsevents.c'
     elif cc.has_function('kqueue', prefix : '#include<sys/event.h>')
         dirmonitor_backend = 'kqueue'
-        lite_sources += 'api/dirmonitor/kqueue.c'
     elif cc.has_function('create_inode_watcher', prefix : '#include<fcntl.h>')
         dirmonitor_backend = 'inodewatcher'
-        add_languages('cpp')
-        lite_sources += 'api/dirmonitor/inodewatcher.cpp'
     elif dependency('libkqueue', required : false).found()
         dirmonitor_backend = 'kqueue'
-        lite_sources += 'api/dirmonitor/kqueue.c'
     elif host_machine.system() == 'windows'
         dirmonitor_backend = 'win32'
-        lite_sources += 'api/dirmonitor/win32.c'
     else
         dirmonitor_backend = 'dummy'
-        lite_sources += 'api/dirmonitor/dummy.c'
         warning('no suitable backend found, defaulting to dummy backend')
     endif
 else
     dirmonitor_backend = get_option('dirmonitor_backend')
 endif
 
-message('dirmonitor_backend: @0@'.format(dirmonitor_backend))
-
-if dirmonitor_backend == 'kqueue'
+if dirmonitor_backend == 'inotify'
+    lite_sources += 'api/dirmonitor/inotify.c'
+elif dirmonitor_backend == 'fsevents'
+    lite_sources += 'api/dirmonitor/fsevents.c'
+elif dirmonitor_backend == 'kqueue'
+    lite_sources += 'api/dirmonitor/kqueue.c'
     libkqueue_dep = dependency('libkqueue', required : false)
     if libkqueue_dep.found()
         lite_deps += libkqueue_dep
     endif
+elif dirmonitor_backend == 'inodewatcher'
+    add_languages('cpp')
+    lite_sources += 'api/dirmonitor/inodewatcher.cpp'
+elif dirmonitor_backend == 'win32'
+    lite_sources += 'api/dirmonitor/win32.c'
+else
+    lite_sources += 'api/dirmonitor/dummy.c'
 endif
+
+message('dirmonitor_backend: @0@'.format(dirmonitor_backend))
 
 lite_rc = []
 if host_machine.system() == 'windows'


### PR DESCRIPTION
When a backend was specified using meson, the relative source files weren't being added.

Fixes #1789.