### PR TITLE
Add support for binary integer literals.

### DIFF
--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -21,6 +21,7 @@ syntax.add {
     { pattern = { '"', '"', '\\' },         type = "string"   },
     { pattern = { "'", "'", '\\' },         type = "string"   },
     { regex   = "0x[0-9a-fA-f]+"..isuf,     type = "number"   },
+    { regex   = "0b[01]+"..isuf,            type = "number"   },
     { regex   = "0()[0-7]+"..isuf,          type = { "keyword", "number" } },
     { pattern = "%d+%.%d*[Ee]%d+"..fsuf,    type = "number"   },
     { pattern = "%d+[Ee]%d+"..fsuf,         type = "number"   },


### PR DESCRIPTION
Modify language_cpp to add support for binary integer literals:

```cpp
int x = 0b010101;
unsigned long long y = 0b111100001111000ull;
```