### PR TITLE
Change co_wait to co_await in language_cpp

### DIFF
--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -133,7 +133,7 @@ syntax.add {
     ["this"]      = "keyword",
     ["thread_local"] = "keyword",
     ["requires"]  = "keyword",
-    ["co_wait"]   = "keyword",
+    ["co_await"]   = "keyword",
     ["co_return"] = "keyword",
     ["co_yield"]  = "keyword",
     ["decltype"] = "keyword",


### PR DESCRIPTION
The C++20 keyword is spelled `co_await`.