### PR TITLE
added Doc:for_each_selection()

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -274,7 +274,15 @@ function Doc:get_selections(sort_intra, idx_reverse)
       idx_reverse == true and ((#self.selections / 4) + 1) or ((idx_reverse or -1) + 1)
 end
 
--- End of cursor seciton.
+--- Calls the provided function for each selection in the document
+---@param func fun(sidx: number, line1: number, col1: number, line2:number, col2: number)
+function Doc:for_each_selection(func, sort_intra, idx_reverse)
+  for idx, l1, c1, l2, c2 in self:get_selections(sort_intra, idx_reverse) do
+    func(idx, l1, c1, l2, c2)
+  end
+end
+
+-- End of cursor section.
 
 function Doc:sanitize_position(line, col)
   local nlines = #self.lines


### PR DESCRIPTION
i extend core.doc with a method that i thought was helpful while making a plugin. 
it calls the provided function for each of the selections in the doc. 

the implementation would look like :
```
doc:for_each_selection(
  function(selection_index, line1, col1, line2, col2)
    -- do some stuff with the selection
    -- doc:replace()... whatever
  end
)
```

its easy enough to do this each time i guess, but it does provide an easy way to give multi-cursor support to a plugin without adding any addition code. 
with this, there really would not be any reason to call doc:get_selections() unless you needed to access all the selections as a whole to manipulate them together for some reason.

let me know what you think!