### PR TITLE
Rearrange Plugin Loading and SDL Initialization

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -684,7 +684,7 @@ function core.set_active_view(view)
   -- Reset the IME even if the focus didn't change
   ime.stop()
   if view ~= core.active_view then
-    system.text_input(core.window, view:supports_text_input())
+    if core.window then system.text_input(core.window, view:supports_text_input()) end
     if core.active_view and core.active_view.force_focus then
       core.next_active_view = view
       return

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -519,8 +519,8 @@ function core.parse_plugin_details(path, file, mod_version_regex, priority_regex
 
   for line in f:lines() do
     if not version_match then
-      local _major, _minor, _patch = mod_version_regex:match(line)
-      if _major then
+      local status, _major, _minor, _patch = pcall(mod_version_regex.match, mod_version_regex, line)
+      if status and _major then
         _major = tonumber(_major) or 0
         _minor = tonumber(_minor) or 0
         _patch = tonumber(_patch) or 0
@@ -537,8 +537,8 @@ function core.parse_plugin_details(path, file, mod_version_regex, priority_regex
     end
 
     if not priority then
-      priority = priority_regex:match(line)
-      if priority then priority = tonumber(priority) end
+      local status, _priority = pcall(priority_regex.match, priority_regex, line)
+      if status and _priority then priority = tonumber(_priority) end
     end
 
     if version_match then

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -55,30 +55,10 @@ local function update_recents_project(action, dir_path_abs)
 end
 
 
-local function reload_customizations()
-  local user_error = not core.load_user_directory()
-  local project_error = not core.load_project_module()
-  if user_error or project_error then
-    -- Use core.add_thread to delay opening the LogView, as opening
-    -- it directly here disturbs the normal save operations.
-    core.add_thread(function()
-      local LogView = require "core.logview"
-      local rn = core.root_view.root_node
-      for _,v in pairs(core.root_view.root_node:get_children()) do
-        if v:is(LogView) then
-          rn:get_node_for_view(v):set_active_view(v)
-          return
-        end
-      end
-      command.perform("core:open-log")
-    end)
-  end
-end
-
-
 function core.add_project(project)
   project = type(project) == "string" and Project(common.normalize_volume(project)) or project
   table.insert(core.projects, project)
+  update_recents_project("add", project.path)
   core.redraw = true
   return project
 end
@@ -98,15 +78,16 @@ end
 
 function core.set_project(project)
   while #core.projects > 0 do core.remove_project(core.projects[#core.projects], true) end
-  return core.add_project(project)
+  local project = core.add_project(project)
+  return project
 end
 
 
 function core.open_project(project)
   local project = core.set_project(project)
   core.root_view:close_all_docviews()
-  reload_customizations()
   update_recents_project("add", project.path)
+  command.perform("core:restart")
 end
 
 
@@ -254,20 +235,17 @@ local config = require "core.config"
 
 -- You may activate some plugins on a per-project basis to override the user's settings.
 -- config.plugins.trimwitespace = true
-]])
-  init_file:close()
+]]):close()
 end
 
 
-function core.load_user_directory()
+function core.ensure_user_directory()
   return core.try(function()
-    local stat_dir = system.get_file_info(USERDIR)
-    if not stat_dir then
+    if not system.get_file_info(USERDIR) then
       create_user_directory()
     end
     local init_filename = USERDIR .. PATHSEP .. "init.lua"
-    local stat_file = system.get_file_info(init_filename)
-    if not stat_file then
+    if not system.get_file_info(init_filename) then
       write_user_init_file(init_filename)
     end
     dofile(init_filename)
@@ -279,21 +257,6 @@ function core.configure_borderless_window()
   system.set_window_bordered(core.window, not config.borderless)
   core.title_view:configure_hit_test(config.borderless)
   core.title_view.visible = config.borderless
-end
-
-
-local function add_config_files_hooks()
-  -- auto-realod style when user's module is saved by overriding Doc:Save()
-  local doc_save = Doc.save
-  local user_filename = system.absolute_path(USERDIR .. PATHSEP .. "init.lua")
-  function Doc:save(filename, abs_filename)
-    local module_filename = core.project_absolute_path(".lite_project.lua")
-    doc_save(self, filename, abs_filename)
-    if self.abs_filename == user_filename or self.abs_filename == module_filename then
-      reload_customizations()
-      core.configure_borderless_window()
-    end
-  end
 end
 
 
@@ -320,21 +283,10 @@ function core.init()
     EXEDIR  = common.normalize_volume(EXEDIR)
   end
 
-  core.window = renwindow._restore()
-  if core.window == nil then
-    core.window = renwindow.create("")
-  end
-  do
-    local session = load_session()
-    if session.window_mode == "normal" then
-      system.set_window_size(core.window, table.unpack(session.window))
-    elseif session.window_mode == "maximized" then
-      system.set_window_mode(core.window, "maximized")
-    end
-    core.recent_projects = session.recents or {}
-    core.previous_find = session.previous_find or {}
-    core.previous_replace = session.previous_replace or {}
-  end
+  local session = load_session()
+  core.recent_projects = session.recents or {}
+  core.previous_find = {}
+  core.previous_replace = {}
 
   local project_dir = core.recent_projects[1] or "."
   local project_dir_explicit = false
@@ -358,6 +310,8 @@ function core.init()
       end
     end
   end
+  -- Ensure that we have a user directory.
+  core.ensure_user_directory()
 
   core.frame_start = 0
   core.clip_rect_stack = {{ 0,0,0,0 }}
@@ -399,14 +353,10 @@ function core.init()
   -- Load default commands first so plugins can override them
   command.add_defaults()
 
-  -- Load user module, plugins and project module
-  local got_user_error, got_project_error = not core.load_user_directory()
-
   local project_dir_abs = system.absolute_path(project_dir)
   -- We prevent set_project below to effectively add and scan the directory because the
   -- project module and its ignore files is not yet loaded.
   if project_dir_abs and pcall(core.set_project, project_dir_abs) then
-    got_project_error = not core.load_project_module()
     if project_dir_explicit then
       update_recents_project("add", project_dir_abs)
     end
@@ -415,23 +365,30 @@ function core.init()
       update_recents_project("remove", project_dir)
     end
     project_dir_abs = system.absolute_path(".")
-    core.set_project(project_dir_abs)
-    got_project_error = not core.load_project_module()
+    local status, err = pcall(core.set_project, project_dir_abs)
   end
 
   -- Load core and user plugins giving preference to user ones with same name.
   local plugins_success, plugins_refuse_list = core.load_plugins()
 
+  core.window = core.window or renwindow._restore() or renwindow.create("")
+  if session.window_mode == "normal" then
+    system.set_window_size(core.window, table.unpack(session.window))
+  elseif session.window_mode == "maximized" then
+    system.set_window_mode(core.window, "maximized")
+  end
+
+
   do
     local pdir, pname = project_dir_abs:match("(.*)[/\\\\](.*)")
-    core.log("Opening project %q from directory %s", pname, pdir)
+    core.log_quiet("Opening project %q from directory %s", pname, pdir)
   end
 
   for _, filename in ipairs(files) do
     core.root_view:open_doc(core.open_doc(filename))
   end
 
-  if not plugins_success or got_user_error or got_project_error then
+  if not plugins_success then
     -- defer LogView to after everything is initialized,
     -- so that EmptyView won't be added after LogView.
     core.add_thread(function()
@@ -466,8 +423,6 @@ function core.init()
         if item.text == "Exit" then os.exit(1) end
       end)
   end
-
-  add_config_files_hooks()
 end
 
 
@@ -546,16 +501,18 @@ function core.restart()
 end
 
 
-local mod_version_regex =
-  regex.compile([[--.*mod-version:(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:$|\s)]])
-local function get_plugin_details(filename)
-  local info = system.get_file_info(filename)
-  if info ~= nil and info.type == "dir" then
-    filename = filename .. PATHSEP .. "init.lua"
-    info = system.get_file_info(filename)
-  end
-  if not info or not filename:match("%.lua$") then return false end
-  local f = io.open(filename, "r")
+local function require_lua_plugin(plugin)
+  return require("plugins." .. plugin.name)
+end
+
+
+local function load_lua_plugin_if_exists(plugin)
+  return system.get_file_info(plugin.file) and dofile(plugin.file)
+end
+
+
+function core.parse_plugin_details(path, file, mod_version_regex, priority_regex)
+  local f = io.open(file, "r")
   if not f then return false end
   local priority = false
   local version_match = false
@@ -581,7 +538,7 @@ local function get_plugin_details(filename)
     end
 
     if not priority then
-      priority = line:match('%-%-.*%f[%a]priority%s*:%s*(%d+)')
+      priority = priority_regex:match(line)
       if priority then priority = tonumber(priority) end
     end
 
@@ -590,11 +547,46 @@ local function get_plugin_details(filename)
     end
   end
   f:close()
-  return true, {
+  local version = major and {major, minor, patch} or {}
+  return {
+    name = common.basename(path),
+    file = file,
     version_match = version_match,
-    version = major and {major, minor, patch} or {},
-    priority = priority or 100
+    version = version,
+    priority = priority or 100,
+    version_string = major and table.concat(version, ".") or "unknown"
   }
+end
+
+
+local mod_version_regex =
+  regex.compile([[--.*mod-version:(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:$|\s)]])
+local priority_regex = regex.compile([[\-\-.*priority\s*:\s*([\d\.]+)]])
+function core.get_plugin_details(path)
+  local info = system.get_file_info(path)
+  local file = path
+  if info ~= nil and info.type == "dir" then
+    file = path .. PATHSEP .. "init.lua"
+    info = system.get_file_info(file)
+  end
+  local details = info and core.parse_plugin_details(path:gsub("%.lua$", ""), file, mod_version_regex, priority_regex)
+  if details then details.load = require_lua_plugin end
+  return details
+end
+
+
+core.plugin_list = {}
+-- Can be called from within plugins; don't insert things lower than your own priority.
+function core.add_plugins(plugins)
+  for i,v in ipairs(plugins) do table.insert(core.plugin_list, v) end
+
+  -- sort by priority or name for plugins that have same priority
+  table.sort(core.plugin_list, function(a, b)
+    if a.priority ~= b.priority then
+      return a.priority < b.priority
+    end
+    return a.name < b.name
+  end)
 end
 
 
@@ -604,77 +596,56 @@ function core.load_plugins()
     userdir = {dir = USERDIR, plugins = {}},
     datadir = {dir = DATADIR, plugins = {}},
   }
-  local files, ordered = {}, {}
+  local files, ordered = {}, {
+    { priority = -2, load = load_lua_plugin_if_exists, version_match = true, file = USERDIR .. PATHSEP .. "init.lua", name = "User Module" },
+    { priority = -1, load = load_lua_plugin_if_exists, version_match = true, file = core.root_project().path .. PATHSEP .. ".lite_project.lua", name = "Project Module" }
+  }
   for _, root_dir in ipairs {DATADIR, USERDIR} do
     local plugin_dir = root_dir .. PATHSEP .. "plugins"
     for _, filename in ipairs(system.list_dir(plugin_dir) or {}) do
       if not files[filename] then
-        table.insert(
-          ordered, {file = filename}
-        )
+        local details = core.get_plugin_details(plugin_dir .. PATHSEP .. filename)
+        if details then table.insert(ordered, details) end
       end
       -- user plugins will always replace system plugins
       files[filename] = plugin_dir
     end
   end
-
-  for _, plugin in ipairs(ordered) do
-    local dir = files[plugin.file]
-    local name = plugin.file:match("(.-)%.lua$") or plugin.file
-    local is_lua_file, details = get_plugin_details(dir .. PATHSEP .. plugin.file)
-
-    plugin.valid = is_lua_file
-    plugin.name = name
-    plugin.dir = dir
-    plugin.priority = details and details.priority or 100
-    plugin.version_match = details and details.version_match or false
-    plugin.version = details and details.version or {}
-    plugin.version_string = #plugin.version > 0 and table.concat(plugin.version, ".") or "unknown"
-  end
-
-  -- sort by priority or name for plugins that have same priority
-  table.sort(ordered, function(a, b)
-    if a.priority ~= b.priority then
-      return a.priority < b.priority
-    end
-    return a.name < b.name
-  end)
+  core.add_plugins(ordered)
 
   local load_start = system.get_time()
-  for _, plugin in ipairs(ordered) do
-    if plugin.valid then
-      if not config.skip_plugins_version and not plugin.version_match then
-        core.log_quiet(
-          "Version mismatch for plugin %q[%s] from %s",
-          plugin.name,
-          plugin.version_string,
-          plugin.dir
-        )
-        local rlist = plugin.dir:find(USERDIR, 1, true) == 1
-          and 'userdir' or 'datadir'
-        local list = refused_list[rlist].plugins
-        table.insert(list, plugin)
-      elseif config.plugins[plugin.name] ~= false then
-        local start = system.get_time()
-        local ok, loaded_plugin = core.try(require, "plugins." .. plugin.name)
-        if ok then
-          local plugin_version = ""
-          if plugin.version_string ~= MOD_VERSION_STRING then
-            plugin_version = "["..plugin.version_string.."]"
-          end
-          core.log_quiet(
-            "Loaded plugin %q%s from %s in %.1fms",
-            plugin.name,
-            plugin_version,
-            plugin.dir,
-            (system.get_time() - start) * 1000
-          )
+  for i = 1, #core.plugin_list do
+    local plugin = core.plugin_list[i]
+    if not config.skip_plugins_version and not plugin.version_match then
+      core.log_quiet(
+        "Version mismatch for plugin %q[%s] from %s",
+        plugin.name,
+        plugin.version_string,
+        common.dirname(plugin.file)
+      )
+      local rlist = plugin.file:find(USERDIR, 1, true) == 1
+        and 'userdir' or 'datadir'
+      table.insert(refused_list[rlist].plugins, plugin)
+    elseif config.plugins[plugin.name] ~= false then
+      local start = system.get_time()
+      local ok, loaded_plugin = core.try(plugin.load, plugin)
+      if ok then
+        local plugin_version = ""
+        if plugin.version_string and  plugin.version_string ~= MOD_VERSION_STRING then
+          plugin_version = "["..plugin.version_string.."]"
         end
-        if not ok then
-          no_errors = false
-        elseif config.plugins[plugin.name].onload then
+        core.log_quiet(
+          "Loaded plugin %q%s from %s in %.1fms",
+          plugin.name,
+          plugin_version,
+          common.dirname(plugin.file),
+          (system.get_time() - start) * 1000
+        )
+        if config.plugins[plugin.name].onload then
           core.try(config.plugins[plugin.name].onload, loaded_plugin)
         end
+      else
+        no_errors = false
       end
     end
   end
@@ -683,21 +654,6 @@ function core.load_plugins()
     (system.get_time() - load_start) * 1000
   )
   return no_errors, refused_list
-end
-
-
-function core.load_project_module()
-  local filename = core.root_project():absolute_path(".lite_project.lua")
-  
-  if system.get_file_info(filename) then
-    return core.try(function()
-      local fn, err = loadfile(filename)
-      if not fn then error("Error when loading project module:\n\t" .. err) end
-      fn()
-      core.log_quiet("Loaded project module")
-    end)
-  end
-  return true
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -248,7 +248,6 @@ function core.ensure_user_directory()
     if not system.get_file_info(init_filename) then
       write_user_init_file(init_filename)
     end
-    dofile(init_filename)
   end)
 end
 

--- a/data/plugins/autorestart.lua
+++ b/data/plugins/autorestart.lua
@@ -1,0 +1,19 @@
+-- mod-version:4
+local core = require "core"
+local config = require "core.config"
+local command = require "core.command"
+local Doc = require "core.doc"
+local common = require "core.common"
+
+config.plugins.autorestart = common.merge({
+  
+}, config.plugins.autorestart)
+
+local save = Doc.save
+Doc.save = function(self, ...)
+  local res = save(self, ...)
+  if self.abs_filename == USERDIR .. PATHSEP .. "init.lua" or self.abs_filename == core.root_project().path .. PATHSEP .. ".lite_project" then
+    command.perform("core:restart")
+  end
+  return res
+end

--- a/src/api/renwindow.c
+++ b/src/api/renwindow.c
@@ -22,6 +22,9 @@ static int f_renwin_create(lua_State *L) {
   float width = luaL_optnumber(L, 4, 0);
   float height = luaL_optnumber(L, 5, 0);
 
+  if (video_init() != 0)
+    return luaL_error(L, "Error creating lite-xl window: %s", SDL_GetError());
+
   if (width < 1 || height < 1) {
     const SDL_DisplayMode* dm = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
 

--- a/src/main.c
+++ b/src/main.c
@@ -109,41 +109,26 @@ int main(int argc, char **argv) {
 #endif
 
   SDL_SetAppMetadata("Lite XL", LITE_PROJECT_VERSION_STR, "com.lite_xl.LiteXL");
-
-  if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS)) {
-    fprintf(stderr, "Error initializing SDL: %s", SDL_GetError());
+  if (SDL_Init(SDL_INIT_EVENTS) != 0) {
+    fprintf(stderr, "Error initializing sdl: %s", SDL_GetError());
     exit(1);
   }
   SDL_EnableScreenSaver();
   SDL_SetEventEnabled(SDL_EVENT_DROP_FILE, true);
   atexit(SDL_Quit);
-
-  SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
-  SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
-  SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "1");
-  SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
-
-  /* This hint tells SDL to respect borderless window as a normal window.
-  ** For example, the window will sit right on top of the taskbar instead
-  ** of obscuring it. */
-  SDL_SetHint("SDL_BORDERLESS_WINDOWED_STYLE", "1");
-  /* This hint tells SDL to allow the user to resize a borderless windoow.
-  ** It also enables aero-snap on Windows apparently. */
-  SDL_SetHint("SDL_BORDERLESS_RESIZABLE_STYLE", "1");
-  SDL_SetHint(SDL_HINT_MOUSE_DOUBLE_CLICK_RADIUS, "4");
-
+  
   if (ren_init() != 0) {
     fprintf(stderr, "Error initializing renderer: %s\n", SDL_GetError());
   }
 
   int has_restarted = 0;
   lua_State *L;
+
 init_lua:
   L = luaL_newstate();
   luaL_openlibs(L);
   api_load_libs(L);
-
-
+  
   lua_newtable(L);
   for (int i = 0; i < argc; i++) {
     lua_pushstring(L, argv[i]);
@@ -176,8 +161,11 @@ init_lua:
     set_macos_bundle_resources(L);
   #endif
 #endif
+<<<<<<< HEAD
   SDL_SetEventEnabled(SDL_EVENT_TEXT_INPUT, true);
   SDL_SetEventEnabled(SDL_EVENT_TEXT_EDITING, true);
+=======
+>>>>>>> 1e1b9328 (Revert "Removed storage module.")
 
   const char *init_lite_code = \
     "local core\n"

--- a/src/main.c
+++ b/src/main.c
@@ -113,7 +113,6 @@ int main(int argc, char **argv) {
     fprintf(stderr, "Error initializing sdl: %s", SDL_GetError());
     exit(1);
   }
-  SDL_EnableScreenSaver();
   SDL_SetEventEnabled(SDL_EVENT_DROP_FILE, true);
   atexit(SDL_Quit);
   
@@ -161,11 +160,8 @@ init_lua:
     set_macos_bundle_resources(L);
   #endif
 #endif
-<<<<<<< HEAD
   SDL_SetEventEnabled(SDL_EVENT_TEXT_INPUT, true);
   SDL_SetEventEnabled(SDL_EVENT_TEXT_EDITING, true);
-=======
->>>>>>> 1e1b9328 (Revert "Removed storage module.")
 
   const char *init_lite_code = \
     "local core\n"

--- a/src/main.c
+++ b/src/main.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
 #endif
 
   SDL_SetAppMetadata("Lite XL", LITE_PROJECT_VERSION_STR, "com.lite_xl.LiteXL");
-  if (SDL_Init(SDL_INIT_EVENTS) != 0) {
+  if (!SDL_Init(SDL_INIT_EVENTS)) {
     fprintf(stderr, "Error initializing sdl: %s", SDL_GetError());
     exit(1);
   }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -776,8 +776,7 @@ int video_init(void) {
     SDL_EnableScreenSaver();
     SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
     SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
-    SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
-    SDL_SetHint(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1");
+    SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "1");
     /* This hint tells SDL to respect borderless window as a normal window.
     ** For example, the window will sit right on top of the taskbar instead
     ** of obscuring it. */

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -771,7 +771,7 @@ static void ren_remove_window(RenWindow *window_renderer) {
 int video_init(void) {
   static int ren_inited = 0;
   if (!ren_inited) {
-    if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0)
+    if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
       return -1;     
     SDL_EnableScreenSaver();
     SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -774,34 +774,18 @@ int video_init(void) {
     if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0)
       return -1;     
     SDL_EnableScreenSaver();
-    #ifdef SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR /* Available since 2.0.8 */
-      SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
-    #endif
-    #if SDL_VERSION_ATLEAST(2, 0, 5)
-      SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
-    #endif
-    #if SDL_VERSION_ATLEAST(2, 0, 18)
-      SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
-    #endif
-    #if SDL_VERSION_ATLEAST(2, 0, 22)
-      SDL_SetHint(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1");
-    #endif
-
-    #if SDL_VERSION_ATLEAST(2, 0, 8)
-      /* This hint tells SDL to respect borderless window as a normal window.
-      ** For example, the window will sit right on top of the taskbar instead
-      ** of obscuring it. */
-      SDL_SetHint("SDL_BORDERLESS_WINDOWED_STYLE", "1");
-    #endif
-    #if SDL_VERSION_ATLEAST(2, 0, 12)
-      /* This hint tells SDL to allow the user to resize a borderless windoow.
-      ** It also enables aero-snap on Windows apparently. */
-      SDL_SetHint("SDL_BORDERLESS_RESIZABLE_STYLE", "1");
-    #endif
-    #if SDL_VERSION_ATLEAST(2, 0, 9)
-      SDL_SetHint("SDL_MOUSE_DOUBLE_CLICK_RADIUS", "4");
-    #endif
-
+    SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
+    SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
+    SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
+    SDL_SetHint(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1");
+    /* This hint tells SDL to respect borderless window as a normal window.
+    ** For example, the window will sit right on top of the taskbar instead
+    ** of obscuring it. */
+    SDL_SetHint("SDL_BORDERLESS_WINDOWED_STYLE", "1");
+    /* This hint tells SDL to allow the user to resize a borderless windoow.
+    ** It also enables aero-snap on Windows apparently. */
+    SDL_SetHint("SDL_BORDERLESS_RESIZABLE_STYLE", "1");
+    SDL_SetHint("SDL_MOUSE_DOUBLE_CLICK_RADIUS", "4");
     SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
     ren_inited = 1;
   }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -768,6 +768,46 @@ static void ren_remove_window(RenWindow *window_renderer) {
   }
 }
 
+int video_init(void) {
+  static int ren_inited = 0;
+  if (!ren_inited) {
+    if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0)
+      return -1;     
+    SDL_EnableScreenSaver();
+    #ifdef SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR /* Available since 2.0.8 */
+      SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
+    #endif
+    #if SDL_VERSION_ATLEAST(2, 0, 5)
+      SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
+    #endif
+    #if SDL_VERSION_ATLEAST(2, 0, 18)
+      SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
+    #endif
+    #if SDL_VERSION_ATLEAST(2, 0, 22)
+      SDL_SetHint(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1");
+    #endif
+
+    #if SDL_VERSION_ATLEAST(2, 0, 8)
+      /* This hint tells SDL to respect borderless window as a normal window.
+      ** For example, the window will sit right on top of the taskbar instead
+      ** of obscuring it. */
+      SDL_SetHint("SDL_BORDERLESS_WINDOWED_STYLE", "1");
+    #endif
+    #if SDL_VERSION_ATLEAST(2, 0, 12)
+      /* This hint tells SDL to allow the user to resize a borderless windoow.
+      ** It also enables aero-snap on Windows apparently. */
+      SDL_SetHint("SDL_BORDERLESS_RESIZABLE_STYLE", "1");
+    #endif
+    #if SDL_VERSION_ATLEAST(2, 0, 9)
+      SDL_SetHint("SDL_MOUSE_DOUBLE_CLICK_RADIUS", "4");
+    #endif
+
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+    ren_inited = 1;
+  }
+  return 0;
+}
+
 int ren_init(void) {
   FT_Error err;
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -42,6 +42,7 @@ double ren_draw_text(RenSurface *rs, RenFont **font, const char *text, size_t le
 
 void ren_draw_rect(RenSurface *rs, RenRect rect, RenColor color);
 
+int video_init(void);
 int ren_init(void);
 void ren_free(void);
 RenWindow* ren_create(SDL_Window *win);


### PR DESCRIPTION
Should only be merged after https://github.com/lite-xl/lite-xl/pull/1455, as this is rebased off of that.

This demotes project and user modules to be the same as every other type of plugin, just inserted slightly differently. It also allows plugins to modify the plugin load order, and insert additional plugins to be loaded; allowing much easier versions of stuff like https://github.com/adamharrison/lite-xl-foreign where custom loaders can load additional plugins in other languages.

I've also taken the liberty of adding a plugin to force a restart on change of project; as project modules stomping on each other is basically a bug currently. Ditto the user module. This now allows you to easily customize this behavior, and removes the weird kinda stomping from the core.

We could theoretically re-add the stomping as a config option for the plugin, but given how problematic it's been, it's probably not the best idea.
