### PR TITLE
check item type before creating input text

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -856,7 +856,12 @@ command.add(
   ["treeview:new-file"] = function(item)
     local text
     if not is_project_folder(item.abs_filename) then
-      text = item.filename .. PATHSEP
+      if item.type == "dir" then
+        text = item.filename .. PATHSEP
+      elseif item.type == "file" then
+        local parent_dir = common.dirname(item.filename)
+        text = parent_dir and  parent_dir .. PATHSEP
+      end
     end
     core.command_view:enter("Filename", {
       text = text,
@@ -878,7 +883,12 @@ command.add(
   ["treeview:new-folder"] = function(item)
     local text
     if not is_project_folder(item.abs_filename) then
-      text = item.filename .. PATHSEP
+      if item.type == "dir" then
+        text = item.filename .. PATHSEP
+      elseif item.type == "file" then
+        local parent_dir = common.dirname(item.filename)
+        text = parent_dir and  parent_dir .. PATHSEP
+      end
     end
     core.command_view:enter("Folder Name", {
       text = text,

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -860,7 +860,7 @@ command.add(
         text = item.filename .. PATHSEP
       elseif item.type == "file" then
         local parent_dir = common.dirname(item.filename)
-        text = parent_dir and  parent_dir .. PATHSEP
+        text = parent_dir and parent_dir .. PATHSEP
       end
     end
     core.command_view:enter("Filename", {

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -887,7 +887,7 @@ command.add(
         text = item.filename .. PATHSEP
       elseif item.type == "file" then
         local parent_dir = common.dirname(item.filename)
-        text = parent_dir and  parent_dir .. PATHSEP
+        text = parent_dir and parent_dir .. PATHSEP
       end
     end
     core.command_view:enter("Folder Name", {


### PR DESCRIPTION
closes #1901 


added a check to see if the selected item is a file or a directory. 
if it is a file. we only prepend the parent directory path, and not the filename.

this was necessary for both 
`treeview:new-file` and `treeview:new-folder`