### PR TITLE
convert unix style paths literals into meson path segments

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -184,54 +184,55 @@ if get_option('portable') or host_machine.system() == 'windows'
     lite_docdir = '/doc'
     lite_datadir = '/data'
     configure_file(
-        input: 'resources/windows/lite-xl.exe.manifest.in',
+        input: 'resources' / 'windows' / 'lite-xl.exe.manifest.in',
         output: 'lite-xl.exe.manifest',
         configuration: conf_data
     )
 elif get_option('bundle') and host_machine.system() == 'darwin'
     lite_cargs += '-DMACOS_USE_BUNDLE'
-    lite_bindir = 'Contents/MacOS'
-    lite_docdir = 'Contents/Resources'
-    lite_datadir = 'Contents/Resources'
+    lite_bindir = 'Contents' / 'MacOS'
+    lite_docdir = 'Contents' / 'Resources'
+    lite_datadir = 'Contents' / 'Resources'
     conf_data.set(
         'CURRENT_YEAR',
         run_command('date', '+%Y', capture: true).stdout().strip()
     )
-    install_data('resources/icons/icon.icns', install_dir : 'Contents/Resources')
+    install_data('resources' / 'icons' / 'icon.icns', install_dir : 'Contents' / 'Resources')
     configure_file(
-        input : 'resources/macos/Info.plist.in',
+        input : 'resources' / 'macos' / 'Info.plist.in',
         output : 'Info.plist',
         configuration : conf_data,
         install : true,
         install_dir : 'Contents'
     )
 else
+    message()
     lite_bindir = 'bin'
-    lite_docdir = get_option('datadir') + '/doc/lite-xl'
-    lite_datadir = get_option('datadir') + '/lite-xl'
+    lite_docdir = get_option('datadir') / 'doc' / 'lite-xl'
+    lite_datadir = get_option('datadir') / 'lite-xl'
     if host_machine.system() == 'linux'
-        install_data('resources/icons/lite-xl.svg',
-            install_dir : get_option('datadir') + '/icons/hicolor/scalable/apps'
+        install_data('resources' / 'icons' / 'lite-xl.svg',
+            install_dir : get_option('datadir') / 'icons' / 'hicolor' / 'scalable' / 'apps'
         )
-        install_data('resources/linux/com.lite_xl.LiteXL.desktop',
-            install_dir : get_option('datadir') + '/applications'
+        install_data('resources' / 'linux' / 'com.lite_xl.LiteXL.desktop',
+            install_dir : get_option('datadir') / 'applications'
         )
-        install_data('resources/linux/com.lite_xl.LiteXL.appdata.xml',
-            install_dir : get_option('datadir') + '/metainfo'
+        install_data('resources' / 'linux' / 'com.lite_xl.LiteXL.appdata.xml',
+            install_dir : get_option('datadir') / 'metainfo'
         )
     endif
 endif
 
-install_data('licenses/licenses.md', install_dir : lite_docdir)
+install_data('licenses' / 'licenses.md', install_dir : lite_docdir)
 
-install_subdir('docs/api' , install_dir : lite_datadir, strip_directory: true)
-install_subdir('data/core' , install_dir : lite_datadir, exclude_files : 'start.lua')
+install_subdir('docs' / 'api' , install_dir : lite_datadir, strip_directory: true)
+install_subdir('data' / 'core' , install_dir : lite_datadir, exclude_files : 'start.lua')
 foreach data_module : ['fonts', 'plugins', 'colors']
     install_subdir(join_paths('data', data_module), install_dir : lite_datadir)
 endforeach
 
 configure_file(
-    input : 'data/core/start.lua',
+    input : 'data' / 'core' / 'start.lua',
     output : 'start.lua',
     configuration : conf_data,
     install_dir : join_paths(lite_datadir, 'core'),

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,22 +37,22 @@ else
 endif
 
 if dirmonitor_backend == 'inotify'
-    lite_sources += 'api/dirmonitor/inotify.c'
+    lite_sources += 'api' / 'dirmonitor' / 'inotify.c'
 elif dirmonitor_backend == 'fsevents'
-    lite_sources += 'api/dirmonitor/fsevents.c'
+    lite_sources += 'api' / 'dirmonitor' / 'fsevents.c'
 elif dirmonitor_backend == 'kqueue'
-    lite_sources += 'api/dirmonitor/kqueue.c'
+    lite_sources += 'api' / 'dirmonitor' / 'kqueue.c'
     libkqueue_dep = dependency('libkqueue', required : false)
     if libkqueue_dep.found()
         lite_deps += libkqueue_dep
     endif
 elif dirmonitor_backend == 'inodewatcher'
     add_languages('cpp')
-    lite_sources += 'api/dirmonitor/inodewatcher.cpp'
+    lite_sources += 'api' / 'dirmonitor' / 'inodewatcher.cpp'
 elif dirmonitor_backend == 'win32'
-    lite_sources += 'api/dirmonitor/win32.c'
+    lite_sources += 'api' / 'dirmonitor' / 'win32.c'
 else
-    lite_sources += 'api/dirmonitor/dummy.c'
+    lite_sources += 'api' / 'dirmonitor' / 'dummy.c'
 endif
 
 message('dirmonitor_backend: @0@'.format(dirmonitor_backend))
@@ -60,8 +60,8 @@ message('dirmonitor_backend: @0@'.format(dirmonitor_backend))
 lite_rc = []
 if host_machine.system() == 'windows'
     windows = import('windows')
-    lite_rc += windows.compile_resources('../resources/icons/icon.rc')
-    lite_rc += windows.compile_resources('../resources/windows/manifest.rc')
+    lite_rc += windows.compile_resources('..' / 'resources' / 'icons' / 'icon.rc')
+    lite_rc += windows.compile_resources('..' / 'resources' / 'windows' / 'manifest.rc')
 elif host_machine.system() == 'darwin'
     lite_sources += 'bundle_open.m'
 endif


### PR DESCRIPTION
While thus far everything has been working without a problem this is mostly due to various translations happening in meson, python and the underlying Windows APIs and we cannot guarantee that nothing will ever change in this translation on any layer

This PR simply replaces the string literals with path segments that form an OS native path 

