### PR TITLE
fix appimage cd error and use static appimage runtime

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -41,7 +41,7 @@ main() {
   fi
 
   if [[ "$OSTYPE" == "linux"* ]]; then
-    sudo apt-get install -qq libfuse2 ninja-build wayland-protocols libsdl2-dev libfreetype6
+    sudo apt-get install -qq libfuse2 ninja-build wayland-protocols libsdl2-dev libfreetype6 desktop-file-utils
     pip3 install meson
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install bash ninja sdl2

--- a/scripts/package-appimage.sh
+++ b/scripts/package-appimage.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+export APPIMAGE_EXTRACT_AND_RUN=1
+
 if [ ! -e "src/api/api.h" ]; then
-  echo "Please run this script from the root directory of Lite XL."
-  exit 1
+	echo "Please run this script from the root directory of Lite XL."
+	exit 1
 fi
 
 source scripts/common.sh
@@ -13,93 +15,95 @@ BUILD_DIR="$(get_default_build_dir)"
 ADDONS=false
 
 show_help(){
-  echo
-  echo "Usage: $0 <OPTIONS>"
-  echo
-  echo "Available options:"
-  echo
-  echo "-h --help                 Show this help and exits."
-  echo "-b --builddir DIRNAME     Sets the name of the build dir (no path)."
-  echo "                          Default: '${BUILD_DIR}'."
-  echo "   --debug                Debug this script."
-  echo "-n --nobuild              Skips the build step, use existing files."
-  echo "-v --version VERSION      Specify a version, non whitespace separated string."
-  echo
+	echo
+	echo "Usage: $0 <OPTIONS>"
+	echo
+	echo "Available options:"
+	echo
+	echo "-h --help                 Show this help and exits."
+	echo "-b --builddir DIRNAME     Sets the name of the build dir (no path)."
+	echo "                          Default: '${BUILD_DIR}'."
+	echo "   --debug                Debug this script."
+	echo "-n --nobuild              Skips the build step, use existing files."
+	echo "-v --version VERSION      Specify a version, non whitespace separated string."
+echo
 }
 
 for i in "$@"; do
-  case $i in
-    -h|--help)
-      show_help
-      exit 0
-      ;;
-    -b|--builddir)
-      BUILD_DIR="$2"
-      shift
-      shift
-      ;;
-    --debug)
-      set -x
-      shift
-      ;;
-    -v|--version)
-      VERSION="$2"
-      shift
-      shift
-      ;;
-    *)
-      # unknown option
-      ;;
-  esac
+	case $i in
+		-h|--help)
+			show_help
+			exit 0
+			;;
+		-b|--builddir)
+			BUILD_DIR="$2"
+			shift
+			shift
+			;;
+		--debug)
+			set -x
+			shift
+			;;
+		-v|--version)
+			VERSION="$2"
+			shift
+			shift
+			;;
+		*)
+			# unknown option
+			;;
+	esac
 done
 
 setup_appimagetool() {
-  if [ ! -e appimagetool ]; then
-    if ! wget -O appimagetool "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${ARCH}.AppImage" ; then
-      echo "Could not download the appimagetool for the arch '${ARCH}'."
-      exit 1
-    else
-      chmod 0755 appimagetool
-    fi
-  fi
-}
-
-download_appimage_apprun() {
-  if [ ! -e AppRun ]; then
-    if ! wget -O AppRun "https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-${ARCH}" ; then
-      echo "Could not download AppRun for the arch '${ARCH}'."
-      exit 1
-    else
-      chmod 0755 AppRun
-    fi
-  fi
+	if [ ! -e appimagetool ]; then
+		if ! wget -O appimagetool "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage" ; then
+			echo "Could not download the appimagetool for the arch '${ARCH}'."
+			exit 1
+		else
+			chmod 0755 appimagetool
+		fi
+	fi
 }
 
 generate_appimage() {
-  [[ ! -e $BUILD_DIR ]] && scripts/build.sh $@
+	[[ ! -e $BUILD_DIR ]] && scripts/build.sh $@
 
-  if [ -e LiteXL.AppDir ]; then
-    rm -rf LiteXL.AppDir
-  fi
+	if [ -e LiteXL.AppDir ]; then
+		rm -rf LiteXL.AppDir
+	fi
 
-  echo "Creating LiteXL.AppDir..."
+	echo "Creating LiteXL.AppDir..."
 
-  DESTDIR="$(realpath LiteXL.AppDir)" meson install -C ${BUILD_DIR}
-  mv AppRun LiteXL.AppDir/
-  # These could be symlinks but it seems they doesn't work with AppimageLauncher
-  cp resources/icons/lite-xl.svg LiteXL.AppDir/
-  cp resources/linux/com.lite_xl.LiteXL.desktop LiteXL.AppDir/
+	DESTDIR="$(realpath LiteXL.AppDir)" meson install -C ${BUILD_DIR}
+	mv AppRun LiteXL.AppDir/
 
-  echo "Generating AppImage..."
-  local version=""
-  if [ -n "$VERSION" ]; then
-    version="-$VERSION"
-  fi
+	cp resources/icons/lite-xl.svg LiteXL.AppDir/
+	cp resources/linux/com.lite_xl.LiteXL.desktop LiteXL.AppDir/
 
-  ./appimagetool --appimage-extract-and-run LiteXL.AppDir LiteXL${version}-${ARCH}-linux.AppImage
-  rm -rf LiteXL.AppDir
+	# https://github.com/lite-xl/lite-xl/issues/1912
+	mkdir -p ./LiteXL.AppDir/usr/share/../bin
+	mv ./LiteXL.AppDir/lite-xl ./LiteXL.AppDir/usr/bin
+	mv ./LiteXL.AppDir/data ./LiteXL.AppDir/usr/share/lite-xl
+	rm -rf ./LiteXL.AppDir/lib64 ./LiteXL.AppDir/include
+
+	echo "Creating AppRun..."
+	cat >> LiteXL.AppDir/AppRun <<- 'EOF'
+	#!/bin/sh
+	CURRENTDIR="$(dirname "$(readlink -f "$0")")"
+	exec "$CURRENTDIR/usr/bin/lite-xl" "$@"
+	EOF
+	chmod +x LiteXL.AppDir/AppRun
+
+	echo "Generating AppImage..."
+	local version=""
+	if [ -n "$VERSION" ]; then
+		version="-$VERSION"
+	fi
+
+	./appimagetool LiteXL.AppDir LiteXL${version}-${ARCH}-linux.AppImage
+	rm -rf LiteXL.AppDir
 }
 
 setup_appimagetool
-download_appimage_apprun
 generate_appimage

--- a/scripts/package-appimage.sh
+++ b/scripts/package-appimage.sh
@@ -4,8 +4,8 @@ set -e
 export APPIMAGE_EXTRACT_AND_RUN=1
 
 if [ ! -e "src/api/api.h" ]; then
-	echo "Please run this script from the root directory of Lite XL."
-	exit 1
+  echo "Please run this script from the root directory of Lite XL."
+  exit 1
 fi
 
 source scripts/common.sh
@@ -15,93 +15,93 @@ BUILD_DIR="$(get_default_build_dir)"
 ADDONS=false
 
 show_help(){
-	echo
-	echo "Usage: $0 <OPTIONS>"
-	echo
-	echo "Available options:"
-	echo
-	echo "-h --help                 Show this help and exits."
-	echo "-b --builddir DIRNAME     Sets the name of the build dir (no path)."
-	echo "                          Default: '${BUILD_DIR}'."
-	echo "   --debug                Debug this script."
-	echo "-n --nobuild              Skips the build step, use existing files."
-	echo "-v --version VERSION      Specify a version, non whitespace separated string."
-echo
+  echo
+  echo "Usage: $0 <OPTIONS>"
+  echo
+  echo "Available options:"
+  echo
+  echo "-h --help                 Show this help and exits."
+  echo "-b --builddir DIRNAME     Sets the name of the build dir (no path)."
+  echo "                          Default: '${BUILD_DIR}'."
+  echo "   --debug                Debug this script."
+  echo "-n --nobuild              Skips the build step, use existing files."
+  echo "-v --version VERSION      Specify a version, non whitespace separated string."
+  echo
 }
 
 for i in "$@"; do
-	case $i in
-		-h|--help)
-			show_help
-			exit 0
-			;;
-		-b|--builddir)
-			BUILD_DIR="$2"
-			shift
-			shift
-			;;
-		--debug)
-			set -x
-			shift
-			;;
-		-v|--version)
-			VERSION="$2"
-			shift
-			shift
-			;;
-		*)
-			# unknown option
-			;;
-	esac
+  case $i in
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    -b|--builddir)
+      BUILD_DIR="$2"
+      shift
+      shift
+      ;;
+    --debug)
+      set -x
+      shift
+      ;;
+    -v|--version)
+      VERSION="$2"
+      shift
+      shift
+      ;;
+    *)
+      # unknown option
+      ;;
+  esac
 done
 
 setup_appimagetool() {
-	if [ ! -e appimagetool ]; then
-		if ! wget -O appimagetool "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage" ; then
-			echo "Could not download the appimagetool for the arch '${ARCH}'."
-			exit 1
-		else
-			chmod 0755 appimagetool
-		fi
-	fi
+  if [ ! -e appimagetool ]; then
+    if ! wget -O appimagetool "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage" ; then
+      echo "Could not download the appimagetool for the arch '${ARCH}'."
+      exit 1
+    else
+      chmod 0755 appimagetool
+    fi
+  fi
 }
 
 generate_appimage() {
-	[[ ! -e $BUILD_DIR ]] && scripts/build.sh $@
+  [[ ! -e $BUILD_DIR ]] && scripts/build.sh $@
 
-	if [ -e LiteXL.AppDir ]; then
-		rm -rf LiteXL.AppDir
-	fi
+  if [ -e LiteXL.AppDir ]; then
+    rm -rf LiteXL.AppDir
+  fi
 
-	echo "Creating LiteXL.AppDir..."
+  echo "Creating LiteXL.AppDir..."
 
-	DESTDIR="$(realpath LiteXL.AppDir)" meson install -C ${BUILD_DIR}
+  DESTDIR="$(realpath LiteXL.AppDir)" meson install -C ${BUILD_DIR}
 
-	cp resources/icons/lite-xl.svg LiteXL.AppDir/
-	cp resources/linux/com.lite_xl.LiteXL.desktop LiteXL.AppDir/
+  cp resources/icons/lite-xl.svg LiteXL.AppDir/
+  cp resources/linux/com.lite_xl.LiteXL.desktop LiteXL.AppDir/
 
-	# https://github.com/lite-xl/lite-xl/issues/1912
-	mkdir -p ./LiteXL.AppDir/usr/share/../bin
-	mv ./LiteXL.AppDir/lite-xl ./LiteXL.AppDir/usr/bin
-	mv ./LiteXL.AppDir/data ./LiteXL.AppDir/usr/share/lite-xl
-	rm -rf ./LiteXL.AppDir/lib64 ./LiteXL.AppDir/include
+  # https://github.com/lite-xl/lite-xl/issues/1912
+  mkdir -p ./LiteXL.AppDir/usr/share/../bin
+  mv ./LiteXL.AppDir/lite-xl ./LiteXL.AppDir/usr/bin
+  mv ./LiteXL.AppDir/data ./LiteXL.AppDir/usr/share/lite-xl
+  rm -rf ./LiteXL.AppDir/lib64 ./LiteXL.AppDir/include
 
-	echo "Creating AppRun..."
+  echo "Creating AppRun..."
 	cat >> LiteXL.AppDir/AppRun <<- 'EOF'
 	#!/bin/sh
 	CURRENTDIR="$(dirname "$(readlink -f "$0")")"
 	exec "$CURRENTDIR/usr/bin/lite-xl" "$@"
 	EOF
-	chmod +x LiteXL.AppDir/AppRun
+  chmod +x LiteXL.AppDir/AppRun
 
-	echo "Generating AppImage..."
-	local version=""
-	if [ -n "$VERSION" ]; then
-		version="-$VERSION"
-	fi
+  echo "Generating AppImage..."
+  local version=""
+  if [ -n "$VERSION" ]; then
+    version="-$VERSION"
+  fi
 
-	./appimagetool LiteXL.AppDir LiteXL${version}-${ARCH}-linux.AppImage
-	rm -rf LiteXL.AppDir
+  ./appimagetool LiteXL.AppDir LiteXL${version}-${ARCH}-linux.AppImage
+  rm -rf LiteXL.AppDir
 }
 
 setup_appimagetool

--- a/scripts/package-appimage.sh
+++ b/scripts/package-appimage.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-export APPIMAGE_EXTRACT_AND_RUN=1
-
 if [ ! -e "src/api/api.h" ]; then
   echo "Please run this script from the root directory of Lite XL."
   exit 1
@@ -100,7 +98,7 @@ generate_appimage() {
     version="-$VERSION"
   fi
 
-  ./appimagetool LiteXL.AppDir LiteXL${version}-${ARCH}-linux.AppImage
+  APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool LiteXL.AppDir LiteXL${version}-${ARCH}-linux.AppImage
   rm -rf LiteXL.AppDir
 }
 

--- a/scripts/package-appimage.sh
+++ b/scripts/package-appimage.sh
@@ -76,7 +76,6 @@ generate_appimage() {
 	echo "Creating LiteXL.AppDir..."
 
 	DESTDIR="$(realpath LiteXL.AppDir)" meson install -C ${BUILD_DIR}
-	mv AppRun LiteXL.AppDir/
 
 	cp resources/icons/lite-xl.svg LiteXL.AppDir/
 	cp resources/linux/com.lite_xl.LiteXL.desktop LiteXL.AppDir/


### PR DESCRIPTION
Fixes #1912 

However this won't fix the issue that the new builds of lite-xl don't use my user settings for some reason. 

-----------------------------------------------------------------

I also updated the appimage to use the new [appimagetool](https://github.com/AppImage/appimagetool) that deploys the static appimage runtime, which gets rid of the libfuse2 dependency, **however this means that the appimage will no longer work with appimagelauncher is right now it does not support the static appimage runtime.**

I think the issue with libfuse2 is much more important since distros now don't ship libfuse2, but if you don't want that just let me know anyway. (Several other projects are switching to the static runtime regardless, most notably Cemu did it 2 years ago).

Also I removed the download of the generic AppRun and instead just made a simple one in the script, this is to avoid issues with the generic AppRun setting a lot of env variables that  don't need to be set and would propagate to everything launched by lite-xl, like the terminal plugin, this is also why I changed the indentation to tabs to make the HEREDOC 😅 

