### PR TITLE
language_cpp: add back digit separators

### DIFF
--- a/data/plugins/language_c.lua
+++ b/data/plugins/language_c.lua
@@ -5,6 +5,8 @@ local syntax = require "core.syntax"
 local isuf = [[(?:[lL][uU]|ll[uU]|LL[uU]|[uU][lL]\b|[uU]ll|[uU]LL|[uU]|[lL]\b|ll|LL)?]]
 -- float suffix combinations as a Lua pattern / regex
 local fsuf = "[fFlL]?"
+-- number with digit separator as a regex non-capturing group
+local digitsep = [[(?:\d[\d']*)]]
 
 syntax.add {
   name = "C",
@@ -12,21 +14,18 @@ syntax.add {
   comment = "//",
   block_comment = { "/*", "*/" },
   patterns = {
-    { pattern = "//.*",                  type = "comment" },
-    { pattern = { "/%*", "%*/" },        type = "comment" },
-    { pattern = { '"', '"', '\\' },      type = "string"  },
-    { pattern = { "'", "'", '\\' },      type = "string"  },
-    { regex   = "0x[0-9a-fA-f]+"..isuf,  type = "number"  },
-    { regex   = "0()[0-7]+"..isuf,       type = { "keyword", "number" } },
-    { pattern = "%d+%.%d*[Ee]%d+"..fsuf, type = "number"  },
-    { pattern = "%d+[Ee]%d+"..fsuf,      type = "number"  },
-    { pattern = "%d+%.%d*"..fsuf,        type = "number"  },
-    { pattern = "%.%d+"..fsuf,           type = "number"  },
-    { regex   = "\\d+"..isuf,            type = "number"  },
-    { pattern = "[%+%-=/%*%^%%<>!~|&]",  type = "operator" },
-    { pattern = "##",                    type = "operator" },
-    { pattern = "struct%s()[%a_][%w_]*", type = {"keyword", "keyword2"} },
-    { pattern = "union%s()[%a_][%w_]*",  type = {"keyword", "keyword2"} },
+    { pattern = "//.*",                                                            type = "comment" },
+    { pattern = { "/%*", "%*/" },                                                  type = "comment" },
+    { pattern = { '"', '"', '\\' },                                                type = "string"  },
+    { pattern = { "'", "'", '\\' },                                                type = "string"  },
+    { regex   = "0x[0-9a-fA-F][0-9a-fA-F']*"..isuf,                                type = "number"  },
+    { regex   = "0()[0-7][0-7']*"..isuf,                                           type = { "keyword", "number" } },
+    { regex   = digitsep.."\\.?"..digitsep.."?(?:[Ee][-+]?"..digitsep..")?"..fsuf, type = "number" },
+    { regex   = "\\."..digitsep.."(?:[Ee][-+]?"..digitsep..")?"..fsuf,             type = "number" },
+    { pattern = "[%+%-=/%*%^%%<>!~|&]",                                            type = "operator" },
+    { pattern = "##",                                                              type = "operator" },
+    { pattern = "struct%s()[%a_][%w_]*",                                           type = {"keyword", "keyword2"} },
+    { pattern = "union%s()[%a_][%w_]*",                                            type = {"keyword", "keyword2"} },
     -- static declarations
     { pattern = "static()%s+()inline",
       type = { "keyword", "normal", "keyword" }

--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -16,24 +16,27 @@ syntax.add {
   comment = "//",
   block_comment = { "/*", "*/" },
   patterns = {
-    { pattern = "//.*",                     type = "comment"  },
-    { pattern = { "/%*", "%*/" },           type = "comment"  },
-    { pattern = { '"', '"', '\\' },         type = "string"   },
-    { pattern = { "'", "'", '\\' },         type = "string"   },
-    { regex   = "0x[0-9a-fA-f]+"..isuf,     type = "number"   },
-    { regex   = "0b[01]+"..isuf,            type = "number"   },
-    { regex   = "0()[0-7]+"..isuf,          type = { "keyword", "number" } },
-    { pattern = "%d+%.%d*[Ee]%d+"..fsuf,    type = "number"   },
-    { pattern = "%d+[Ee]%d+"..fsuf,         type = "number"   },
-    { pattern = "%d+%.%d*"..fsuf,           type = "number"   },
-    { pattern = "%.%d+"..fsuf,              type = "number"   },
-    { regex   = "\\d+"..isuf,               type = "number"   },
-    { pattern = "[%+%-=/%*%^%%<>!~|:&]",    type = "operator" },
-    { pattern = "##",                       type = "operator" },
-    { pattern = "struct%s()[%a_][%w_]*",    type = {"keyword", "keyword2"} },
-    { pattern = "class%s()[%a_][%w_]*",     type = {"keyword", "keyword2"} },
-    { pattern = "union%s()[%a_][%w_]*",     type = {"keyword", "keyword2"} },
-    { pattern = "namespace%s()[%a_][%w_]*", type = {"keyword", "keyword2"} },
+    { pattern = "//.*",                                     type = "comment"  },
+    { pattern = { "/%*", "%*/" },                           type = "comment"  },
+    { pattern = { '"', '"', '\\' },                         type = "string"   },
+    { pattern = { "'", "'", '\\' },                         type = "string"   },
+    { regex   = "0x[0-9a-fA-f][0-9a-fA-F']*"..isuf,         type = "number"   },
+    { regex   = "0b[01][01']*"..isuf,                       type = "number"   },
+    { regex   = "0()[0-7][0-7']*"..isuf,                    type = { "keyword", "number" } },
+    { pattern = "[%d][%d']*%.%d[%d']*[Ee][%d][%d']*"..fsuf, type = "number"   }, -- 1'000.1'000e1'000
+    { pattern = "[%d][%d']*%.[Ee][%d][%d']*"..fsuf,         type = "number"   }, -- 1'000.e1'000
+    { pattern = "%d[%d']*[Ee][%d][%d']*"..fsuf,             type = "number"   }, -- 1'000e1'000
+    { pattern = "%d[%d']*%.%d[%d']*"..fsuf,                 type = "number"   }, -- 1'000.1'000
+    { pattern = "%d[%d']%.%d"..fsuf,                        type = "number"   }, -- 1'000.1
+    { pattern = "%.%d[%d']*"..fsuf,                         type = "number"   }, -- .1'000
+    { pattern = "%.%d"..fsuf,                               type = "number"   }, -- .1
+    { regex   = "\\d+"..isuf,                               type = "number"   },
+    { pattern = "[%+%-=/%*%^%%<>!~|:&]",                    type = "operator" },
+    { pattern = "##",                                       type = "operator" },
+    { pattern = "struct%s()[%a_][%w_]*",                    type = {"keyword", "keyword2"} },
+    { pattern = "class%s()[%a_][%w_]*",                     type = {"keyword", "keyword2"} },
+    { pattern = "union%s()[%a_][%w_]*",                     type = {"keyword", "keyword2"} },
+    { pattern = "namespace%s()[%a_][%w_]*",                 type = {"keyword", "keyword2"} },
     -- static declarations
     { pattern = "static()%s+()inline",
       type = { "keyword", "normal", "keyword" }

--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -5,6 +5,8 @@ local syntax = require "core.syntax"
 local isuf = [[(?:[lL][uU]|ll[uU]|LL[uU]|[uU][lL]\b|[uU]ll|[uU]LL|[uU]|[lL]\b|ll|LL)?]]
 -- float suffix combinations as a Lua pattern / regex
 local fsuf = "[fFlL]?"
+-- number with digit separator as a regex non-capturing group
+local digitsep = [[(?:\d[\d']*)]]
 
 syntax.add {
   name = "C++",
@@ -16,27 +18,21 @@ syntax.add {
   comment = "//",
   block_comment = { "/*", "*/" },
   patterns = {
-    { pattern = "//.*",                                     type = "comment"  },
-    { pattern = { "/%*", "%*/" },                           type = "comment"  },
-    { pattern = { '"', '"', '\\' },                         type = "string"   },
-    { pattern = { "'", "'", '\\' },                         type = "string"   },
-    { regex   = "0x[0-9a-fA-f][0-9a-fA-F']*"..isuf,         type = "number"   },
-    { regex   = "0b[01][01']*"..isuf,                       type = "number"   },
-    { regex   = "0()[0-7][0-7']*"..isuf,                    type = { "keyword", "number" } },
-    { pattern = "[%d][%d']*%.%d[%d']*[Ee][%d][%d']*"..fsuf, type = "number"   }, -- 1'000.1'000e1'000
-    { pattern = "[%d][%d']*%.[Ee][%d][%d']*"..fsuf,         type = "number"   }, -- 1'000.e1'000
-    { pattern = "%d[%d']*[Ee][%d][%d']*"..fsuf,             type = "number"   }, -- 1'000e1'000
-    { pattern = "%d[%d']*%.%d[%d']*"..fsuf,                 type = "number"   }, -- 1'000.1'000
-    { pattern = "%d[%d']%.%d"..fsuf,                        type = "number"   }, -- 1'000.1
-    { pattern = "%.%d[%d']*"..fsuf,                         type = "number"   }, -- .1'000
-    { pattern = "%.%d"..fsuf,                               type = "number"   }, -- .1
-    { regex   = "\\d+"..isuf,                               type = "number"   },
-    { pattern = "[%+%-=/%*%^%%<>!~|:&]",                    type = "operator" },
-    { pattern = "##",                                       type = "operator" },
-    { pattern = "struct%s()[%a_][%w_]*",                    type = {"keyword", "keyword2"} },
-    { pattern = "class%s()[%a_][%w_]*",                     type = {"keyword", "keyword2"} },
-    { pattern = "union%s()[%a_][%w_]*",                     type = {"keyword", "keyword2"} },
-    { pattern = "namespace%s()[%a_][%w_]*",                 type = {"keyword", "keyword2"} },
+    { pattern = "//.*",                                                            type = "comment"  },
+    { pattern = { "/%*", "%*/" },                                                  type = "comment"  },
+    { pattern = { '"', '"', '\\' },                                                type = "string"   },
+    { pattern = { "'", "'", '\\' },                                                type = "string"   },
+    { regex   = "0x[0-9a-fA-F][0-9a-fA-F']*"..isuf,                                type = "number"   },
+    { regex   = "0b[01][01']*"..isuf,                                              type = "number"   },
+    { regex   = "0()[0-7][0-7']*"..isuf,                                           type = { "keyword", "number" } },
+    { regex   = digitsep.."\\.?"..digitsep.."?(?:[Ee][-+]?"..digitsep..")?"..fsuf, type = "number" },
+    { regex   = "\\."..digitsep.."(?:[Ee][-+]?"..digitsep..")?"..fsuf,             type = "number" },
+    { pattern = "[%+%-=/%*%^%%<>!~|:&]",                                           type = "operator" },
+    { pattern = "##",                                                              type = "operator" },
+    { pattern = "struct%s()[%a_][%w_]*",                                           type = {"keyword", "keyword2"} },
+    { pattern = "class%s()[%a_][%w_]*",                                            type = {"keyword", "keyword2"} },
+    { pattern = "union%s()[%a_][%w_]*",                                            type = {"keyword", "keyword2"} },
+    { pattern = "namespace%s()[%a_][%w_]*",                                        type = {"keyword", "keyword2"} },
     -- static declarations
     { pattern = "static()%s+()inline",
       type = { "keyword", "normal", "keyword" }


### PR DESCRIPTION
Fixes #2022.

There is an issue tho: things like `0x22'` would be valid, but they aren't supposed to be, as specified in [this thing](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3781.pdf).
To do that, we'll probably need some lookahead / behind magic which I am not familiar with, and it will increase the complexity of the (imo already complex) regex.

Before:

![image](https://github.com/user-attachments/assets/01b57466-73d5-4bb8-a88b-64954dd476a9)

After:

![image](https://github.com/user-attachments/assets/ed090209-6b87-4dd9-a1d2-61b505443317)
