### PR TITLE
Allow you to scroll CommandView.

### DIFF
--- a/data/core/commandview.lua
+++ b/data/core/commandview.lua
@@ -94,7 +94,7 @@ function CommandView:get_scrollable_size()
 end
 
 function CommandView:get_h_scrollable_size()
-  return 0
+  return math.huge
 end
 
 


### PR DESCRIPTION
We shouldn't make this assumption. Sometimes in IDE, I have a very large argument to throw to my binary; this allows me to scroll to see it.