### PR TITLE
renderer: rewrite glyph cache

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -30,7 +30,7 @@ static FT_Library library = NULL;
 #define check_alloc(P) _check_alloc(P, __FILE__, __LINE__)
 static void* _check_alloc(void *ptr, const char *const file, size_t ln) {
   if (!ptr) {
-    fprintf(stderr, "%s:%ld: memory allocation failed\n", file, ln);
+    fprintf(stderr, "%s:%zu: memory allocation failed\n", file, ln);
     exit(EXIT_FAILURE);
   }
   return ptr;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -267,9 +267,9 @@ static void font_load_glyph(RenFont *font, unsigned int glyph_id) {
   for (int bitmap_idx = 0; bitmap_idx < bitmaps; bitmap_idx++) {
     FT_GlyphSlot slot = font->face->glyph;
     if (FT_Load_Glyph(font->face, glyph_id, load_option | FT_LOAD_BITMAP_METRICS_ONLY) != 0
-      || font_set_style(&slot->outline, bitmap_idx * (64 / SUBPIXEL_BITMAPS_CACHED), font->style) != 0
-      || FT_Render_Glyph(slot, render_option) != 0)
-    return;
+        || font_set_style(&slot->outline, bitmap_idx * (64 / SUBPIXEL_BITMAPS_CACHED), font->style) != 0
+        || FT_Render_Glyph(slot, render_option) != 0)
+      return;
 
     // save the metrics
     if (!font->glyphs.metrics[bitmap_idx][row]) {

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -224,7 +224,7 @@ static SDL_Surface *font_allocate_glyph_surface(RenFont *font, FT_GlyphSlot slot
     assert(atlas->surfaces[i]->userdata);
     GlyphMetric *m = (GlyphMetric *) atlas->surfaces[i]->userdata;
     int new_min_waste = (int) atlas->surfaces[i]->h - (int) m->y1;
-    if (new_min_waste >= 0 && new_min_waste < min_waste) {
+    if (new_min_waste >= metric->y1 && new_min_waste < min_waste) {
       surface_idx = i;
       min_waste = new_min_waste;
     }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -64,6 +64,9 @@ static void* _check_alloc(void *ptr, const char *const file, size_t ln) {
 
 // metrics for a loaded glyph
 typedef struct {
+  // 0 is a valid atlas and surface index. To check if a glyph is not loaded,
+  // also check if x == y == 0, because for loaded glyphs with no bitmap,
+  // atlas and surface index is set to BITMAP_NOT_AVAILABLE, and x and y are set to 0.
   unsigned short atlas_idx, surface_idx;
   unsigned int x0, x1, y0, y1;
   int bitmap_left, bitmap_top;
@@ -325,7 +328,7 @@ static RenFont *font_group_get_glyph(RenFont **fonts, unsigned int codepoint, in
   subpixel_idx = FONT_IS_SUBPIXEL(font) ? subpixel_idx : 0;
   int row = glyph_id / GLYPHMAP_COL, col = glyph_id - (row * GLYPHMAP_COL);
   GlyphMetric *m = font->glyphs.metrics[subpixel_idx][row] ? &font->glyphs.metrics[subpixel_idx][row][col] : NULL;
-  if (!m || !m->surface_idx) font_load_glyph(font, glyph_id);
+  if (!m || (m->surface_idx == 0 && m->x0 == m->x1)) font_load_glyph(font, glyph_id);
   if (metric && m) *metric = m;
   if (surface && m && m->atlas_idx != BITMAP_NOT_AVAILABLE) *surface = font->glyphs.atlas[subpixel_idx][m->atlas_idx].surfaces[m->surface_idx];
   return font;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -236,12 +236,12 @@ static SDL_Surface *font_allocate_glyph_surface(RenFont *font, FT_GlyphSlot slot
     if (h <= FONT_HEIGHT_OVERFLOW_PX) h += font->size;
     atlas->surfaces = check_alloc(realloc(atlas->surfaces, sizeof(SDL_Surface *) * (atlas->nsurface + 1)));
     atlas->surfaces[atlas->nsurface] = check_alloc(SDL_CreateRGBSurface(
-      0, atlas->width, GLYPH_PER_ATLAS * h, FONT_BITMAP_COUNT(font) * 8,
+      0, atlas->width, GLYPHS_PER_ATLAS * h, FONT_BITMAP_COUNT(font) * 8,
       0, 0, 0, 0
     ));
     atlas->surfaces[atlas->nsurface]->userdata = NULL;
     surface_idx = atlas->nsurface++;
-    font->glyphs.bytesize += (sizeof(SDL_Surface *) + sizeof(SDL_Surface) + atlas->width * GLYPH_PER_ATLAS * h * FONT_BITMAP_COUNT(font));
+    font->glyphs.bytesize += (sizeof(SDL_Surface *) + sizeof(SDL_Surface) + atlas->width * GLYPHS_PER_ATLAS * h * FONT_BITMAP_COUNT(font));
   }
   metric->surface_idx = surface_idx;
   if (atlas->surfaces[surface_idx]->userdata) {

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -399,11 +399,16 @@ static int font_set_face_metrics(RenFont *font, FT_Face face) {
     return err;
 
   font->face = face;
+  if(FT_IS_SCALABLE(face)) {
   font->height = (short)((face->height / (float)face->units_per_EM) * font->size);
   font->baseline = (short)((face->ascender / (float)face->units_per_EM) * font->size);
 
   if(FT_IS_SCALABLE(face))
     font->underline_thickness = (unsigned short)((face->underline_thickness / (float)face->units_per_EM) * font->size);
+  } else {
+    font->height = (short) font->face->size->metrics.height / 64.0f;
+    font->baseline = (short) font->face->size->metrics.ascender / 64.0f;
+  }   
   if(!font->underline_thickness)
     font->underline_thickness = ceil((double) font->height / 14.0);
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -18,7 +18,7 @@
 #include "renwindow.h"
 
 // uncomment the line below for more debugging information through printf
-#define RENDERER_DEBUG
+// #define RENDERER_DEBUG
 
 static RenWindow **window_list = NULL;
 static size_t window_count = 0;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -195,7 +195,7 @@ static unsigned int font_get_glyph_id(RenFont *font, unsigned int codepoint) {
 #define FONT_BITMAP_COUNT(F) ((F)->antialiasing == FONT_ANTIALIASING_SUBPIXEL ? SUBPIXEL_BITMAPS_CACHED : 1)
 
 static SDL_Surface *font_find_glyph_surface(RenFont *font, FT_GlyphSlot slot, int bitmap_idx, GlyphMetric *metric) {
-  // get an atlas with the correct height
+  // get an atlas with the correct width
   int atlas_idx = -1;
   for (int i = 0; i < font->glyphs.natlas; i++) {
     if (font->glyphs.atlas[bitmap_idx][i].width >= metric->x1) {

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -83,7 +83,9 @@ typedef struct {
 
 // maps glyph IDs -> glyph metrics
 typedef struct {
+  // accessed with metrics[bitmap_idx][glyph_id / nrow][glyph_id - (row * ncol)]
   GlyphMetric *metrics[SUBPIXEL_BITMAPS_CACHED][GLYPHMAP_ROW];
+  // accessed with atlas[bitmap_idx][atlas_idx].surfaces[surface_idx]
   GlyphAtlas *atlas[SUBPIXEL_BITMAPS_CACHED];
   size_t natlas;
 } GlyphMap;
@@ -331,13 +333,13 @@ static void font_clear_glyph_cache(RenFont* font) {
     }
     free(font->glyphs.atlas[bitmap_idx]);
     font->glyphs.atlas[bitmap_idx] = NULL;
-    font->glyphs.natlas = 0;
     // clear glyph metric
     for (int glyphmap_row = 0; glyphmap_row < GLYPHMAP_ROW; glyphmap_row++) {
       free(font->glyphs.metrics[bitmap_idx][glyphmap_row]);
       font->glyphs.metrics[bitmap_idx][glyphmap_row] = NULL;
     }
   }
+  font->glyphs.natlas = 0;
 }
 
 // based on https://github.com/libsdl-org/SDL_ttf/blob/2a094959055fba09f7deed6e1ffeb986188982ae/SDL_ttf.c#L1735

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -331,6 +331,7 @@ static void font_clear_glyph_cache(RenFont* font) {
     }
     free(font->glyphs.atlas[bitmap_idx]);
     font->glyphs.atlas[bitmap_idx] = NULL;
+    font->glyphs.natlas = 0;
     // clear glyph metric
     for (int glyphmap_row = 0; glyphmap_row < GLYPHMAP_ROW; glyphmap_row++) {
       free(font->glyphs.metrics[bitmap_idx][glyphmap_row]);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -246,7 +246,7 @@ static void font_find_glyph_surface(RenFont *font, FT_GlyphSlot slot, int bitmap
   }
   metric->surface_idx = surface_idx;
   metric->y0 = (uintptr_t) atlas->surfaces[surface_idx]->userdata;
-  atlas->surfaces[surface_idx]->userdata += metric->y1;
+  atlas->surfaces[surface_idx]->userdata = (void *) ((uintptr_t) atlas->surfaces[surface_idx]->userdata + metric->y1);
   metric->y1 = (uintptr_t) atlas->surfaces[surface_idx]->userdata;
 }
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -129,7 +129,7 @@ static const char* utf8_to_codepoint(const char *p, const char *endp, unsigned *
     case 0xc0 :  res = *up & 0x1f;  n = 1;  break;
     default   :  res = *up;         n = 0;  break;
   }
-  while (up < endp && n--) {
+  while (up < (const unsigned char *)endp && n--) {
     res = (res << 6) | (*(++up) & 0x3f);
   }
   *dst = res;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -586,7 +586,7 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
     int start_x = floor(pen_x) + metric->bitmap_left;
     int end_x = metric->x1 + start_x; // x0 is assumed to be 0
     int glyph_end = metric->x1, glyph_start = 0;
-    if (!(metric->flags & EGlyphBitmap) && !is_whitespace(codepoint))
+    if (!font_surface && !is_whitespace(codepoint))
       ren_draw_rect(rs, (RenRect){ start_x + 1, y, font->space_advance - 1, ren_font_group_get_height(fonts) }, color);
     if (!is_whitespace(codepoint) && font_surface && color.a > 0 && end_x >= clip.x && start_x < clip_end_x) {
       uint8_t* source_pixels = font_surface->pixels;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -411,10 +411,8 @@ RenFont* ren_font_load(const char* path, float size, ERenFontAntialiasing antial
   stream->pos = 0;
   stream->size = (unsigned long) SDL_RWsize(file);
 
-  if (FT_Open_Face(library, &(FT_Open_Args) { .flags = FT_OPEN_STREAM, .stream = stream }, 0, &face) != 0)
-    goto stream_failure;
-
-  if (FT_Set_Pixel_Sizes(face, 0, (int) size) != 0)
+  if (FT_Open_Face(library, &(FT_Open_Args) { .flags = FT_OPEN_STREAM, .stream = stream }, 0, &face) != 0
+      || FT_Set_Pixel_Sizes(face, 0, (int) size) != 0)
     goto failure;
 
   font->face = face;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -333,7 +333,7 @@ static RenFont *font_group_get_glyph(RenFont **fonts, unsigned int codepoint, in
     // use the first font that has representation for the glyph ID, but for whitespaces always use the first font
     if (glyph_id || is_whitespace(codepoint)) break;
   }
-  // // load the glyph if it is not loaded
+  // load the glyph if it is not loaded
   subpixel_idx = FONT_IS_SUBPIXEL(font) ? subpixel_idx : 0;
   int row = glyph_id / GLYPHMAP_COL, col = glyph_id - (row * GLYPHMAP_COL);
   GlyphMetric *m = font->glyphs.metrics[subpixel_idx][row] ? &font->glyphs.metrics[subpixel_idx][row][col] : NULL;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -596,7 +596,7 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
           g = (color.g * src.g * color.a + dst.g * (65025 - src.g * color.a) + 32767) / 65025;
           b = (color.b * src.b * color.a + dst.b * (65025 - src.b * color.a) + 32767) / 65025;
           // the standard way of doing this would be SDL_GetRGBA, but that introduces a performance regression. needs to be investigated
-          *destination_pixel++ = dst.a << surface->format->Ashift | r << surface->format->Rshift | g << surface->format->Gshift | b << surface->format->Bshift;
+          *destination_pixel++ = (unsigned int) dst.a << surface->format->Ashift | r << surface->format->Rshift | g << surface->format->Gshift | b << surface->format->Bshift;
         }
       }
     }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -34,7 +34,7 @@ static void* _check_alloc(void *ptr, const char *const file, size_t ln) {
 /************************* Fonts *************************/
 
 // approximate number of glyphs per atlas surface
-#define GLYPH_PER_ATLAS 256
+#define GLYPHS_PER_ATLAS 256
 // some padding to add to atlas surface to store more glyphs
 #define FONT_HEIGHT_OVERFLOW_PX 6
 #define FONT_WIDTH_OVERFLOW_PX 6

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -194,7 +194,7 @@ static unsigned int font_get_glyph_id(RenFont *font, unsigned int codepoint) {
 #define FONT_IS_SUBPIXEL(F) ((F)->antialiasing == FONT_ANTIALIASING_SUBPIXEL)
 #define FONT_BITMAP_COUNT(F) ((F)->antialiasing == FONT_ANTIALIASING_SUBPIXEL ? SUBPIXEL_BITMAPS_CACHED : 1)
 
-static SDL_Surface *font_find_glyph_surface(RenFont *font, FT_GlyphSlot slot, int bitmap_idx, GlyphMetric *metric) {
+static SDL_Surface *font_allocate_glyph_surface(RenFont *font, FT_GlyphSlot slot, int bitmap_idx, GlyphMetric *metric) {
   // get an atlas with the correct width
   int atlas_idx = -1;
   for (int i = 0; i < font->glyphs.natlas; i++) {
@@ -218,7 +218,7 @@ static SDL_Surface *font_find_glyph_surface(RenFont *font, FT_GlyphSlot slot, in
   metric->atlas_idx = atlas_idx;
   GlyphAtlas *atlas = &font->glyphs.atlas[bitmap_idx][atlas_idx];
 
-  // find the surface with the minimum width that can fit the glyph (limited to last 100 surfaces)
+  // find the surface with the minimum height that can fit the glyph (limited to last 100 surfaces)
   int surface_idx = -1, max_surface_idx = (int) atlas->nsurface - 100, min_waste = INT_MAX;
   for (int i = atlas->nsurface - 1; i >= 0 && i > max_surface_idx; i--) {
     assert(atlas->surfaces[i]->userdata);
@@ -298,7 +298,7 @@ static void font_load_glyph(RenFont *font, unsigned int glyph_id) {
     metric->flags |= (EGlyphBitmap | EGlyphDualSource);
 
     // find the best surface to copy the glyph over, and copy it
-    SDL_Surface *surface = font_find_glyph_surface(font, slot, bitmap_idx, metric);
+    SDL_Surface *surface = font_allocate_glyph_surface(font, slot, bitmap_idx, metric);
     uint8_t* pixels = surface->pixels;
     for (unsigned int line = 0; line < slot->bitmap.rows; ++line) {
       int target_offset = surface->pitch * (line + metric->y0); // x0 is always assumed to be 0

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -119,7 +119,7 @@ void update_font_scale(RenWindow *window_renderer, RenFont **fonts) {
 }
 #endif
 
-static const char* utf8_to_codepoint(const char *p, unsigned *dst) {
+static const char* utf8_to_codepoint(const char *p, const char *endp, unsigned *dst) {
   const unsigned char *up = (unsigned char*)p;
   unsigned res, n;
   switch (*p & 0xf0) {
@@ -129,7 +129,7 @@ static const char* utf8_to_codepoint(const char *p, unsigned *dst) {
     case 0xc0 :  res = *up & 0x1f;  n = 1;  break;
     default   :  res = *up;         n = 0;  break;
   }
-  while (n--) {
+  while (up < endp && n--) {
     res = (res << 6) | (*(++up) & 0x3f);
   }
   *dst = res;
@@ -523,7 +523,7 @@ double ren_font_group_get_width(RenFont **fonts, const char *text, size_t len, i
   bool set_x_offset = x_offset == NULL;
   while (text < end) {
     unsigned int codepoint;
-    text = utf8_to_codepoint(text, &codepoint);
+    text = utf8_to_codepoint(text, end, &codepoint);
     GlyphMetric *metric = NULL;
     font_group_get_glyph(fonts, codepoint, 0, NULL, &metric);
     width += FONT_GET_XADVANCE(fonts[0], codepoint, metric);
@@ -578,7 +578,7 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
 
   while (text < end) {
     unsigned int codepoint, r, g, b;
-    text = utf8_to_codepoint(text, &codepoint);
+    text = utf8_to_codepoint(text, end,  &codepoint);
     SDL_Surface *font_surface = NULL; GlyphMetric *metric = NULL;
     RenFont* font = font_group_get_glyph(fonts, codepoint, (int)(fmod(pen_x, 1.0) * SUBPIXEL_BITMAPS_CACHED), &font_surface, &metric);
     if (!metric)

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -250,14 +250,14 @@ static void font_find_glyph_surface(RenFont *font, FT_GlyphSlot slot, int bitmap
   metric->y1 = (uintptr_t) atlas->surfaces[surface_idx]->userdata;
 }
 
-static int font_load_glyph(RenFont *font, unsigned int glyph_id) {
+static void font_load_glyph(RenFont *font, unsigned int glyph_id) {
   unsigned int render_option = font_set_render_options(font);
   unsigned int load_option = font_set_load_options(font);
   // load the font without hinting to fix an issue with monospaced fonts,
   // because freetype doesn't report the correct LSB and RSB delta. Transformation & subpixel positioning don't affect
   // the xadvance, so we can save some time by not doing this step multiple times
   if (FT_Load_Glyph(font->face, glyph_id, (load_option | FT_LOAD_BITMAP_METRICS_ONLY | FT_LOAD_NO_HINTING) & ~FT_LOAD_FORCE_AUTOHINT) != 0)
-    return -1;
+    return;
   double unhinted_xadv = font->face->glyph->advance.x / 64.0f;
   // render the glyph for all bitmap
   int bitmaps = FONT_BITMAP_COUNT(font);
@@ -267,7 +267,7 @@ static int font_load_glyph(RenFont *font, unsigned int glyph_id) {
     if (FT_Load_Glyph(font->face, glyph_id, load_option | FT_LOAD_BITMAP_METRICS_ONLY) != 0
       || font_set_style(&slot->outline, bitmap_idx * (64 / SUBPIXEL_BITMAPS_CACHED), font->style) != 0
       || FT_Render_Glyph(slot, render_option) != 0)
-    return -1;
+    return;
 
     GlyphMetric metric = {0};
     metric.surface_idx = metric.atlas_idx = BITMAP_NOT_AVAILABLE; // overridden later
@@ -315,7 +315,6 @@ save_metrics:
     }
     font->glyphs.metrics[bitmap_idx][row][col] = metric;
   }
-  return 0;
 }
 
 // https://en.wikipedia.org/wiki/Whitespace_character

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -9,11 +9,6 @@
 #include FT_OUTLINE_H
 #include FT_SYSTEM_H
 
-#ifdef _WIN32
-#include <windows.h>
-#include "utfconv.h"
-#endif
-
 #include "renderer.h"
 #include "renwindow.h"
 

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -281,7 +281,7 @@ static void font_load_glyph(RenFont *font, unsigned int glyph_id) {
     metric->xadvance = unhinted_xadv;
 
     // if this bitmap is empty, or has a format we don't support, just store the xadvance
-    if (!slot->bitmap.width || !slot->bitmap.rows ||
+    if (!slot->bitmap.width || !slot->bitmap.rows || !slot->bitmap.buffer ||
         (slot->bitmap.pixel_mode != FT_PIXEL_MODE_MONO
           && slot->bitmap.pixel_mode != FT_PIXEL_MODE_GRAY
           && slot->bitmap.pixel_mode != FT_PIXEL_MODE_LCD))


### PR DESCRIPTION
# Rewriting the glyph cache

This has been planned by @Guldoman and me for a while now since the current GlyphSet-based cache cannot properly support more advanced glyph manipulation (ligatures anyone?) and is very wasteful in terms of memory as it allocates a relatively huge struct, approximately 0x100000 times. This rewrite splits the cache into two:

### Mapping codepoints to glyph IDs: `CharMap`

This is a 2D array that maps each codepoint to glyph IDs. Glyph IDs are assumed to be uint16 (according to OpenType, I've not known other formats that have a larger glyph ID). The rows of this map are dynamically allocated for efficiency, and when fully allocated, it's roughly 4,457,468 bytes. This map can be replaced with something else for more features, like shaping.

### Mapping glyph IDs to glyphs: `GlyphMap`

This is the main part of the rewrite. A GlyphMap contains a map of GlyphMetrics similar to how CharMap works. This map adds up to roughly 2,098,176 bytes. A GlyphMap also contains a list of GlyphAtlas per (subpixel) bitmap index (1 if grayscale AA, 3 if subpixel AA), mapped by their width.

A GlyphAtlas represents a list of SDL_Surfaces with the same width. Each glyph is stacked on the surface vertically. The GlyphAtlas acts as a bump allocator; when someone tries to store something bigger than the current surface can handle, it allocates a new surface with the appropriate size and stores it there. If the current surface has sufficient space, it stores the bitmap there directly.
The GlyphSet will try to find a GlyphAtlas with a suitable width or allocate a new one.

The renderer no longer renders an entire GlyphSet (256 characters) at once for one glyph. Glyphs are packed tightly together whenever possible. Calls to FT_Get_Char_Index are also cached, which would improve performance a bit.

### Other changes

Aside from the GlyphSet cache, the tab character handling has been reworked _a bit_ not to directly set the values in the GlyphMetric. The FT_Stream is now properly freed. The check_alloc function is modified to display file and line number (which can be useful), and an internal function called `ren_font_dump()` is added to dump a font's contents into a series of BMP files for inspection. This is guarded behind a preprocessor macro called `RENDERER_DEBUG` and is disabled by default. This function is intended to be used inside a debugger.

### Benchmarks

This is the most exciting part. Comparing this PR to master:

| My PR | Master |
| ----- | ------ |
| <pre>*** get-width-fira-sans :    5.267ms  31.60%<br>*** get-width-fira-sans-grayscale :    2.539ms  15.23%<br>*** get-width-cjk    :   17.946ms 107.68%<br>*** get-width-cjk-grayscale :   11.705ms  70.23%</pre> | <pre>*** get-width-fira-sans :   47.054ms 282.32%<br>*** get-width-fira-sans-grayscale :   15.333ms  92.00%<br>*** get-width-cjk    : 6337.212ms 38023.27%<br>*** get-width-cjk-grayscale : 1207.724ms 7246.34%</pre> |

Compared to my previous PR #1543:

| My PR | #1543 |
| ----- | ----- |
| <pre>*** get-width-fira-sans :    5.267ms  31.60%<br>*** get-width-fira-sans-grayscale :    2.539ms  15.23%<br>*** get-width-cjk    :   17.946ms 107.68%<br>*** get-width-cjk-grayscale :   11.705ms  70.23%</pre> | <pre>*** get-width-fira-sans :    6.434ms  38.60%<br>*** get-width-fira-sans-grayscale :    5.113ms  30.68%<br>*** get-width-cjk    :  502.446ms 3014.67%<br>*** get-width-cjk-grayscale :  419.128ms 2514.77%</pre> |

As you can see, the time is inconsistent across even the same run, but this PR demonstrates **a clear increase** compared to master and #1543.

<details>
<summary>Code</summary>

```lua
local common = require "core.common"

common.bench("get-width-fira-sans", function()
  local font = renderer.font.load(DATADIR .. "/fonts/FiraSans-Regular.ttf", 14 * SCALE)
  for i = 1, 100 do
    font:get_width(utf8.char(32 + i))
  end
end)

common.bench("get-width-fira-sans-grayscale", function()
  local font = renderer.font.load(DATADIR .. "/fonts/FiraSans-Regular.ttf", 14 * SCALE, { antialiasing = "grayscale" })
  for i = 1, 100 do
    font:get_width(utf8.char(32 + i))
  end
end)

common.bench("get-width-cjk", function()
  local font = renderer.font.load(DATADIR .. "/fonts/NotoSansCJKsc-Regular.otf", 14 * SCALE)
  for i = 1, 100 do
    font:get_width(utf8.char(1000 + i + i * 256))
  end
end)

common.bench("get-width-cjk-grayscale", function()
  local font = renderer.font.load(DATADIR .. "/fonts/NotoSansCJKsc-Regular.otf", 14 * SCALE, { antialiasing = "grayscale" })
  for i = 1, 100 do
    font:get_width(utf8.char(1000 + i + i * 256))
  end
end)
```
</details>

### Real-life tests

This PR:

https://github.com/lite-xl/lite-xl/assets/20792268/9fd1ed38-4ba8-4c0f-8f47-b39780ed8115

#1543:

https://github.com/lite-xl/lite-xl/assets/20792268/52144e6f-1b2d-431f-b268-75459c51d02f

Master:

https://github.com/lite-xl/lite-xl/assets/20792268/3ee957a9-e6bc-4492-9efd-d2067ea33ff8







