### PR TITLE
renderer: pass errors via SDL_SetError

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -97,7 +97,7 @@ static int f_font_load(lua_State *L) {
   RenFont** font = lua_newuserdata(L, sizeof(RenFont*));
   *font = ren_font_load(filename, size, antialiasing, hinting, style);
   if (!*font)
-    return luaL_error(L, "failed to load font");
+    return luaL_error(L, "failed to load font: %s", SDL_GetError());
   luaL_setmetatable(L, API_TYPE_FONT);
   return 1;
 }
@@ -143,7 +143,7 @@ static int f_font_copy(lua_State *L) {
     RenFont** font = lua_newuserdata(L, sizeof(RenFont*));
     *font = ren_font_copy(fonts[i], size, antialiasing, hinting, style);
     if (!*font)
-      return luaL_error(L, "failed to copy font");
+      return luaL_error(L, "failed to copy font: %s", SDL_GetError());
     luaL_setmetatable(L, API_TYPE_FONT);
     if (table)
       lua_rawseti(L, -2, i+1);

--- a/src/main.c
+++ b/src/main.c
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
 #endif
 
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
-    fprintf(stderr, "Error initializing sdl: %s", SDL_GetError());
+    fprintf(stderr, "Error initializing SDL: %s\n", SDL_GetError());
     exit(1);
   }
   SDL_EnableScreenSaver();
@@ -145,8 +145,8 @@ int main(int argc, char **argv) {
 
   SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
 
-  if ( ren_init() ) {
-    fprintf(stderr, "internal font error when starting the application\n");
+  if (ren_init() != 0) {
+    fprintf(stderr, "Error initializing renderer: %s\n", SDL_GetError());
   }
 
   int has_restarted = 0;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -33,6 +33,16 @@ static void* _check_alloc(void *ptr, const char *const file, size_t ln) {
   return ptr;
 }
 
+// getting freetype error messages (https://freetype.org/freetype2/docs/reference/ft2-error_enumerations.html)
+static const char *const get_ft_error(FT_Error err) {
+#undef FTERRORS_H_
+#define FT_ERROR_START_LIST switch (FT_ERROR_BASE(err)) {
+#define FT_ERRORDEF(e, v, s) case v: return s;
+#define FT_ERROR_END_LIST }
+#include FT_ERRORS_H
+  return "unknown error";
+}
+
 /************************* Fonts *************************/
 
 // approximate number of glyphs per atlas surface
@@ -444,12 +454,15 @@ static int font_set_face_metrics(RenFont *font, FT_Face face) {
 }
 
 RenFont* ren_font_load(const char* path, float size, ERenFontAntialiasing antialiasing, ERenFontHinting hinting, unsigned char style) {
+  FT_Error err = FT_Err_Ok;
   SDL_RWops *file = NULL; RenFont *font = NULL;
   FT_Face face = NULL; FT_Stream stream = NULL;
 
-  file = SDL_RWFromFile(path, "rb");
-  if (!file) return NULL;
+  SDL_ClearError();
 
+  file = SDL_RWFromFile(path, "rb");
+  if (!file) return NULL; // error set by SDL_RWFromFile
+  
   int len = strlen(path);
   font = check_alloc(calloc(1, sizeof(RenFont) + len + 1));
   strcpy(font->path, path);
@@ -470,15 +483,16 @@ RenFont* ren_font_load(const char* path, float size, ERenFontAntialiasing antial
   stream->pos = 0;
   stream->size = (unsigned long) SDL_RWsize(file);
 
-  if (FT_Open_Face(library, &(FT_Open_Args) { .flags = FT_OPEN_STREAM, .stream = stream }, 0, &face) != 0)
+  if ((err = FT_Open_Face(library, &(FT_Open_Args) { .flags = FT_OPEN_STREAM, .stream = stream }, 0, &face)) != 0)
     goto failure;
-  if (font_set_face_metrics(font, face) != 0)
+  if ((err = font_set_face_metrics(font, face)) != 0)
     goto failure;
   return font;
 
 stream_failure:
   if (file) SDL_RWclose(file);
 failure:
+  if (err != FT_Err_Ok) SDL_SetError("%s", get_ft_error(err));
   if (face) FT_Done_Face(face);
   if (font) free(font);
   return NULL;
@@ -489,7 +503,7 @@ RenFont* ren_font_copy(RenFont* font, float size, ERenFontAntialiasing antialias
   hinting = hinting == -1 ? font->hinting : hinting;
   style = style == -1 ? font->style : style;
 
-  return ren_font_load(font->path, size, antialiasing, hinting, style);
+  return ren_font_load(font->path, size, antialiasing, hinting, style); // SDL_SetError() will be called appropriately
 }
 
 const char* ren_font_get_path(RenFont *font) {
@@ -744,13 +758,16 @@ static void ren_remove_window(RenWindow *window_renderer) {
 }
 
 int ren_init(void) {
-  int err;
+  FT_Error err;
+  SDL_ClearError();
 
   draw_rect_surface = SDL_CreateRGBSurface(0, 1, 1, 32,
                        0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF);
+  if (!draw_rect_surface)
+    return -1; // error set by SDL_CreateRGBSurface
 
   if ((err = FT_Init_FreeType(&library)) != 0)
-    return err;
+    return SDL_SetError("%s", get_ft_error(err));
 
   return 0;
 }


### PR DESCRIPTION
This is a thing that everyone wants but it keeps delayed for no good reason.
This PR adds error messages by using SDL_GetError(). There are a few ways that we can pass error codes around the renderer:

1. Use some error code. Unfortunately, SDL doesn't use it, and FreeType error codes are limited (can't open file? _why_?). There is also the question of which set of error codes to return - FreeType, our own, or what? Or we can do it like Windows, by indicating whether the error is generated by SDL or FreeType with the high byte? Wouldn't that still clash with FreeType?
2. Return some kind of error type that be casted to a string, directly or indirectly. This still raises questions regarding if that string should be statically allocated, or comes with a complementary free function, etc.
3. Just use SDL_SetError() and SDL_GetError(). I'm pretty sure this way of error handling is shunned by a lot of people, but face it - this is just the most flexible way when you have error messages from various sources, and in various formats. SDL_GetError() also stores the message in thread local storage, so no problems with multithreading either.

Obviously, this PR uses approach 3. Finally we can get stuff like this:
![image](https://github.com/user-attachments/assets/f8306898-5afb-4697-8807-53026db12d04)

Obviously that message is kinda long, but this beats not having a proper error message AT ALL.

As a side note, this also implicitly implies that we should adopt a 0 for success and negative for failure convention, as used by SDL. I don't think this is much problem, since we partially use 0 for success already in various places in the codebase.

Closes #1721.