### PR TITLE
fix: only allow backslash as path separator in Windows in `common.path_suggest`

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -226,7 +226,12 @@ function common.path_suggest(text, root)
   if root and root:sub(-1) ~= PATHSEP then
     root = root .. PATHSEP
   end
-  local path, name = text:match("^(.-)([^"..PATHSEP.."/]*)$")
+
+  local pathsep = PATHSEP
+  if PLATFORM == "Windows" then
+    pathsep = "\\/"
+  end
+  local path = text:match("^(.-)[^"..pathsep.."]*$")
   local clean_dotslash = false
   -- ignore root if path is absolute
   local is_absolute = common.is_absolute_path(text)


### PR DESCRIPTION
Follow up from #1875.

Avoid considering backslash as pathsep on non-windows, as backslashes are allowed in names.