### PR TITLE
CI: publish on winget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,7 +296,7 @@ jobs:
           bodyFile: release-notes.md
           artifacts: "releases/*.*"
 
-      - name: Releease on Winget
+      - name: Release on Winget
         uses: vedantmgoyal9/winget-releaser@main
         if: ${{ needs.version.outputs.release }}
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
             echo "release=$REF" >> $GITHUB_OUTPUT
             echo "Release Version: $REF"
           fi
-          
+
   build_darwin:
     name: Darwin
     needs: [version]
@@ -70,18 +70,18 @@ jobs:
           bash --version
           gcc -v
           xcodebuild -version
-          
+
       - uses: actions/checkout@v4
-        
+
       - name: Python Setup
         uses: actions/setup-python@v5
         with: { python-version: "3.11" }
-        
+
       - name: Install Dependencies
         run: |
           brew install bash
           pip3 install meson ninja
-        
+
       - name: Build & Package Mac (Bundle)
         run: |
           scripts/build.sh --addons --debug --forcefallback --reconfigure --bundle -b build
@@ -91,7 +91,7 @@ jobs:
         run: |
           scripts/build.sh --addons --debug --forcefallback --reconfigure --portable -b build
           tar -C build -czvf lite-xl-${{ needs.version.outputs.ref }}-${{ matrix.config.arch }}-portable.tar.gz lite-xl
-        
+
       - name: Upload (Intermediate)
         uses: actions/upload-artifact@v4
         with:
@@ -104,7 +104,7 @@ jobs:
     name: Darwin (Universal)
     needs: [version, build_darwin]
     runs-on: macos-14
-    steps:          
+    steps:
       - uses: actions/checkout@v4
 
       - name: Python Setup
@@ -115,7 +115,7 @@ jobs:
         run: |
           brew install bash
           pip3 install dmgbuild
-      
+
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -139,7 +139,7 @@ jobs:
           dmgbuild -s resources/macos/lite-xl-dmg.py \
             -D "app_path=lite-xl-${{ needs.version.outputs.ref }}-universal-darwin-bundle/Lite XL.app" \
             "Lite XL" "lite-xl-${{ needs.version.outputs.ref }}-universal-darwin.dmg"
-        
+
       - name: Package Darwin (Universal Portable)
         run: tar -C lite-xl-${{ needs.version.outputs.ref }}-universal-darwin-portable -zcvf lite-xl-${{ needs.version.outputs.ref }}-universal-darwin-portable.tar.gz .
 
@@ -158,13 +158,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        
+
       - name: Build
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box-manylinux:v3
         with:
           entrypoint: /entrypoint.sh
           args: bash scripts/build.sh --addons --debug --forcefallback --portable -b build
-        
+
       - name: Package Linux (Portable)
         run: tar -C build -czvf lite-xl-${{ needs.version.outputs.ref }}-x86_64-linux-portable.tar.gz lite-xl
 
@@ -173,7 +173,7 @@ jobs:
         with:
           entrypoint: /entrypoint.sh
           run: bash scripts/package-appimage.sh --debug --version ${{ needs.version.outputs.ref }} -b build
-        
+
       - name: Upload (Release)
         uses: actions/upload-artifact@v4
         with:
@@ -181,12 +181,12 @@ jobs:
           path: |
             *.tar.gz
             *.AppImage
-               
+
 
   build_windows:
     name: Windows (x86_64) (MSYS)
     runs-on: windows-2019
-    defaults: 
+    defaults:
       run:
         shell: msys2 {0}
     needs: [version]
@@ -206,16 +206,16 @@ jobs:
             pkg-config:p
 
       - uses: actions/checkout@v4
-        
+
       - name: Build
         run: bash scripts/build.sh --addons --debug --forcefallback --portable -b build
 
       - name: Package Windows (Portable)
         run: cd build && zip -r ../lite-xl-${{ needs.version.outputs.ref }}-x86_64-windows-portable.zip lite-xl && cd ..
-        
+
       - name: Package Windows (InnoSetup)
         run: bash scripts/package-innosetup.sh --debug --version ${{ needs.version.outputs.ref }} -b build
-        
+
       - name: Upload (Release)
         uses: actions/upload-artifact@v4
         with:
@@ -271,17 +271,20 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: lite-xl-*-release
           merge-multiple: true
           path: releases
+
       - name: Generate Release Notes
         if: needs.version.outputs.release
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash scripts/generate-release-notes.sh --version ${{ needs.version.outputs.release }}
+
       - name: Versioned Release
         uses: ncipollo/release-action@v1
         if: ${{ needs.version.outputs.release }}
@@ -292,13 +295,26 @@ jobs:
           allowUpdates: true
           bodyFile: release-notes.md
           artifacts: "releases/*.*"
-      - name: Update Tag
+
+      - name: Releease on Winget
+        uses: vedantmgoyal9/winget-releaser@main
+        if: ${{ needs.version.outputs.release }}
+        with:
+          identifier: 'LiteXLTeam.LiteXL'
+          version: ${{ needs.version.outputs.release }}
+          release-tag: ${{ needs.version.outputs.ref }}
+          fork-user: 'lite-xl'
+          token: ${{ secrets.WINGET_TOKEN }}
+          installers-regex: '^releases/.+\-windows\-setup\.exe$'
+
+      - name: Update Continuous Tag
         uses: richardsimko/update-tag@v1
         if: github.ref == 'refs/heads/master'
         with:
           tag_name: continuous
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Continuous Release
         uses: ncipollo/release-action@v1
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
 
       - name: Release on Winget
         uses: vedantmgoyal9/winget-releaser@main
-        if: ${{ needs.version.outputs.release }}
+        if: ${{ needs.version.outputs.release && github.repository == 'lite-xl/lite-xl' }}
         with:
           identifier: 'LiteXLTeam.LiteXL'
           version: ${{ needs.version.outputs.release }}


### PR DESCRIPTION
# DO NOT RUN THIS PR (it should not run if I set it up completely)

This PR allows us to publish Lite XL versions directly on winget. It requires a service account to function (which I have created and stored the token in the secrets for the org).

We also need to cherry-pick this accordingly for the bugfix releases with some changes to the regex.