### PR TITLE
add better delete movements

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -729,6 +729,9 @@ for name, obj in pairs(translations) do
   end
 end
 
+commands["doc:delete-word-left"] = function(dv) dv.doc:delete_to(translate.word_left, dv) end
+commands["doc:delete-word-right"] = function(dv) dv.doc:delete_to(translate.word_right, dv) end
+
 commands["doc:move-to-previous-char"] = function(dv)
   for idx, line1, col1, line2, col2 in dv.doc:get_selections(true) do
     if line1 ~= line2 or col1 ~= col2 then

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -92,6 +92,8 @@ config.symbol_pattern = "[%a_][%w_]*"
 ---The default is ``" \t\n/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"``
 ---@type string
 config.non_word_chars = " \t\n/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
+config.symbol_chars = "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
+config.space_chars = " \t\n"
 
 ---The timeout, in seconds, before several consecutive actions
 ---are merged as a single undo step.


### PR DESCRIPTION
The default behavior of `"doc:delete-to-next-word-end"` and `"doc:delete-to-previous-word-start"` is too aggressive. When the cursor is on the next line following a word, executing these commands delete the whitespace up that word as well as the word itself.

The issue lies in `translate.previous_word_start` and `translate.next_word_end` because they make use of the `is_non_word` predicate function to decide whether to keep moving or stop. The default behavior is not in line with other text editors like VSCode/Sublime/Focus etc..

I added a `config.symbol_chars` and `config.space_chars` to `core\config.lua` to better differentiate between symbols without spaces and space-only chars. The `symbol_chars` group helps bring LXL in line with other editors when it comes to deleting multiple symbols in one movement (e.g. `()` or `{}`).

In addition, we always skip one space. For example, if the cursor is at the end of `word` (position 5) or no more than one space away (position 6), executing the command deletes the whole word. Anything more than one space and we fall back to normal deletion of space characters only.

Here is a little snippet showing the old and new behavior.

https://github.com/user-attachments/assets/1a2e0fd9-ece6-43af-a484-e5d34fff3f3a

I kept the previous commands intact in case someone depends on them. The core idea is deleting words should be different than moving/selecting words. The new character groups and the "scanner" or "skipper" functions along with the new translate functions should help with that.

Let me know what needs to be cleaned up in case this is approved.