### PR TITLE
allow `/` for path suggestions in all OSes

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -226,7 +226,7 @@ function common.path_suggest(text, root)
   if root and root:sub(-1) ~= PATHSEP then
     root = root .. PATHSEP
   end
-  local path, name = text:match("^(.-)([^"..PATHSEP.."]*)$")
+  local path, name = text:match("^(.-)([^"..PATHSEP.."/]*)$")
   local clean_dotslash = false
   -- ignore root if path is absolute
   local is_absolute = common.is_absolute_path(text)


### PR DESCRIPTION
mainly done because of an annoying thingy that is in Windows where I'm unable to see suggestions for files in some directory when ending in `/`, I must use `\`:
![image](https://github.com/user-attachments/assets/37f69b5e-3635-4df1-9bb2-e81371ee4a17)
not sure if this is a proper solution
