### PR TITLE
Handle static constexpr in language_cpp

### DIFF
--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -28,6 +28,15 @@ syntax.add {
     { pattern = "static()%s+()inline",
       type = { "keyword", "normal", "keyword" }
     },
+    { pattern = "static()%s+()constexpr",
+      type = { "keyword", "normal", "keyword" }
+    },
+    { pattern = "static()%s+()constinit",
+      type = { "keyword", "normal", "keyword" }
+    },
+    { pattern = "static()%s+()consteval",
+      type = { "keyword", "normal", "keyword" }
+    },
     { pattern = "static()%s+()const",
       type = { "keyword", "normal", "keyword" }
     },


### PR DESCRIPTION
Add handling for C++ declarations that look like `static constexpr` or `static consteval`.
Without this change, the `const` part was highlighted but the `eval` part wasn't.

![image](https://github.com/lite-xl/lite-xl/assets/1566237/dc508bc5-c7bd-4311-987f-36c6bd4074b1)

With this change, the keywords are highlighted properly:

![image](https://github.com/lite-xl/lite-xl/assets/1566237/c292af4a-c48a-4387-9ca0-e1db458fa811)
