### PR TITLE
ci: use latest macos images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      # --lhelper will eliminate a warning with arm64 and libusb
       # installing md5sha1sum will eliminate a warning with arm64 and libusb
       - name: Install Dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,13 +65,16 @@ jobs:
 
   build_macos:
     name: macOS
-    runs-on: macos-11
+    strategy:
+      matrix:
+        config:
+          - { arch: x86_64, runner: macos-13 } # macos-13 uses x86_64
+          - { arch: arm64, runner: macos-14 } # macos-14 / latest uses M1
+
+    runs-on: ${{ matrix.config.runner }}
     env:
       CC: clang
       CXX: clang++
-    strategy:
-      matrix:
-        arch: ["x86_64", "arm64"]
 
     steps:
       - name: System Information
@@ -85,8 +88,7 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
-          echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
-          if [[ $(uname -m) != ${{ matrix.arch }} ]]; then echo "ARCH=--cross-arch ${{ matrix.arch }}" >> "$GITHUB_ENV"; fi
+          echo "INSTALL_NAME=lite-xl-${GITHUB_REF##*/}-macos-${{ matrix.config.arch }}" >> "$GITHUB_ENV"
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -98,26 +100,28 @@ jobs:
 
       # --lhelper will eliminate a warning with arm64 and libusb
       - name: Install Dependencies
-        run: bash scripts/install-dependencies.sh --debug --lhelper
+        run: |
+          brew install bash md5sha1sum
+          pip install meson ninja dmgbuild
 
       - name: Build
         run: |
           bash --version
-          bash scripts/build.sh --bundle --debug --forcefallback $ARCH
+          bash scripts/build.sh --bundle --debug --forcefallback
 
       - name: Create DMG Image
-        run: bash scripts/package.sh --version ${INSTALL_REF} $ARCH --debug --dmg
+        run: bash scripts/package.sh --version ${INSTALL_REF} --debug --dmg
 
       - name: Upload DMG Image
         uses: actions/upload-artifact@v4
         with:
-          name: macOS DMG Images (${{ matrix.arch }})
+          name: macOS DMG Images (${{ matrix.config.arch }})
           path: ${{ env.INSTALL_NAME }}.dmg
           compression-level: 0
 
   build_macos_universal:
     name: macOS (Universal)
-    runs-on: macos-11
+    runs-on: macos-14
     needs: build_macos
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,7 @@ jobs:
           python-version: "3.11"
 
       # --lhelper will eliminate a warning with arm64 and libusb
+      # installing md5sha1sum will eliminate a warning with arm64 and libusb
       - name: Install Dependencies
         run: |
           brew install bash md5sha1sum

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
 
   build_macos_universal:
     name: macOS (Universal)
-    runs-on: macos-13
+    runs-on: macos-14
     needs: build_macos
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
 
   build_macos_universal:
     name: macOS (Universal)
-    runs-on: macos-14
+    runs-on: macos-13
     needs: build_macos
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,10 +129,13 @@ jobs:
   build_macos:
     name: macOS
     needs: release
-    runs-on: macos-11
     strategy:
       matrix:
-        arch: [x86_64, arm64]
+        config:
+          - { arch: x86_64, runner: macos-13 } # macos-13 uses x86_64
+          - { arch: arm64, runner: macos-14 } # macos-14 / latest uses M1
+
+    runs-on: ${{ matrix.config.runner }}
     env:
       CC: clang
       CXX: clang++
@@ -149,9 +152,8 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-          echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
-          echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos-${{ matrix.arch }}" >> "$GITHUB_ENV"
-          if [[ $(uname -m) != ${{ matrix.arch }} ]]; then echo "ARCH=--cross-arch ${{ matrix.arch }}" >> "$GITHUB_ENV"; fi
+          echo "INSTALL_NAME=lite-xl-${{ needs.release.outputs.version }}-macos-${{ matrix.config.arch }}" >> "$GITHUB_ENV"
+          echo "INSTALL_NAME_ADDONS=lite-xl-${{ needs.release.outputs.version }}-addons-macos-${{ matrix.config.arch }}" >> "$GITHUB_ENV"
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -162,22 +164,24 @@ jobs:
           python-version: "3.11"
 
       - name: Install Dependencies
-        run: bash scripts/install-dependencies.sh --debug
+        run: |
+          brew install bash md5sha1sum
+          pip install meson ninja dmgbuild
 
       - name: Build
         run: |
           bash --version
-          bash scripts/build.sh --bundle --debug --forcefallback --release $ARCH
+          bash scripts/build.sh --bundle --debug --forcefallback --release
 
       - name: Create DMG Image
         run: |
-          bash scripts/package.sh --version ${INSTALL_REF} $ARCH --debug --dmg --release
-          bash scripts/package.sh --version ${INSTALL_REF} $ARCH --debug --addons --dmg --release
+          bash scripts/package.sh --version ${INSTALL_REF} --debug --dmg --release
+          bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --dmg --release
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: macOS DMG Images (${{ matrix.arch }})
+          name: macOS DMG Images (${{ matrix.config.arch }})
           path: |
             ${{ env.INSTALL_NAME }}.dmg
             ${{ env.INSTALL_NAME_ADDONS }}.dmg
@@ -185,7 +189,7 @@ jobs:
   build_macos_universal:
     name: macOS (Universal)
     needs: [release, build_macos]
-    runs-on: macos-11
+    runs-on: macos-14
 
     steps:
       - name: System Information

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
   build_macos_universal:
     name: macOS (Universal)
     needs: [release, build_macos]
-    runs-on: macos-14
+    runs-on: macos-13
 
     steps:
       - name: System Information

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
   build_macos_universal:
     name: macOS (Universal)
     needs: [release, build_macos]
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       - name: System Information

--- a/meson.build
+++ b/meson.build
@@ -123,7 +123,6 @@ if not get_option('source-only')
     sdl_options += 'use_atomic=enabled'
     sdl_options += 'use_threads=enabled'
     sdl_options += 'use_timers=enabled'
-    sdl_options += 'with_main=true'
     # investigate if this is truly needed
     # Do not remove before https://github.com/libsdl-org/SDL/issues/5413 is released
     sdl_options += 'use_events=enabled'
@@ -150,6 +149,7 @@ if not get_option('source-only')
     sdl_options += 'test=false'
     sdl_options += 'use_sensor=disabled'
     sdl_options += 'use_haptic=disabled'
+    sdl_options += 'use_hidapi=disabled'
     sdl_options += 'use_audio=disabled'
     sdl_options += 'use_cpuinfo=disabled'
     sdl_options += 'use_joystick=disabled'

--- a/scripts/make-universal-binaries.sh
+++ b/scripts/make-universal-binaries.sh
@@ -30,4 +30,9 @@ done
 
 lipo -create -output "Lite XL.app/Contents/MacOS/lite-xl" "$WORKDIR/"*-lite-xl
 
+# https://eclecticlight.co/2019/01/17/code-signing-for-the-concerned-3-signing-an-app/
+# https://wiki.lazarus.freepascal.org/Code_Signing_for_macOS#Big_Sur_and_later_on_Apple_M1_ARM64_processors
+# codesign all the files again, hopefully this would fix signature validation
+codesign --force --deep --digest-algorithm=sha1,sha256 -s - "Lite XL.app"
+
 source scripts/appdmg.sh "$2"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -270,7 +270,8 @@ main() {
 
   if [[ $bundle == true ]]; then
     # https://eclecticlight.co/2019/01/17/code-signing-for-the-concerned-3-signing-an-app/
-    codesign --force --deep -s - "${dest_dir}"
+    # https://wiki.lazarus.freepascal.org/Code_Signing_for_macOS#Big_Sur_and_later_on_Apple_M1_ARM64_processors
+    codesign --force --deep --digest-algorithm=sha1,sha256 -s - "${dest_dir}"
   fi
 
   echo "Creating a compressed archive ${package_name}"


### PR DESCRIPTION
I didn't know the macos-11 image is getting deprecated late June. This would break CI.

![image](https://github.com/lite-xl/lite-xl/assets/20792268/3ab124b2-7b6a-44ec-93b0-0385fbf0cedf)

Aside from updating the macOS images, I also removed cross-compilation for Apple M1, since M1-based runners are now available. I also removed the dependency from `install-dependencies.sh`.

This change resulted in a significant improvement in CI time, since M1 runners are currently faster than the Intel runners, and the CI uses images that has brew prebuilts, so no more compiling bash from source.

Comparison:

CI:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/lite-xl/lite-xl/assets/20792268/2483caac-10ba-438c-b946-9759b1a97108) | ![image](https://github.com/lite-xl/lite-xl/assets/20792268/5d15b4e4-6a7e-469d-b5b0-00901516e506) |

Release:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/lite-xl/lite-xl/assets/20792268/78a6357b-ce05-47dc-b8f3-75d1de37d86c) | ![image](https://github.com/lite-xl/lite-xl/assets/20792268/30943393-134b-484e-b980-33eb0054b54c) |

