### PR TITLE
fix: use current char to determine `col` in `DocView:get_x_offset_col`

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -203,7 +203,7 @@ end
 function DocView:get_x_offset_col(line, x)
   local line_text = self.doc.lines[line]
 
-  local xoffset, last_i, i = 0, 1, 1
+  local xoffset, i = 0, 1
   local default_font = self:get_font()
   local _, indent_size = self.doc:get_indent_info()
   default_font:set_tab_size(indent_size)
@@ -219,11 +219,10 @@ function DocView:get_x_offset_col(line, x)
     else
       for char in common.utf8_chars(text) do
         local w = font:get_width(char, {tab_offset = xoffset})
-        if xoffset >= x then
-          return (xoffset - x > w / 2) and last_i or i
+        if xoffset + w >= x then
+          return (x <= xoffset + (w / 2)) and i or i + #char
         end
         xoffset = xoffset + w
-        last_i = i
         i = i + #char
       end
     end


### PR DESCRIPTION
Previously it would use the last char position, which resulted in incorrect values when the next char had a different size than the current one.