### PR TITLE
generate metainfo release tag using git tags

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -210,21 +210,64 @@ elif get_option('bundle') and host_machine.system() == 'darwin'
         install_dir : 'Contents'
     )
 else
-    message()
     lite_bindir = 'bin'
     lite_docdir = get_option('datadir') / 'doc' / 'lite-xl'
     lite_datadir = get_option('datadir') / 'lite-xl'
     lpm_userdir = 'lite-xl'
     lpm_install_dir = get_option('datadir')
     if host_machine.system() == 'linux'
+        git_command = find_program('git', required : false)
+
+        if git_command.found()
+            git_tags = run_command(
+                [git_command, 'tag', '-l', '--sort=-version:refname', '--format=%(refname:strip=2) %(creatordate:short)'],
+                check : false
+            ).stdout().split('\n')
+
+            releases = []
+
+            foreach tag : git_tags
+                taga = tag.split(' ')
+                if taga.length() != 2
+                    continue
+                endif
+
+                ref = taga[0]
+                date = taga[1]
+                if not ref.startswith('v') or ref.contains('-')
+                    continue
+                endif
+
+                if ref.startswith('v1.0')
+                    # releases 1.01 to 1.09 used an invalid versioning scheme so we ignore them
+                    continue
+                endif
+
+                releases += '<release version="@0@" date="@1@" />'.format(ref, date)
+            endforeach
+
+            releases_tag = ''
+            if releases.length() > 0
+                releases_tag = '<releases>\n@0@\n</releases>'.format('\n'.join(releases))
+            endif
+
+            conf_data.set('METAINFO_RELEASES', releases_tag)
+        else
+            conf_data.set('METAINFO_RELEASES', '')
+        endif
+
         install_data('resources' / 'icons' / 'lite-xl.svg',
             install_dir : get_option('datadir') / 'icons' / 'hicolor' / 'scalable' / 'apps'
         )
         install_data('resources' / 'linux' / 'com.lite_xl.LiteXL.desktop',
             install_dir : get_option('datadir') / 'applications'
         )
-        install_data('resources' / 'linux' / 'com.lite_xl.LiteXL.appdata.xml',
-            install_dir : get_option('datadir') / 'metainfo'
+        configure_file(
+            input : 'resources' / 'linux' / 'com.lite_xl.LiteXL.metainfo.xml.in',
+            output : 'com.lite_xl.LiteXL.metainfo.xml',
+            configuration : conf_data,
+            install : true,
+            install_dir : 'share/metainfo'
         )
     endif
 endif

--- a/resources/linux/com.lite_xl.LiteXL.metainfo.xml.in
+++ b/resources/linux/com.lite_xl.LiteXL.metainfo.xml.in
@@ -28,7 +28,5 @@
     <binary>lite-xl</binary>
   </provides>
 
-  <releases>
-    <release version="2.1.5" date="2024-06-29" />
-  </releases>
+  @METAINFO_RELEASES@
 </component>


### PR DESCRIPTION
- rename appdata to metainfo ([appdata is the legacy name](https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html))
- fill optional releases section with info from git, if available
    - this skips the versions `1.01` to `1.09` because they break the versioning scheme, I could implement a workaround however these versions are old and can probably be left out