### PR TITLE
balance computed directory list, remove recursive function invocation

### DIFF
--- a/data/core/project.lua
+++ b/data/core/project.lua
@@ -104,19 +104,27 @@ function Project:get_file_info(path)
   return info
 end
 
-
-local function find_files_rec(project, path)
+local function get_dir_content(project, path, entries)
   local all = system.list_dir(path) or {}
   for _, file in ipairs(all) do
     local file = path .. PATHSEP .. file
     local info = project:get_file_info(file)
     if info then
       info.filename = file
-      if info.type == "file" then
-        coroutine.yield(project, info)
-      elseif not common.match_pattern(common.basename(info.filename), config.ignore_files) and info.type then
-        find_files_rec(project, file)
-      end
+      table.insert(entries, info)
+    end
+  end
+end
+
+local function find_files_rec(project, path)
+  local entries = {}
+  get_dir_content(project, path, entries)
+
+  for _, info in ipairs(entries) do
+    if info.type == "file" then
+      coroutine.yield(project, info)
+    elseif not common.match_pattern(common.basename(info.filename), config.ignore_files) and info.type then
+      get_dir_content(project, info.filename, entries)
     end
   end
 end


### PR DESCRIPTION
does what it says on the tin

the previous behavior iterated through recursive function calls where as this new implementation avoids recursion

here is the difference of the output when ran on the lite-xl src directory:

before:
```
src/api
src/api/dirmonitor
src/api/dirmonitor/dummy.c
src/api/dirmonitor/fsevents.c
src/api/dirmonitor/inodewatcher.cpp
src/api/dirmonitor/inotify.c
src/api/dirmonitor/kqueue.c
src/api/dirmonitor/win32.c
src/api/api.c
src/api/api.h
src/api/dirmonitor.c
src/api/process.c
src/api/regex.c
src/api/renderer.c
src/api/renwindow.c
src/api/system.c
src/api/utf8.c
src/arena_allocator.c
src/arena_allocator.h
src/bundle_open.m
src/main.c
src/meson.build
src/rencache.c
src/rencache.h
src/renderer.c
src/renderer.h
src/renwindow.c
src/renwindow.h
src/unidata.h
src/utfconv.h
```

after:
```
src/rencache.h
src/unidata.h
src/meson.build
src/api
src/rencache.c
src/arena_allocator.h
src/arena_allocator.c
src/renderer.c
src/utfconv.h
src/renwindow.c
src/main.c
src/bundle_open.m
src/renwindow.h
src/renderer.h
src/api/api.h
src/api/utf8.c
src/api/dirmonitor.c
src/api/api.c
src/api/renderer.c
src/api/system.c
src/api/dirmonitor
src/api/renwindow.c
src/api/regex.c
src/api/process.c
src/api/dirmonitor/inotify.c
src/api/dirmonitor/dummy.c
src/api/dirmonitor/inodewatcher.cpp
src/api/dirmonitor/win32.c
src/api/dirmonitor/fsevents.c
src/api/dirmonitor/kqueue.c
```

the result is that it the iterations are balanced and no specific path is favored in any way and that larger directories won't exhaust the max project file count before smaller directories get their chance