### PR TITLE
Unlimited SDL3 Works

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -759,27 +759,11 @@ static int f_ftruncate(lua_State *L) {
 
 static int f_mkdir(lua_State *L) {
   const char *path = luaL_checkstring(L, 1);
-
-#ifdef _WIN32
-  LPWSTR wpath = utfconv_utf8towc(path);
-  if (wpath == NULL) {
-    lua_pushboolean(L, 0);
-    lua_pushstring(L, UTFCONV_ERROR_INVALID_CONVERSION);
+  lua_pushboolean(L, SDL_CreateDirectory(path));
+  if (!lua_toboolean(L, -1)) {
+    lua_pushstring(L, SDL_GetError());
     return 2;
   }
-
-  int err = _wmkdir(wpath);
-  free(wpath);
-#else
-  int err = mkdir(path, S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
-#endif
-  if (err < 0) {
-    lua_pushboolean(L, 0);
-    lua_pushstring(L, strerror(errno));
-    return 2;
-  }
-
-  lua_pushboolean(L, 1);
   return 1;
 }
 

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -362,6 +362,7 @@ top:
         lua_pushinteger(L, e.tfinger.fingerID);
         return 6;
       }
+
     case SDL_EVENT_WILL_ENTER_FOREGROUND:
     case SDL_EVENT_DID_ENTER_FOREGROUND:
       {
@@ -377,12 +378,21 @@ top:
         lua_pushstring(L, e.type == SDL_EVENT_WILL_ENTER_FOREGROUND ? "enteringforeground" : "enteredforeground");
         return 1;
       }
+
     case SDL_EVENT_WILL_ENTER_BACKGROUND:
       lua_pushstring(L, "enteringbackground");
       return 1;
+
     case SDL_EVENT_DID_ENTER_BACKGROUND:
       lua_pushstring(L, "enteredbackground");
       return 1;
+
+    case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
+    case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+      {
+        RenWindow* window_renderer = ren_find_window_from_id(e.window.windowID);
+        ren_resize_window(window_renderer);
+      }
 
     default:
       goto top;


### PR DESCRIPTION
I am the bone of my sword- yeah I'm going to spare everyone from the rest of this meme; but anyways here are some bugfixes for when SDL3 land(ed).

In system.c:
1. We need to react to `SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED` and `SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED`, which will give us pretty good HiDPI support already (on Plasma Wayland).
2. Rewrote `get_file_info` to use `SDL_GetPathInfo`. This reduced the complexity quite a bit. Fortunately, we can still preserve the symlink check, since it is only triggered when the path is a directory. This also led to somewhat simplified win32 code.
3. Rewrote `mkdir` to use `SDL_CreateDirectory`. **Note that this is technically a breaking change since SDL_CreateDirectory behaves like `mkdir -p` rather than `mkdir`**. Let me know if this is acceptable.
4. Make `api_require` use `SDL_bsearch`. In theory this would improve native plugin startup speed, but honestly I've observed no difference.

In main.c:
1. Rearranged SDL hints to appear before `SDL_Init` as they should be.
2. Avoid calling `enable_momentum_scroll` when only the Lua part of the editor restarts.
3. Remove `SDL_HINT_RENDER_DRIVER` since this basically only applies to `-Drenderer` mode, and most platforms with this enabled require Metal / OpenGL to render anyway (only X11 and Windows AFAIK supports non-accelerated rendering).
4. Set `SDL_HINT_IME_IMPLEMENTED_UI` to `compositing` following [this](https://wiki.libsdl.org/SDL3/SDL_HINT_IME_IMPLEMENTED_UI).

Do let me know if any of these changes should be excluded / changed.