### PR TITLE
language_cpp: add cuda syntax highlighting

### DIFF
--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -11,7 +11,7 @@ syntax.add {
   files = {
     "%.h$", "%.inl$", "%.cpp$", "%.cc$", "%.C$", "%.cxx$",
     "%.c++$", "%.hh$", "%.H$", "%.hxx$", "%.hpp$", "%.h++$",
-    "%.ino$"
+    "%.ino$", "%.cu$", "%.cuh$"
   },
   comment = "//",
   block_comment = { "/*", "*/" },


### PR DESCRIPTION
This PR add a syntax highlight for CUDA source codes.
Below is before and after:
![syntax-no-cuda](https://github.com/lite-xl/lite-xl/assets/53614504/6ab188ba-810d-4674-b6c5-fee308f79b43)
![syntax-yes-cuda](https://github.com/lite-xl/lite-xl/assets/53614504/84fddb4e-bd61-4f88-b2ee-10ad04fbdbab)
