### PR TITLE
feat: add support for tab stops

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -178,7 +178,7 @@ function DocView:get_col_x_offset(line, col)
     if font ~= default_font then font:set_tab_size(indent_size) end
     local length = #text
     if column + length <= col then
-      xoffset = xoffset + font:get_width(text)
+      xoffset = xoffset + font:get_width(text, {tab_offset = xoffset})
       column = column + length
       if column >= col then
         return xoffset
@@ -188,7 +188,7 @@ function DocView:get_col_x_offset(line, col)
         if column >= col then
           return xoffset
         end
-        xoffset = xoffset + font:get_width(char)
+        xoffset = xoffset + font:get_width(char, {tab_offset = xoffset})
         column = column + #char
       end
     end
@@ -208,7 +208,7 @@ function DocView:get_x_offset_col(line, x)
   for _, type, text in self.doc.highlighter:each_token(line) do
     local font = style.syntax_fonts[type] or default_font
     if font ~= default_font then font:set_tab_size(indent_size) end
-    local width = font:get_width(text)
+    local width = font:get_width(text, {tab_offset = xoffset})
     -- Don't take the shortcut if the width matches x,
     -- because we need last_i which should be calculated using utf-8.
     if xoffset + width < x then
@@ -216,7 +216,7 @@ function DocView:get_x_offset_col(line, x)
       i = i + #text
     else
       for char in common.utf8_chars(text) do
-        local w = font:get_width(char)
+        local w = font:get_width(char, {tab_offset = xoffset})
         if xoffset >= x then
           return (xoffset - x > w / 2) and last_i or i
         end
@@ -449,12 +449,13 @@ function DocView:draw_line_text(line, x, y)
   if string.sub(tokens[tokens_count], -1) == "\n" then
     last_token = tokens_count - 1
   end
+  local start_tx = tx
   for tidx, type, text in self.doc.highlighter:each_token(line) do
     local color = style.syntax[type]
     local font = style.syntax_fonts[type] or default_font
     -- do not render newline, fixes issue #1164
     if tidx == last_token then text = text:sub(1, -2) end
-    tx = renderer.draw_text(font, text, tx, ty, color)
+    tx = renderer.draw_text(font, text, tx, ty, color, {tab_offset = tx - start_tx})
     if tx > self.position.x + self.size.x then break end
   end
   return self:get_line_height()

--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include <string.h>
 #include <assert.h>
 #include "api.h"
@@ -204,7 +205,7 @@ static int f_font_gc(lua_State *L) {
 
 
 static RenTab checktab(lua_State *L, int idx) {
-  RenTab tab = {.enabled = false, .offset = 0};
+  RenTab tab = {.offset = NAN};
   if (lua_isnoneornil(L, idx)) {
     return tab;
   }
@@ -213,7 +214,6 @@ static RenTab checktab(lua_State *L, int idx) {
     return tab;
   }
   tab.offset = luaL_checknumber(L, -1);
-  tab.enabled = true;
   return tab;
 }
 

--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -203,12 +203,28 @@ static int f_font_gc(lua_State *L) {
 }
 
 
+static RenTab checktab(lua_State *L, int idx) {
+  RenTab tab = {.enabled = false, .offset = 0};
+  if (lua_isnoneornil(L, idx)) {
+    return tab;
+  }
+  luaL_checktype(L, idx, LUA_TTABLE);
+  lua_getfield(L, idx, "tab_offset");
+  if (lua_isnoneornil(L, -1)) {
+    return tab;
+  }
+  tab.offset = luaL_checknumber(L, -1);
+  tab.enabled = true;
+  return tab;
+}
+
 static int f_font_get_width(lua_State *L) {
   RenFont* fonts[FONT_FALLBACK_MAX]; font_retrieve(L, fonts, 1);
   size_t len;
   const char *text = luaL_checklstring(L, 2, &len);
+  RenTab tab = checktab(L, 3);
 
-  lua_pushnumber(L, ren_font_group_get_width(fonts, text, len, NULL));
+  lua_pushnumber(L, ren_font_group_get_width(fonts, text, len, tab, NULL));
   return 1;
 }
 
@@ -373,7 +389,8 @@ static int f_draw_text(lua_State *L) {
   double x = luaL_checknumber(L, 3);
   int y = luaL_checknumber(L, 4);
   RenColor color = checkcolor(L, 5, 255);
-  x = rencache_draw_text(ren_get_target_window(), fonts, text, len, x, y, color);
+  RenTab tab = checktab(L, 6);
+  x = rencache_draw_text(ren_get_target_window(), fonts, text, len, x, y, color, tab);
   lua_pushnumber(L, x);
   return 1;
 }

--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -209,8 +209,7 @@ static RenTab checktab(lua_State *L, int idx) {
     return tab;
   }
   luaL_checktype(L, idx, LUA_TTABLE);
-  lua_getfield(L, idx, "tab_offset");
-  if (lua_isnoneornil(L, -1)) {
+  if (lua_getfield(L, idx, "tab_offset") == LUA_TNIL) {
     return tab;
   }
   tab.offset = luaL_checknumber(L, -1);

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -52,6 +52,7 @@ typedef struct {
   float text_x;
   size_t len;
   int8_t tab_size;
+  RenTab tab;
   char text[];
 } DrawTextCommand;
 
@@ -190,10 +191,10 @@ void rencache_draw_rect(RenWindow *window_renderer, RenRect rect, RenColor color
   }
 }
 
-double rencache_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, double x, int y, RenColor color)
+double rencache_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, double x, int y, RenColor color, RenTab tab)
 {
   int x_offset;
-  double width = ren_font_group_get_width(fonts, text, len, &x_offset);
+  double width = ren_font_group_get_width(fonts, text, len, tab, &x_offset);
   RenRect rect = { x + x_offset, y, (int)(width - x_offset), ren_font_group_get_height(fonts) };
   if (rects_overlap(last_clip_rect, rect)) {
     int sz = len + 1;
@@ -206,6 +207,7 @@ double rencache_draw_text(RenWindow *window_renderer, RenFont **fonts, const cha
       cmd->text_x = x;
       cmd->len = len;
       cmd->tab_size = ren_font_group_get_tab_size(fonts);
+      cmd->tab = tab;
     }
   }
   return x + width;
@@ -320,7 +322,7 @@ void rencache_end_frame(RenWindow *window_renderer) {
           break;
         case DRAW_TEXT:
           ren_font_group_set_tab_size(tcmd->fonts, tcmd->tab_size);
-          ren_draw_text(&rs, tcmd->fonts, tcmd->text, tcmd->len, tcmd->text_x, tcmd->rect.y, tcmd->color);
+          ren_draw_text(&rs, tcmd->fonts, tcmd->text, tcmd->len, tcmd->text_x, tcmd->rect.y, tcmd->color, tcmd->tab);
           break;
       }
     }

--- a/src/rencache.h
+++ b/src/rencache.h
@@ -8,7 +8,7 @@
 void  rencache_show_debug(bool enable);
 void  rencache_set_clip_rect(RenWindow *window_renderer, RenRect rect);
 void  rencache_draw_rect(RenWindow *window_renderer, RenRect rect, RenColor color);
-double rencache_draw_text(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, double x, int y, RenColor color);
+double rencache_draw_text(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, double x, int y, RenColor color, RenTab tab);
 void  rencache_invalidate(void);
 void  rencache_begin_frame(RenWindow *window_renderer);
 void  rencache_end_frame(RenWindow *window_renderer);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -519,7 +519,7 @@ float font_get_xadvance(RenFont *font, unsigned int codepoint, GlyphMetric *metr
     return font->space_advance;
   }
   float tab_size = font->space_advance * font->tab_size;
-  if (!tab.enabled) {
+  if (isnan(tab.offset)) {
     return tab_size;
   }
   double offset = fmodl(curr_x + tab.offset, tab_size);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -511,11 +511,27 @@ int ren_font_group_get_height(RenFont **fonts) {
 }
 
 // some fonts provide xadvance for whitespaces (e.g. Unifont), which we need to ignore
-#define FONT_GET_XADVANCE(F, C, M) (is_whitespace((C)) || !(M) || !(M)->xadvance \
-  ? (F)->space_advance * (float) ((C) == '\t' ? (F)->tab_size : 1) \
-  : (M)->xadvance)
+float font_get_xadvance(RenFont *font, unsigned int codepoint, GlyphMetric *metric, double curr_x, RenTab tab) {
+  if (!is_whitespace(codepoint) && metric && metric->xadvance) {
+    return metric->xadvance;
+  }
+  if (codepoint != '\t') {
+    return font->space_advance;
+  }
+  float tab_size = font->space_advance * font->tab_size;
+  if (!tab.enabled) {
+    return tab_size;
+  }
+  double offset = fmodl(curr_x + tab.offset, tab_size);
+  float adv = tab_size - offset;
+  // If there is not enough space until the next stop, skip it
+  if (adv < font->space_advance) {
+    adv += tab_size;
+  }
+  return adv;
+}
 
-double ren_font_group_get_width(RenFont **fonts, const char *text, size_t len, int *x_offset) {
+double ren_font_group_get_width(RenFont **fonts, const char *text, size_t len, RenTab tab, int *x_offset) {
   double width = 0;
   const char* end = text + len;
 
@@ -525,7 +541,7 @@ double ren_font_group_get_width(RenFont **fonts, const char *text, size_t len, i
     text = utf8_to_codepoint(text, end, &codepoint);
     GlyphMetric *metric = NULL;
     font_group_get_glyph(fonts, codepoint, 0, NULL, &metric);
-    width += FONT_GET_XADVANCE(fonts[0], codepoint, metric);
+    width += font_get_xadvance(fonts[0], codepoint, metric, width, tab);
     if (!set_x_offset && metric) {
       set_x_offset = true;
       *x_offset = metric->bitmap_left; // TODO: should this be scaled by the surface scale?
@@ -558,13 +574,14 @@ void ren_font_dump(RenFont *font) {
 }
 #endif
 
-double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t len, float x, int y, RenColor color) {
+double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t len, float x, int y, RenColor color, RenTab tab) {
   SDL_Surface *surface = rs->surface;
   SDL_Rect clip;
   SDL_GetClipRect(surface, &clip);
 
   const int surface_scale = rs->scale;
   double pen_x = x * surface_scale;
+  double original_pen_x = pen_x;
   y *= surface_scale;
   const char* end = text + len;
   uint8_t* destination_pixels = surface->pixels;
@@ -631,7 +648,7 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
       }
     }
 
-    float adv = FONT_GET_XADVANCE(fonts[0], codepoint, metric);
+    float adv = font_get_xadvance(fonts[0], codepoint, metric, pen_x - original_pen_x, tab);
 
     if(!last) last = font;
     else if(font != last || text == end) {

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -19,6 +19,7 @@ typedef enum { FONT_ANTIALIASING_NONE, FONT_ANTIALIASING_GRAYSCALE, FONT_ANTIALI
 typedef enum { FONT_STYLE_BOLD = 1, FONT_STYLE_ITALIC = 2, FONT_STYLE_UNDERLINE = 4, FONT_STYLE_SMOOTH = 8, FONT_STYLE_STRIKETHROUGH = 16 } ERenFontStyle;
 typedef struct { uint8_t b, g, r, a; } RenColor;
 typedef struct { int x, y, width, height; } RenRect;
+typedef struct { bool enabled; double offset; } RenTab;
 typedef struct { SDL_Surface *surface; int scale; } RenSurface;
 
 struct RenWindow;
@@ -36,8 +37,8 @@ void ren_font_group_set_size(RenFont **font, float size, int surface_scale);
 void update_font_scale(RenWindow *window_renderer, RenFont **fonts);
 #endif
 void ren_font_group_set_tab_size(RenFont **font, int n);
-double ren_font_group_get_width(RenFont **font, const char *text, size_t len, int *x_offset);
-double ren_draw_text(RenSurface *rs, RenFont **font, const char *text, size_t len, float x, int y, RenColor color);
+double ren_font_group_get_width(RenFont **font, const char *text, size_t len, RenTab tab, int *x_offset);
+double ren_draw_text(RenSurface *rs, RenFont **font, const char *text, size_t len, float x, int y, RenColor color, RenTab tab);
 
 void ren_draw_rect(RenSurface *rs, RenRect rect, RenColor color);
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -19,7 +19,7 @@ typedef enum { FONT_ANTIALIASING_NONE, FONT_ANTIALIASING_GRAYSCALE, FONT_ANTIALI
 typedef enum { FONT_STYLE_BOLD = 1, FONT_STYLE_ITALIC = 2, FONT_STYLE_UNDERLINE = 4, FONT_STYLE_SMOOTH = 8, FONT_STYLE_STRIKETHROUGH = 16 } ERenFontStyle;
 typedef struct { uint8_t b, g, r, a; } RenColor;
 typedef struct { int x, y, width, height; } RenRect;
-typedef struct { bool enabled; double offset; } RenTab;
+typedef struct { double offset; } RenTab;
 typedef struct { SDL_Surface *surface; int scale; } RenSurface;
 
 struct RenWindow;


### PR DESCRIPTION
Contrary to #1944 this uses pixel coordinates.

I'm using a table to pass `tab_offset` to allow for future expansion (custom tab stops positions, other kinds of properties, ...).

Another possible name could be `stop_offset` or `tab_stop_offset` to be more explicit.

Passing `tab_offset` is optional, and if absent, falls back to our previous behavior.

Closes #953.