### PR TITLE
Implement logic for tracking active window

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -16,6 +16,7 @@
 // #define RENDERER_DEBUG
 
 static RenWindow **window_list = NULL;
+static RenWindow *target_window = NULL;
 static size_t window_count = 0;
 
 // draw_rect_surface is used as a 1x1 surface to simplify ren_draw_rect with blending
@@ -793,4 +794,14 @@ RenWindow* ren_find_window(SDL_Window *window) {
 RenWindow* ren_find_window_from_id(uint32_t id) {
   SDL_Window *window = SDL_GetWindowFromID(id);
   return ren_find_window(window);
+}
+
+RenWindow* ren_get_target_window(void)
+{
+  return target_window;
+}
+
+void ren_set_target_window(RenWindow *window)
+{
+  target_window = window;
 }

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -52,5 +52,7 @@ void ren_get_size(RenWindow *window_renderer, int *x, int *y); /* Reports the si
 size_t ren_get_window_list(RenWindow ***window_list_dest);
 RenWindow* ren_find_window(SDL_Window *window);
 RenWindow* ren_find_window_from_id(uint32_t id);
+RenWindow* ren_get_target_window(void);
+void ren_set_target_window(RenWindow *window);
 
 #endif


### PR DESCRIPTION
this will be needed when SDL3 happens due to many more functions requesting a window handle
wording could be improved? maybe `current` instead of `active`? idk, lots of bike shedding.