### PR TITLE
Use lite-xl-build-box-manylinux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           sudo apt-get install -y ccache
 
       - name: Build Portable
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.2.0
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box-manylinux:v3.0.2
         with:
           entrypoint: /entrypoint.sh
           args: |
@@ -100,7 +100,7 @@ jobs:
             bash scripts/build.sh --debug --forcefallback --portable --release
 
       - name: Package Portables
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.2.0
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box-manylinux:v3.0.2
         with:
           entrypoint: /entrypoint.sh
           args: |
@@ -108,7 +108,7 @@ jobs:
             bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
 
       - name: Build AppImages
-        uses: docker://ghcr.io/lite-xl/lite-xl-build-box:v2.2.0
+        uses: docker://ghcr.io/lite-xl/lite-xl-build-box-manylinux:v3.0.2
         with:
           entrypoint: /entrypoint.sh
           args: |


### PR DESCRIPTION
This PR builds Lite XL with lite-xl-build-box-manylinux.

I have created a build box variant with [manylinux_2014](https://github.com/pypa/manylinux). manylinux is Python's solution for the whole Glibc incompatibility thing and we are using the CentOS 7 variant with Glibc 2.17 while Ubuntu 18.04 is on Glibc 2.27. Python obviously works on the manylinux image, and some amenities were installed by default (GCC, CMake, new version of Git). Hopefully this would allow us to support more systems and make maintenance easier.

Example build is in https://github.com/takase1121/lite-xl/releases/tag/v2.1.5-manylinux.