### PR TITLE
Run "escape" before executing any "core" command.

### DIFF
--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -223,6 +223,9 @@ function keymap.on_key_pressed(k, ...)
             performed = true
           end
         else
+          if cmd:find("^core:") then
+            command.perform("command:escape")
+          end
           performed = command.perform(cmd, ...)
         end
         if performed then break end


### PR DESCRIPTION
Addresses https://github.com/lite-xl/lite-xl/issues/2052

Runs "command:escape" before performing any "core:" command.