### PR TITLE
fix: avoid iterating over a changing table in `run_threads`

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1402,7 +1402,15 @@ local run_threads = coroutine.wrap(function()
     local max_time = 1 / config.fps - 0.004
     local minimal_time_to_wake = math.huge
 
+    local threads = {}
+    -- We modify core.threads while iterating, both by removing dead threads,
+    -- and by potentially adding more threads while we yielded early,
+    -- so we need to extract the threads list and iterate over that instead.
     for k, thread in pairs(core.threads) do
+      threads[k] = thread
+    end
+
+    for k, thread in pairs(threads) do
       -- run thread
       if thread.wake < system.get_time() then
         local _, wait = assert(coroutine.resume(thread.cr))

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1411,8 +1411,8 @@ local run_threads = coroutine.wrap(function()
     end
 
     for k, thread in pairs(threads) do
-      -- run thread
-      if thread.wake < system.get_time() then
+      -- Run thread if it wasn't deleted externally and it's time to resume it
+      if core.threads[k] and thread.wake < system.get_time() then
         local _, wait = assert(coroutine.resume(thread.cr))
         if coroutine.status(thread.cr) == "dead" then
           if type(k) == "number" then


### PR DESCRIPTION
This is done to avoid iterating over a table that can change in the meantime. More precisely the issue appears if a thread is removed from the table, we yield early because we reached the end of the frame, and a new thread is added before the next iteration.

For example:
```lua
local lost_time = false
core.add_thread(function()
  -- force early yield
  local t0 = system.get_time()
  while system.get_time() - t0 < .1 do end
  lost_time = true
end, "a")

local step = core.step
function core.step()
  if lost_time then
    -- add a new thread while run_threads hasn't finished iterating
    core.add_thread(function()end, "a1")
    lost_time = false
  end
  return step()
end
```
would crash with `invalid key to 'next'`.