### PR TITLE
treeview: remove unused code

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -442,9 +442,6 @@ function TreeView:draw()
   self:draw_background(style.background2)
   local _y, _h = self.position.y, self.size.y
 
-  local doc = core.active_view.doc
-  local active_filename = doc and system.absolute_path(doc.filename or "")
-
   for item, x,y,w,h in self:each_item() do
     if y + h >= _y and y < _y + _h then
       self:draw_item(item,


### PR DESCRIPTION
It caused a lot of useless `system.absolute_path` calls.