### PR TITLE
Generate better release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Fetch Version
         id: tag
@@ -45,7 +43,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate Release Notes
-        run: bash scripts/generate-release-notes.sh --version ${{ steps.tag.outputs.version }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/generate-release-notes.sh --debug --version ${{ steps.tag.outputs.version }}
 
       - name: Create Release
         id: create_release
@@ -55,7 +55,6 @@ jobs:
           tag: ${{ steps.tag.outputs.version }}
           draft: true
           bodyFile: release-notes.md
-          generateReleaseNotes: true
           allowUpdates: true
 
   build_linux:

--- a/resources/release-notes.md
+++ b/resources/release-notes.md
@@ -25,7 +25,7 @@ For OS requirements, please refer to the relevant section in the [README].
 Please go to [changelog.md] for detailed description of all the changes.
 
 <!-- UPDATE THIS! -->
-**Commits since last version**: https://github.com/lite-xl/lite-xl/compare/v2.1.3...${RELEASE_TAG}
+**Commits since last version**: https://github.com/lite-xl/lite-xl/compare/${LAST_RELEASE_TAG}...${RELEASE_TAG}
 
 
 [win32-setup]:      https://github.com/lite-xl/lite-xl/releases/download/${RELEASE_TAG}/LiteXL-${RELEASE_TAG}-addons-i686-setup.exe


### PR DESCRIPTION
The updated script now uses gh CLI to fetch actual releases and correctly write the changelog. Tested in v2.1.5 release.