### PR TITLE
Removed draw asserts for window renderer

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -329,7 +329,6 @@ static RenRect rect_to_grid(lua_Number x, lua_Number y, lua_Number w, lua_Number
 
 
 static int f_set_clip_rect(lua_State *L) {
-  assert(active_window_renderer != NULL);
   lua_Number x = luaL_checknumber(L, 1);
   lua_Number y = luaL_checknumber(L, 2);
   lua_Number w = luaL_checknumber(L, 3);
@@ -341,7 +340,6 @@ static int f_set_clip_rect(lua_State *L) {
 
 
 static int f_draw_rect(lua_State *L) {
-  assert(active_window_renderer != NULL);
   lua_Number x = luaL_checknumber(L, 1);
   lua_Number y = luaL_checknumber(L, 2);
   lua_Number w = luaL_checknumber(L, 3);
@@ -353,7 +351,6 @@ static int f_draw_rect(lua_State *L) {
 }
 
 static int f_draw_text(lua_State *L) {
-  assert(active_window_renderer != NULL);
   RenFont* fonts[FONT_FALLBACK_MAX];
   font_retrieve(L, fonts, 1);
 

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -128,8 +128,9 @@ static bool expand_command_buffer(RenWindow *window_renderer) {
 }
 
 static void* push_command(RenWindow *window_renderer, enum CommandType type, int size) {
-  if (resize_issue) {
+  if (!window_renderer || resize_issue) {
     // Don't push new commands as we had problems resizing the command buffer.
+    // Or, we don't have an active buffer.
     // Let's wait for the next frame.
     return NULL;
   }


### PR DESCRIPTION
As discussed on Discord; there are some issues where some things like StatusView call draw between frames, because they want to determine the size of elements. This is legitimate, and simple, so makes sense to remove the asserts, let widgets do this, and just not push any commands into buffers if the buffer isn't bound to to the global variable.