### PR TITLE
ci: dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      groups:
+        all:
+          patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-      groups:
-        all:
-          patterns: ["*"]
+    groups:
+      all:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,5 @@ updates:
     schedule:
       interval: weekly
     groups:
-      all:
+      github-actions:
         patterns: ["*"]


### PR DESCRIPTION
me when github runners deprecate node 20 there's warning everywhere until it straight up broke

Joking aside, this is a real issue because no one actually keep tracks of new action releases, which means our CI eventually degrade and break. The recent #1804 and #1724 are good examples of how things can go really wrong. IIRC dependabot will not keep track of `docker://` protocol versions which was used by `lite-xl-build-box`, but I don't expect the build box to break.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#github-actions