### PR TITLE
Add cursors above/below: don't add cursors on lines that already contain them

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -105,10 +105,14 @@ local function split_cursor(dv, direction)
   local dv_translate = direction < 0
     and DocView.translate.previous_line
     or DocView.translate.next_line
-  for _, line1, col1 in dv.doc:get_selections() do
-    if line1 + direction >= 1 and line1 + direction <= #dv.doc.lines then
-      table.insert(new_cursors, { dv_translate(dv.doc, line1, col1, dv) })
+  local last_line = nil
+  for _, l1, c1 in dv.doc:get_selections(false, direction == 1 and true or false) do
+    if last_line == nil or last_line == l1 or last_line - direction ~= l1 then
+      if l1 + direction >= 1 and l1 + direction <= #dv.doc.lines then
+        table.insert(new_cursors, { dv_translate(dv.doc, l1, c1, dv) })
+      end
     end
+    last_line = l1
   end
   -- add selections in the order that will leave the "last" added one as doc.last_selection
   local start, stop = 1, #new_cursors


### PR DESCRIPTION
Before:

![BEFORE](https://github.com/user-attachments/assets/8ab64413-851a-409d-a2fb-363052d92fb7) &nbsp; &nbsp; ![BEFORE2](https://github.com/user-attachments/assets/db72eb63-c678-46e4-93b5-f59ec8fefcb1)

After:

![AFTER](https://github.com/user-attachments/assets/3a8e5ac4-6083-44f4-894c-5b8723389897) &nbsp; &nbsp; ![AFTER2](https://github.com/user-attachments/assets/9f059537-a91d-44c4-84dc-8817dc3989f9)
