### PR TITLE
Removed log for opening a project.

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -795,7 +795,7 @@ function core.init()
 
   do
     local pdir, pname = project_dir_abs:match("(.*)[/\\\\](.*)")
-    core.log("Opening project %q from directory %s", pname, pdir)
+    core.log_quiet("Opening project %q from directory %s", pname, pdir)
   end
 
   -- We add the project directory now because the project's module is loaded.


### PR DESCRIPTION
I feel like this is a pretty unnecessary loud log; it's always the result of a user action that will always be basically exactly what the user specified. Thoughts?