### PR TITLE
process: call poll_process when getting returncode

### DIFF
--- a/src/api/process.c
+++ b/src/api/process.c
@@ -697,7 +697,7 @@ static int f_pid(lua_State* L) {
 
 static int f_returncode(lua_State *L) {
   process_t* self = (process_t*) luaL_checkudata(L, 1, API_TYPE_PROCESS);
-  if (self->running)
+  if (poll_process(self, WAIT_NONE))
     return 0;
   lua_pushinteger(L, self->returncode);
   return 1;


### PR DESCRIPTION
I cannot get plugin_manager to work reliably despite the fix in #1973. This PR makes process:returncode() poll for process completion, which is meh, but fixes the issue.