### PR TITLE
Add in missing #include.

### DIFF
--- a/src/api/renwindow.c
+++ b/src/api/renwindow.c
@@ -2,6 +2,7 @@
 #include "../renwindow.h"
 #include "lua.h"
 #include <SDL.h>
+#include <stdlib.h>
 
 static RenWindow *persistant_window = NULL;
 

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1,6 +1,7 @@
 #include <SDL.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
 #include <sys/types.h>

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef _MSC_VER

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <math.h>
 #include <ft2build.h>


### PR DESCRIPTION
As per #2014, we don't actually include the appropriate header for things like `system` and `free`; it's only transitively included implementation-dependently.

This fixes that.