### PR TITLE
Install plugins with lpm inside meson

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,20 @@
+if get_option('bundle_plugins').length() > 0
+    lpm_exe = find_program('lpm')
+    plugin_bundle = custom_target(
+        'lpm_plugins',
+        input: 'meson.build',
+        output: lpm_userdir,
+        command: [
+            lpm_exe,
+            '--datadir', meson.project_source_root() / 'data',
+            '--userdir', '@OUTPUT0@',
+            '--cachedir', 'lpm_cache',
+            '--assume-yes',
+            'install',
+            get_option('bundle_plugins'),
+        ],
+        install: true,
+        install_dir: lpm_install_dir,
+        build_by_default: true,
+    )
+endif

--- a/data/meson.build
+++ b/data/meson.build
@@ -3,18 +3,18 @@ if get_option('bundle_plugins').length() > 0
     plugin_bundle = custom_target(
         'lpm_plugins',
         input: 'meson.build',
-        output: lpm_userdir,
+        output: [lpm_userdir, 'lpm_cache'],
         command: [
             lpm_exe,
             '--datadir', meson.project_source_root() / 'data',
             '--userdir', '@OUTPUT0@',
-            '--cachedir', 'lpm_cache',
+            '--cachedir', '@OUTPUT1@',
             '--assume-yes',
             'install',
             get_option('bundle_plugins'),
         ],
         install: true,
-        install_dir: lpm_install_dir,
+        install_dir: [lpm_install_dir, false],
         build_by_default: true,
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -183,6 +183,8 @@ if get_option('portable') or host_machine.system() == 'windows'
     lite_bindir = '/'
     lite_docdir = '/doc'
     lite_datadir = '/data'
+    lpm_userdir = 'data'
+    lpm_install_dir = '/'
     configure_file(
         input: 'resources' / 'windows' / 'lite-xl.exe.manifest.in',
         output: 'lite-xl.exe.manifest',
@@ -193,6 +195,8 @@ elif get_option('bundle') and host_machine.system() == 'darwin'
     lite_bindir = 'Contents' / 'MacOS'
     lite_docdir = 'Contents' / 'Resources'
     lite_datadir = 'Contents' / 'Resources'
+    lpm_userdir = 'Resources'
+    lpm_install_dir = 'Contents'
     conf_data.set(
         'CURRENT_YEAR',
         run_command('date', '+%Y', capture: true).stdout().strip()
@@ -210,6 +214,8 @@ else
     lite_bindir = 'bin'
     lite_docdir = get_option('datadir') / 'doc' / 'lite-xl'
     lite_datadir = get_option('datadir') / 'lite-xl'
+    lpm_userdir = 'lite-xl'
+    lpm_install_dir = get_option('datadir')
     if host_machine.system() == 'linux'
         install_data('resources' / 'icons' / 'lite-xl.svg',
             install_dir : get_option('datadir') / 'icons' / 'hicolor' / 'scalable' / 'apps'
@@ -241,4 +247,5 @@ configure_file(
 if not get_option('source-only')
     subdir('src')
     subdir('scripts')
+    subdir('data')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,3 +5,4 @@ option('renderer', type : 'boolean', value : false, description: 'Use SDL render
 option('dirmonitor_backend', type : 'combo', value : '', choices : ['', 'inotify', 'fsevents', 'kqueue', 'win32', 'dummy'], description: 'define what dirmonitor backend to use')
 option('arch_tuple', type : 'string', value : '', description: 'Specify a custom architecture tuple')
 option('use_system_lua', type : 'boolean', value : false, description: 'Prefer System Lua over a the meson wrap')
+option('bundle_plugins', type : 'array', value : [], description: 'Plugins to bundle when building Lite XL')

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -42,9 +42,8 @@ main() {
   local platform="$(get_platform_name)"
   local arch="$(get_platform_arch)"
   local build_dir
-  local plugins="welcome"
+  local plugins
   local prefix=/
-  local addons
   local build_type="release"
   local force_fallback
   local bundle
@@ -55,6 +54,7 @@ main() {
   local cross_arch
   local cross_file
   local reconfigure
+  local lpm_path
   local should_reconfigure
 
   for i in "$@"; do
@@ -90,7 +90,12 @@ main() {
         shift
         ;;
       -A|--addons)
-        addons="1"
+        if [[ -n $2 ]] && [[ $2 != -* ]]; then
+          plugins="-Dbundle_plugins=$2"
+          shift
+        else
+          plugins="-Dbundle_plugins=welcome"
+        fi
         shift
         ;;
       -B|--bundle)
@@ -192,6 +197,17 @@ main() {
     rm -rf "${build_dir}"
   fi
 
+  if [[ -n "$plugins" ]] && [[ -z `command -v lpm` ]] then
+    mkdir -p "${build_dir}"
+    lpm_path="$(pwd)/${build_dir}/lpm$(get_executable_extension)"
+    if [[ ! -e "$lpm_path" ]]; then
+      curl --insecure -L -o "$lpm_path" \
+        "https://github.com/lite-xl/lite-xl-plugin-manager/releases/download/${LPM_VERSION:-v1.3.1}/lpm.$(get_platform_tuple)$(get_executable_extension)"
+      chmod u+x "$lpm_path"
+    fi
+    export PATH="$(dirname "$lpm_path"):$PATH"
+  fi
+
   CFLAGS=$CFLAGS LDFLAGS=$LDFLAGS meson setup \
     "${build_dir}" \
     --buildtype "$build_type" \
@@ -201,6 +217,7 @@ main() {
     $bundle \
     $portable \
     $pgo \
+    $plugins \
     $reconfigure
 
   meson compile -C "${build_dir}"
@@ -215,11 +232,6 @@ main() {
   fi
 
   rm -fr $build_dir/src/lite-xl.*p $build_dir/src/*.o
-
-  if [[ $addons != "" ]]; then
-    [[ ! -e "$build_dir/lpm" ]] && curl --insecure -L "https://github.com/lite-xl/lite-xl-plugin-manager/releases/download/v1.2.9/lpm.$(get_platform_tuple)$(get_executable_extension)" -o "$build_dir/lpm$(get_executable_extension)" && chmod +x "$build_dir/lpm$(get_executable_extension)"
-    "$build_dir/lpm$(get_executable_extension)" install --datadir ${build_dir}/src/data --userdir ${build_dir}/src/data --arch $(get_platform_tuple) $plugins --assume-yes; "$build_dir/lpm$(get_executable_extension)" purge --datadir ${build_dir}/src/data --userdir ${build_dir}/src/data && chmod -R a+r ${build_dir}
-  fi
 
   mv "${build_dir}/src" "${build_dir}/lite-xl"
 }


### PR DESCRIPTION
This PR allows user to specify which plugins to bundle with meson by specifying `-Dbundle_plugins=<pluginslist>`. Meson will use lpm in PATH (or when run with `build.sh`, will download lpm if it doesn't exist in PATH) to install the plugins.

Closes #1802.