### PR TITLE
macos: support drag-and-drop and default file associations

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1313,20 +1313,7 @@ function core.on_event(type, ...)
   elseif type == "minimized" or type == "maximized" or type == "restored" then
     core.window_mode = type == "restored" and "normal" or type
   elseif type == "filedropped" then
-    if not core.root_view:on_file_dropped(...) then
-      local filename, mx, my = ...
-      local info = system.get_file_info(filename)
-      if info and info.type == "dir" then
-        system.exec(string.format("%q %q", EXEFILE, filename))
-      else
-        local ok, doc = core.try(core.open_doc, filename)
-        if ok then
-          local node = core.root_view.root_node:get_child_overlapping_point(mx, my)
-          node:set_active_view(node.active_view)
-          core.root_view:open_doc(doc)
-        end
-      end
-    end
+    core.root_view:on_file_dropped(...)
   elseif type == "focuslost" then
     core.root_view:on_focus_lost(...)
   elseif type == "quit" then

--- a/data/core/rootview.lua
+++ b/data/core/rootview.lua
@@ -27,6 +27,7 @@ function RootView:new()
   self.grab = nil -- = {view = nil, button = nil}
   self.overlapping_view = nil
   self.touched_view = nil
+  self.first_update_done = false
 end
 
 
@@ -373,29 +374,27 @@ end
 function RootView:on_file_dropped(filename, x, y)
   local node = self.root_node:get_child_overlapping_point(x, y)
   local result = node and node.active_view:on_file_dropped(filename, x, y)
-  if not result then
-    local info = system.get_file_info(filename)
-    if info and info.type == "dir" then
-      if self.first_update then
-        -- first update done, open in new window
-        system.exec(string.format("%q %q", EXEFILE, filename))
-      else
-        -- DND event before first update, this is sent by macOS when folder is dropped into the dock
-        core.confirm_close_docs(core.docs, function(dirpath)
-          core.open_folder_project(dirpath)
-        end, system.absolute_path(filename))
-      end
+  if result then return result end
+  local info = system.get_file_info(filename)
+  if info and info.type == "dir" then
+    if self.first_update_done then
+      -- first update done, open in new window
+      system.exec(string.format("%q %q", EXEFILE, filename))
     else
-      local ok, doc = core.try(core.open_doc, filename)
-      if ok then
-        local node = core.root_view.root_node:get_child_overlapping_point(x, y)
-        node:set_active_view(node.active_view)
-        core.root_view:open_doc(doc)
-      end
+      -- DND event before first update, this is sent by macOS when folder is dropped into the dock
+      core.confirm_close_docs(core.docs, function(dirpath)
+        core.open_folder_project(dirpath)
+      end, system.absolute_path(filename))
     end
-    result = true
+  else
+    local ok, doc = core.try(core.open_doc, filename)
+    if ok then
+      local node = core.root_view.root_node:get_child_overlapping_point(x, y)
+      node:set_active_view(node.active_view)
+      core.root_view:open_doc(doc)
+    end
   end
-  return result
+  return true
 end
 
 
@@ -483,7 +482,7 @@ function RootView:update()
   self:update_drag_overlay()
   self:interpolate_drag_overlay(self.drag_overlay)
   self:interpolate_drag_overlay(self.drag_overlay_tab)
-  self.first_update = true
+  self.first_update_done = true
 end
 
 

--- a/resources/macos/Info.plist.in
+++ b/resources/macos/Info.plist.in
@@ -25,11 +25,12 @@
 	</array>
 	<key>LSItemContentTypes</key>
 	<array>
-		<string>public.plain-text</string>
+		<string>public.text</string>
+		<string>public.folder</string>
 	</array>
 	<key>NSExportableTypes</key>
 	<array>
-		<string>public.plain-text</string>
+		<string>public.text</string>
 	</array>
 	<key>CFBundleIdentifier</key>
 	<string>com.lite-xl</string>

--- a/resources/macos/Info.plist.in
+++ b/resources/macos/Info.plist.in
@@ -8,8 +8,23 @@
 	<string>lite-xl</string>
 	<key>CFBundleIconFile</key>
 	<string>icon.icns</string>
-  <key>CFBundleIdentifier</key>
-  <string>com.lite-xl</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+			  <string>*</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>NSDocumentClass</key>
+			<string>NSDocument</string>
+			<key>CFBundleTypeName</key>
+			<string>All Files</string>
+		</dict>
+	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.lite-xl</string>
 	<key>CFBundleName</key>
 	<string>Lite XL</string>
 	<key>CFBundlePackageType</key>

--- a/resources/macos/Info.plist.in
+++ b/resources/macos/Info.plist.in
@@ -23,6 +23,14 @@
 			<string>All Files</string>
 		</dict>
 	</array>
+	<key>LSItemContentTypes</key>
+	<array>
+		<string>public.plain-text</string>
+	</array>
+	<key>NSExportableTypes</key>
+	<array>
+		<string>public.plain-text</string>
+	</array>
 	<key>CFBundleIdentifier</key>
 	<string>com.lite-xl</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Closes #1821.

~~Aside from fixes from our side, I am also planning to take this up to SDL2 and see if they would adapt the changes. It would eliminate the need of method swizzling if they adopted it.~~

No need for all that, this is just a info.plist change.

A potential issue is that the supported file extension can be too "wide", perhaps we should limit it?

https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-101685

## Before

https://github.com/lite-xl/lite-xl/assets/20792268/41558f6b-02fa-4cb0-a1b3-f7a112c51c54

## After

https://github.com/lite-xl/lite-xl/assets/20792268/ca464ad5-f0c9-4922-81d4-8d965912b9aa

https://github.com/lite-xl/lite-xl/assets/20792268/2ad1fdbd-7161-47b5-a711-31627da6ffa5



