### PR TITLE
LTO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,28 +90,28 @@ jobs:
           bash --version
           gcc -v
           xcodebuild -version
-          
+
       - uses: actions/checkout@v4
-        
+
       - name: Python Setup
         uses: actions/setup-python@v5
         with: { python-version: "3.11" }
-        
+
       - name: Install Dependencies
         run: |
           brew install bash
           pip3 install meson ninja
-        
+
       - name: Build & Package Mac (Bundle)
         run: |
-          scripts/build.sh --addons --debug --forcefallback --reconfigure --bundle --mode ${{ needs.version.outputs.buildtype }} -b build
+          scripts/build.sh --addons --debug --forcefallback --reconfigure --lto --bundle --mode ${{ needs.version.outputs.buildtype }} -b build
           tar -C build -czvf lite-xl-${{ needs.version.outputs.ref }}-${{ matrix.config.arch }}-bundle.tar.gz "Lite XL.app"
 
       - name: Build & Package Mac (Portable)
         run: |
-          scripts/build.sh --addons --debug --forcefallback --reconfigure --portable --mode ${{ needs.version.outputs.buildtype }} -b build
+          scripts/build.sh --addons --debug --forcefallback --reconfigure --lto --portable --mode ${{ needs.version.outputs.buildtype }} -b build
           tar -C build -czvf lite-xl-${{ needs.version.outputs.ref }}-${{ matrix.config.arch }}-portable.tar.gz lite-xl
-        
+
       - name: Upload (Intermediate)
         uses: actions/upload-artifact@v4
         with:
@@ -124,7 +124,7 @@ jobs:
     name: Darwin (Universal)
     needs: [version, build_darwin]
     runs-on: macos-14
-    steps:          
+    steps:
       - uses: actions/checkout@v4
 
       - name: Python Setup
@@ -135,7 +135,7 @@ jobs:
         run: |
           brew install bash
           pip3 install dmgbuild
-      
+
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -159,7 +159,7 @@ jobs:
           dmgbuild -s resources/macos/lite-xl-dmg.py \
             -D "app_path=lite-xl-${{ needs.version.outputs.ref }}-universal-darwin-bundle/Lite XL.app" \
             "Lite XL" "lite-xl-${{ needs.version.outputs.ref }}-universal-darwin.dmg"
-        
+
       - name: Package Darwin (Universal Portable)
         run: tar -C lite-xl-${{ needs.version.outputs.ref }}-universal-darwin-portable -zcvf lite-xl-${{ needs.version.outputs.ref }}-universal-darwin-portable.tar.gz .
 
@@ -178,13 +178,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        
+
       - name: Build
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box-manylinux:v4
         with:
           entrypoint: /entrypoint.sh
-          args: bash scripts/build.sh --addons --debug --forcefallback --portable --mode ${{ needs.version.outputs.buildtype }} -b build
-        
+          args: bash scripts/build.sh --addons --debug --forcefallback --lto --portable --mode ${{ needs.version.outputs.buildtype }} -b build
+
       - name: Package Linux (Portable)
         run: tar -C build -czvf lite-xl-${{ needs.version.outputs.ref }}-x86_64-linux-portable.tar.gz lite-xl
 
@@ -192,8 +192,8 @@ jobs:
         uses: docker://ghcr.io/lite-xl/lite-xl-build-box-manylinux:v4
         with:
           entrypoint: /entrypoint.sh
-          run: bash scripts/package-appimage.sh --debug --reconfigure --version ${{ needs.version.outputs.ref }} --mode ${{ needs.version.outputs.buildtype }} -b build
-        
+          run: bash scripts/package-appimage.sh --debug --version ${{ needs.version.outputs.ref }} -b build
+
       - name: Upload (Release)
         uses: actions/upload-artifact@v4
         with:
@@ -201,12 +201,12 @@ jobs:
           path: |
             *.tar.gz
             *.AppImage
-               
+
 
   build_windows:
     name: Windows (x86_64) (MSYS)
     runs-on: windows-2019
-    defaults: 
+    defaults:
       run:
         shell: msys2 {0}
     needs: [version]
@@ -226,16 +226,16 @@ jobs:
             pkg-config:p
 
       - uses: actions/checkout@v4
-        
+
       - name: Build
-        run: bash scripts/build.sh --addons --debug --forcefallback --portable --mode ${{ needs.version.outputs.buildtype }} -b build
+        run: bash scripts/build.sh --addons --debug --forcefallback --lto --portable --mode ${{ needs.version.outputs.buildtype }} -b build
 
       - name: Package Windows (Portable)
         run: cd build && zip -r ../lite-xl-${{ needs.version.outputs.ref }}-x86_64-windows-portable.zip lite-xl && cd ..
-        
+
       - name: Package Windows (InnoSetup)
         run: bash scripts/package-innosetup.sh --debug --version ${{ needs.version.outputs.ref }} -b build
-        
+
       - name: Upload (Release)
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,6 +33,8 @@ show_help() {
   echo "-O --pgo                      Use profile guided optimizations (pgo)."
   echo "                              macOS: disabled when used with --bundle,"
   echo "                              Windows: Implicit being the only option."
+  echo "-L --lto [MODE]               Enables Link-Time Optimization (LTO)."
+  echo "                              MODE: [default],thin"
   echo "   --cross-platform PLATFORM  Cross compile for this platform."
   echo "                              The script will find the appropriate"
   echo "                              cross file in 'resources/cross'."
@@ -54,6 +56,8 @@ main() {
   local bundle="-Dbundle=false"
   local portable="-Dportable=false"
   local pgo
+  local lto
+  local lto_mode
   local cross
   local cross_platform
   local cross_arch
@@ -120,6 +124,14 @@ main() {
         ;;
       -O|--pgo)
         pgo="-Db_pgo=generate"
+        shift
+        ;;
+      -L|--lto)
+        lto="-Db_lto=true"
+        if [[ -n $2 ]] && [[ $2 != -* ]]; then
+          lto_mode="-Db_lto_mode=$2"
+          shift
+        fi
         shift
         ;;
       --cross-arch)
@@ -225,6 +237,8 @@ main() {
     $bundle \
     $portable \
     $pgo \
+    $lto \
+    $lto_mode \
     $plugins \
     $reconfigure
 


### PR DESCRIPTION
We should use LTO for all (at least Linux) builds.
LTO generally comes in two flavors - thin and full LTO, where thinLTO is currently available on LLVM (clang) only.

All examples here are compiled with clang and lld (v19.1.7) on 6.13.7-3-cachyos.

### Highlights

| Criteria  | Non-LTO (Base)      | Full LTO                      | thinLTO
| --------  | --------------      | --------                      | -------
| Tokenizer | 22743.91964 tok/sec | 25716.07018 tok/sec (+13.07%) | 25572.93249 tok/sec (+12.44%)
| Draw      | 0.00675 ms/frame    | 0.00470 ms/frame (-30.37%)    | 0.00358 ms/frame (-46.96%)
| Binary Size | 3875520 Bytes     | 3772728 Bytes (-2.65%)        | 4012640 Bytes (+3.54%)

<details>
<summary>Benchmarks of non-LTO, LTO and thinLTO builds</summary>

Benchmark tests tokenizing [sqlite.c](https://www.sqlite.org/2025/sqlite-amalgamation-3490100.zip), as well as rendering text for 1000 frames.

Benchmark code here:
[bootstrap.zip](https://github.com/user-attachments/files/19402579/bootstrap.zip)

Run with:

```sh
$ LDFLAGS='-fuse-ld=lld' CC=clang CXX=clang++ bash scripts/build.sh -P --forcefallback --lto && ln -s ../../../data/bootstrap.lua build-x86_64-linux/lite-xl/data/bootstrap.lua && LITE_XL_RUNTIME=bootstrap build-x86_64-linux/lite-xl/lite-xl tokenizer
$ LDFLAGS='-fuse-ld=lld' CC=clang CXX=clang++ bash scripts/build.sh -P --forcefallback --lto && ln -s ../../../data/bootstrap.lua build-x86_64-linux/lite-xl/data/bootstrap.lua && LITE_XL_RUNTIME=bootstrap build-x86_64-linux/lite-xl/lite-xl draw
```

## Tokenizer

### Non-LTO

```
Sleeping 10 seconds for CPU to calm down...
Tokenizing sqlite3.c: .......................Interrupted (more than 10s)
Tokenized sqlite.c with 230000 tokens in 10112.59289 ms, 22743.91964 tok/sec
```

### Full LTO

```
Sleeping 10 seconds for CPU to calm down...
Tokenizing sqlite3.c: ...........................Interrupted (more than 10s)
Tokenized sqlite.c with 270000 tokens in 10499.27139 ms, 25716.07018 tok/sec
```

### ThinLTO

```
Sleeping 10 seconds for CPU to calm down...
Tokenizing sqlite3.c: ..........................Interrupted (more than 10s)
Tokenized sqlite.c with 260000 tokens in 10166.99982 ms, 25572.93249 tok/sec
```

## Draw

### Non-LTO
```
Sleeping 10 seconds for CPU to calm down...
average frames over 10000 frames: 0.00675 ms
```

### Full LTO

```
Sleeping 10 seconds for CPU to calm down...
average frames over 10000 frames: 0.00470 ms
```

### ThinLTO

```
Sleeping 10 seconds for CPU to calm down...
average frames over 10000 frames: 0.00358 ms
```

</details>

<details>
<summary>Binary sizes of non-LTO, LTO and thinLTO binaries on Linux</summary>

### Non-LTO

```
  File: build-x86_64-linux/lite-xl/lite-xl
  Size: 3875520         Blocks: 7576       IO Block: 4096   regular file
```

### Full LTO

```
  File: build-x86_64-linux/lite-xl/lite-xl
  Size: 3772728         Blocks: 7376       IO Block: 4096   regular file
```

### ThinLTO

```
  File: build-x86_64-linux/lite-xl/lite-xl
  Size: 4012640         Blocks: 7840       IO Block: 4096   regular file
```

</details>