### PR TITLE
Add support for numeric literal suffixes in C and CPP

### DIFF
--- a/data/plugins/language_c.lua
+++ b/data/plugins/language_c.lua
@@ -11,9 +11,23 @@ syntax.add {
     { pattern = { "/%*", "%*/" },        type = "comment" },
     { pattern = { '"', '"', '\\' },      type = "string"  },
     { pattern = { "'", "'", '\\' },      type = "string"  },
-    { pattern = "0x%x+",                 type = "number"  },
-    { pattern = "%d+[%d%.eE]*f?",        type = "number"  },
-    { pattern = "%.?%d+f?",              type = "number"  },
+    -- hex integer
+    { pattern = "0x%x+[%x']*[uUlL]*",       type = "number"   },
+    -- TODO: add hex float
+    -- float 123.456e+78f
+    { pattern = "%d+[%d']*%.[%d']*[eE][%+-]?%d+f?",
+      type = "number"
+    },
+    -- float 123.456f
+    { pattern = "%d+[%d']*%.[%d']*f?",      type = "number"   },
+    -- float .123e+45f
+    { pattern = "%.%d+[%d']*[eE][%+-]?%d+f?",
+      type = "number"
+    },
+    -- float .123f
+    { pattern = "%.%d+[%d']*f?",            type = "number"   },
+    -- decimal or octal integer
+    { pattern = "%d%d*[%d']*[uUlL]*",       type = "number"   },
     { pattern = "[%+%-=/%*%^%%<>!~|&]",  type = "operator" },
     { pattern = "##",                    type = "operator" },
     { pattern = "struct%s()[%a_][%w_]*", type = {"keyword", "keyword2"} },

--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -15,9 +15,23 @@ syntax.add {
     { pattern = { "/%*", "%*/" },           type = "comment"  },
     { pattern = { '"', '"', '\\' },         type = "string"   },
     { pattern = { "'", "'", '\\' },         type = "string"   },
-    { pattern = "0x%x+[%x']*",              type = "number"   },
-    { pattern = "%d+[%d%.'eE]*f?",          type = "number"   },
-    { pattern = "%.?%d+[%d']*f?",           type = "number"   },
+    -- hex integer
+    { pattern = "0x%x+[%x']*[uUlL]*",       type = "number"   },
+    -- TODO: add hex float
+    -- float 123.456e+78f
+    { pattern = "%d+[%d']*%.[%d']*[eE][%+-]?%d+f?",
+      type = "number"
+    },
+    -- float 123.456f
+    { pattern = "%d+[%d']*%.[%d']*f?",      type = "number"   },
+    -- float .123e+45f
+    { pattern = "%.%d+[%d']*[eE][%+-]?%d+f?",
+      type = "number"
+    },
+    -- float .123f
+    { pattern = "%.%d+[%d']*f?",            type = "number"   },
+    -- decimal or octal integer
+    { pattern = "%d%d*[%d']*[uUlL]*",       type = "number"   },
     { pattern = "[%+%-=/%*%^%%<>!~|:&]",    type = "operator" },
     { pattern = "##",                       type = "operator" },
     { pattern = "struct%s()[%a_][%w_]*",    type = {"keyword", "keyword2"} },


### PR DESCRIPTION
Modify `language_c.lua` and `language_cpp.lua` to add support for integer suffixes.

Specifically `123u` or `0x123ull` are integer literals, including the `u` and `ull` suffixes respectively.