### PR TITLE
Refactor how arguments are handled in process.start()

### DIFF
--- a/data/core/process.lua
+++ b/data/core/process.lua
@@ -1,4 +1,5 @@
 local config = require "core.config"
+local common = require "core.common"
 
 
 ---An abstraction over the standard input and outputs of a process
@@ -149,10 +150,53 @@ function process:__index(k)
   return self.process[k]
 end
 
+local function env_key(str)
+  if PLATFORM == "Windows" then return str:upper() else return str end
+end
+
+---Sorts the environment variable by its key, converted to uppercase.
+---This is only needed on Windows.
+local function compare_env(a, b)
+  return env_key(a:match("([^=]*)=")) < env_key(b:match("([^=]*)="))
+end
 
 local old_start = process.start
-function process.start(...)
-  local self = setmetatable({ process = old_start(...) }, process)
+function process.start(command, options)
+  assert(type(command) == "table" or type(command) == "string", "invalid argument #1 to process.start(), expected string or table, got "..type(command))
+  assert(type(options) == "table" or type(options) == "nil", "invalid argument #2 to process.start(), expected table or nil, got "..type(options))
+  if PLATFORM == "Windows" then
+    if type(command) == "table" then
+      -- escape the arguments into a command line string
+      -- https://github.com/python/cpython/blob/48f9d3e3faec5faaa4f7c9849fecd27eae4da213/Lib/subprocess.py#L531
+      local arglist = {}
+      for _, v in ipairs(command) do
+        local backslash, arg = 0, {}
+        for c in v:gmatch(".") do
+          if     c == "\\" then backslash = backslash + 1
+          elseif c == '"'  then arg[#arg+1] = string.rep("\\", backslash * 2 + 1)..'"'; backslash = 0
+          else                  arg[#arg+1] = string.rep("\\", backslash) .. c;         backslash = 0 end
+        end
+        arg[#arg+1] = string.rep("\\", backslash) -- add remaining backslashes
+        if #v == 0 or v:find("[\t\v\r\n ]") then arglist[#arglist+1] = '"'..table.concat(arg, "")..'"'
+        else                                     arglist[#arglist+1] = table.concat(arg, "") end
+      end
+      command = table.concat(arglist, " ")
+    end
+  else
+    command = type(command) == "table" and command or { command }
+  end
+  if type(options) == "table" and options.env then
+    local user_env = options.env --[[@as table]]
+    options.env = function(system_env)
+      local final_env, envlist = {}, {}
+      for k, v in pairs(system_env) do final_env[env_key(k)] = k.."="..v end
+      for k, v in pairs(user_env)   do final_env[env_key(k)] = k.."="..v end
+      for _, v in pairs(final_env)  do envlist[#envlist+1] = v end
+      if PLATFORM == "Windows" then table.sort(envlist, compare_env) end
+      return table.concat(envlist, "\0").."\0\0"
+    end
+  end
+  local self = setmetatable({ process = old_start(command, options) }, process)
   self.stdout = process.stream.new(self, process.STREAM_STDOUT)
   self.stderr = process.stream.new(self, process.STREAM_STDERR)
   self.stdin  = process.stream.new(self, process.STREAM_STDIN)

--- a/src/arena_allocator.c
+++ b/src/arena_allocator.c
@@ -3,9 +3,17 @@
 #include <string.h>
 #include <lauxlib.h>
 
-void lxl_arena_init(lua_State *L, lxl_arena *arena) {
+struct lxl_arena {
+  lua_State *L;
+  int ref;
+};
+
+lxl_arena *lxl_arena_init(lua_State *L) {
   lua_newtable(L);
-  arena->L = L; arena->ref = lua_gettop(L);
+  lxl_arena *arena = lua_newuserdata(L, sizeof(lxl_arena));
+  arena->L = L; arena->ref = lua_gettop(L)-1;
+  lua_rawseti(L, -2, 1);
+  return arena;
 }
 
 void *lxl_arena_malloc(lxl_arena *arena, size_t size) {

--- a/src/arena_allocator.c
+++ b/src/arena_allocator.c
@@ -1,0 +1,44 @@
+#include "arena_allocator.h"
+
+#include <string.h>
+#include <lauxlib.h>
+
+void lxl_arena_init(lua_State *L, lxl_arena *arena) {
+  lua_newtable(L);
+  arena->L = L; arena->ref = lua_gettop(L);
+}
+
+void *lxl_arena_malloc(lxl_arena *arena, size_t size) {
+  if (!arena || !arena->L) return NULL;
+  if (!lua_istable(arena->L, arena->ref)) luaL_error(arena->L, "invalid arena reference");
+  void *data = lua_newuserdata(arena->L, size);
+  lua_pushlightuserdata(arena->L, data);
+  lua_pushvalue(arena->L, -2);
+  lua_settable(arena->L, arena->ref);
+  lua_pop(arena->L, 1);
+  return data;
+}
+
+void *lxl_arena_zero(lxl_arena *arena, size_t size) {
+  void *v = lxl_arena_malloc(arena, size);
+  return v ? memset(v, 0, size) : NULL;
+}
+
+char *lxl_arena_strdup(lxl_arena *arena, const char *str) {
+  if (!str) return NULL;
+  return lxl_arena_copy(arena, (void *) str, (strlen(str) + 1) * sizeof(char));
+}
+
+char *lxl_arena_copy(lxl_arena *arena, void *ptr, size_t len) {
+  if (!ptr) return NULL;
+  char *output = lxl_arena_malloc(arena, sizeof(char) * len);
+  return output ? memcpy(output, ptr, len) : NULL;
+}
+
+void lxl_arena_free(lxl_arena *arena, void *ptr) {
+  if (!arena || !arena->L || !ptr) return;
+  if (!lua_istable(arena->L, arena->ref)) luaL_error(arena->L, "invalid arena reference");
+  lua_pushlightuserdata(arena->L, ptr);
+  lua_pushnil(arena->L);
+  lua_settable(arena->L, arena->ref);
+}

--- a/src/arena_allocator.h
+++ b/src/arena_allocator.h
@@ -10,12 +10,9 @@
 
 #include <lua.h>
 
-typedef struct lxl_arena {
-  lua_State *L;
-  int ref;
-} lxl_arena;
+typedef struct lxl_arena lxl_arena;
 
-void lxl_arena_init(lua_State *L, lxl_arena *arena);
+lxl_arena *lxl_arena_init(lua_State *L);
 void *lxl_arena_malloc(lxl_arena *arena, size_t size);
 void *lxl_arena_zero(lxl_arena *arena, size_t size);
 char *lxl_arena_copy(lxl_arena *arena, void *ptr, size_t len);

--- a/src/arena_allocator.h
+++ b/src/arena_allocator.h
@@ -1,0 +1,25 @@
+/**
+ * An arena allocator using the Lua state; similar to luaL_Buffer.
+ * Initialize the arena with lxl_arena_init(), and you can use lxl_arena_malloc(),
+ * lxl_arena_zero() to allocate (and optionally zero) the memory.
+ * lxl_arena_free() can be optionally used to free memory, but this is generally not needed.
+ */
+
+#ifndef LUA_ALLOCATOR_H
+#define LUA_ALLOCATOR_H
+
+#include <lua.h>
+
+typedef struct lxl_arena {
+  lua_State *L;
+  int ref;
+} lxl_arena;
+
+void lxl_arena_init(lua_State *L, lxl_arena *arena);
+void *lxl_arena_malloc(lxl_arena *arena, size_t size);
+void *lxl_arena_zero(lxl_arena *arena, size_t size);
+char *lxl_arena_copy(lxl_arena *arena, void *ptr, size_t len);
+char *lxl_arena_strdup(lxl_arena *arena, const char *str);
+void lxl_arena_free(lxl_arena *arena, void *ptr);
+
+#endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,6 +6,7 @@ lite_sources = [
     'api/system.c',
     'api/process.c',
     'api/utf8.c',
+    'arena_allocator.c',
     'renderer.c',
     'renwindow.c',
     'rencache.c',

--- a/src/utfconv.h
+++ b/src/utfconv.h
@@ -12,7 +12,33 @@
 #include <stdlib.h>
 #include <windows.h>
 
+#include "arena_allocator.h"
+
 #define UTFCONV_ERROR_INVALID_CONVERSION "Input contains invalid byte sequences."
+
+#define utfconv_fromutf8(A, str) utfconv_fromlutf8(A, str, -1)
+
+static UNUSED LPWSTR utfconv_fromlutf8(lxl_arena *A, const char *str, int len) {
+  int output_len = MultiByteToWideChar(CP_UTF8, 0, str, len, NULL, 0);
+  if (!output_len) return NULL;
+  LPWSTR output = lxl_arena_malloc(A, sizeof(WCHAR) * output_len);
+  if (!output) return NULL;
+  output_len = MultiByteToWideChar(CP_UTF8, 0, str, len, output, output_len);
+  if (!output_len) return (lxl_arena_free(A, output), NULL);
+  return output;
+}
+
+#define utfconv_fromwstr(A, str) utfconv_fromlwstr(A, str, -1)
+
+static UNUSED const char *utfconv_fromlwstr(lxl_arena *A, LPWSTR str, int len) {
+  int output_len = WideCharToMultiByte(CP_UTF8, 0, str, len, NULL, 0, NULL, NULL);
+  if (!output_len) return NULL;
+  char *output = lxl_arena_malloc(A, sizeof(char) * output_len);
+  if (!output) return NULL;
+  output_len = WideCharToMultiByte(CP_UTF8, 0, str, len, output, output_len, NULL, NULL);
+  if (!output_len) return (lxl_arena_free(A, output), NULL);
+  return (const char *) output;
+}
 
 static UNUSED LPWSTR utfconv_utf8towc(const char *str) {
   LPWSTR output;


### PR DESCRIPTION
This PR started with great intentions but kinda languished in the end. I've ported most of the argument handling _especially you Windows_ to Lua, and hoped that it would reduce the complexity of the C code and make it easier to debug. Midway through I was distracted by the arena allocator and focused some effort into it.

## The boring stuff: moving argument parsing into Lua

The Windows code is a mess of spaghetti with encoding conversion at various places, and nightmares with memory allocation (especially when dealing with the luaL_check* functions, where it could jump out of the function, skipping memory management).

I moved the majority of the code into Lua, making `process.start()` (at least the unwrapped, C version) accept only what they need: A command line string on Windows, and the environment variables concatenated into a single string. This allows the arguments to be passed directly to `CreateProcessW` with a bit of string manipulation on the Unix side.

## The more interesting stuff: `arena_allocator`

This popped up mid-conversation with @Guldoman, but it is possible to use Lua userdata pushed to a table to control their lifetime. PUC Lua itself [allows this](https://stackoverflow.com/a/38754241) (not sure about LuaJIT); even when this is not allowed, you can simply add all allocation to a Lua table, assign a finalizer for the said table, and free memory in the finalizer. There is no finer-grain control over this yet (at least I am not aware of, looking at to-be-closed variables here), but this GREATLY simplifies memory handling inside a C Lua API function. Return anywhere, and your memory is freed. It is semi-similar to [golang arenas](https://uptrace.dev/blog/golang-memory-arena.html).

This arena allocator is implemented as a Lua table, with a userdata (the `lxl_arena`) in it. When `lxl_arena_malloc` is called, we get the Lua state, allocate some userdata and store it in the table. This userdata is now "pinned" to the table and freed when the table gets freed. You can optionally free memory in an arena with `lxl_arena_free`, but its absolutely optional and might be useful for implementing memory checking. `lxl_arena_init` pushes the table onto a stack, and this means that unless you accidentally pop this item off the stack, it will be valid for the duration of the C function. You can also pin this table to the Lua Registry for some long-running processes.

The limit of this system is that there's a fixed limit to the userdata size, `((size_t)(~(size_t)0)-2)` (maximum value of `size_t` - 2), but that's honestly a pretty respectable limit.