### PR TITLE
renderer: add offset to renderer when window is borderless and maximized on Windows

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -769,12 +769,14 @@ void ren_set_clip_rect(RenWindow *window_renderer, RenRect rect) {
 
 void ren_get_size(RenWindow *window_renderer, int *x, int *y) {
   RenSurface rs = renwin_get_surface(window_renderer);
-  *x = rs.surface->w;
+  *x = rs.surface->w; 
   *y = rs.surface->h;
 #ifdef LITE_USE_SDL_RENDERER
   *x /= rs.scale;
   *y /= rs.scale;
 #endif
+  *x -= 2 * window_renderer->offset_x;
+  *y -= 2 * window_renderer->offset_y;
 }
 
 size_t ren_get_window_list(RenWindow ***window_list_dest) {

--- a/src/renwindow.c
+++ b/src/renwindow.c
@@ -97,6 +97,17 @@ void renwin_resize_surface(RenWindow *ren) {
     setup_renderer(ren, new_w, new_h);
   }
 #endif
+#ifdef _WIN32
+  if ((SDL_GetWindowFlags(ren->window) & (SDL_WINDOW_BORDERLESS | SDL_WINDOW_MAXIMIZED)) == (SDL_WINDOW_BORDERLESS | SDL_WINDOW_MAXIMIZED)) {
+    // when this happens, the window is larger than the screen with negative positions
+    int x = 0, y = 0;
+    SDL_GetWindowPosition(ren->window, &x, &y);
+    ren->offset_x = x >= 0 ? 0 : -x;
+    ren->offset_y = x >= 0 ? 0 : -y;
+  } else {
+    ren->offset_x = ren->offset_y = 0;
+  }
+#endif
 }
 
 void renwin_update_scale(RenWindow *ren) {

--- a/src/renwindow.h
+++ b/src/renwindow.h
@@ -8,6 +8,8 @@ struct RenWindow {
   size_t command_buf_size;
   float scale_x;
   float scale_y;
+  int offset_x;
+  int offset_y;
 #ifdef LITE_USE_SDL_RENDERER
   SDL_Renderer *renderer;
   SDL_Texture *texture;


### PR DESCRIPTION
Imagine a place...

![image](https://github.com/user-attachments/assets/0cf54976-ba84-47ff-812c-9505c39c8c09)

Yes, this PR just makes window appear correctly on Windows when we draw our own decoration. Compared to current code:

![image](https://github.com/user-attachments/assets/55b50d29-2740-4d20-8cd0-903594fe192c)

In theory this does not affect non RENDERER code, because we aren't using RenSurface scale. I haven't tested it on 2x scale with the RENDERER backend, because the highest I can do is 1.75x.

Closes #1966.

