### PR TITLE
feat: add SDL file picker

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -1,6 +1,7 @@
 local core = require "core"
 local common = require "core.common"
 local command = require "core.command"
+local config = require "core.config"
 local keymap = require "core.keymap"
 local LogView = require "core.logview"
 
@@ -22,6 +23,63 @@ local function check_directory_path(path)
       return nil
     end
     return abs_path
+end
+
+local function open_file(use_dialog)
+  local view = core.active_view
+  local text
+  if view.doc and view.doc.abs_filename then
+    local dirname, _ = view.doc.abs_filename:match("(.*)[/\\](.+)$")
+    if dirname then
+      if use_dialog then
+        text = dirname
+      else
+        dirname = core.normalize_to_project_dir(dirname)
+        text = dirname == core.root_project().path and "" or common.home_encode(dirname) .. PATHSEP
+      end
+    end
+  end
+
+  if use_dialog then
+    core.open_file_dialog(core.window, function(status, result)
+      if status == "accept" then
+      	for _, filename in ipairs(result --[[ @as string[] ]]) do
+          core.root_view:open_doc(core.open_doc(filename))
+      	end
+      end
+    end, text, true)
+  	return
+  end
+
+  core.command_view:enter("Open File", {
+    text = text,
+    submit = function(text)
+      local filename = core.project_absolute_path(common.home_expand(text))
+      core.root_view:open_doc(core.open_doc(filename))
+    end,
+    suggest = function (text)
+      return common.home_encode_list(common.path_suggest(common.home_expand(text), core.root_project() and core.root_project().path))
+    end,
+    validate = function(text)
+        local filename = core.project_absolute_path(common.home_expand(text))
+        local path_stat, err = system.get_file_info(filename)
+        if err then
+          if err:find("No such file", 1, true) then
+            -- check if the containing directory exists
+            local dirname = common.dirname(filename)
+            local dir_stat = dirname and system.get_file_info(dirname)
+            if not dirname or (dir_stat and dir_stat.type == 'dir') then
+              return true
+            end
+          end
+          core.error("Cannot open file %s: %s", text, err)
+        elseif path_stat.type == 'dir' then
+          core.error("Cannot open %s, is a folder", text)
+        else
+          return true
+        end
+      end,
+  })
 end
 
 command.add(nil, {
@@ -99,44 +157,15 @@ command.add(nil, {
   end,
 
   ["core:open-file"] = function()
-    local view = core.active_view
-    local text
-    if view.doc and view.doc.abs_filename then
-      local dirname, filename = view.doc.abs_filename:match("(.*)[/\\](.+)$")
-      if dirname then
-        dirname = core.normalize_to_project_dir(dirname)
-        text = dirname == core.root_project().path and "" or common.home_encode(dirname) .. PATHSEP
-      end
-    end
-    core.command_view:enter("Open File", {
-      text = text,
-      submit = function(text)
-        local filename = core.project_absolute_path(common.home_expand(text))
-        core.root_view:open_doc(core.open_doc(filename))
-      end,
-      suggest = function (text)
-        return common.home_encode_list(common.path_suggest(common.home_expand(text), core.root_project() and core.root_project().path))
-      end,
-      validate = function(text)
-          local filename = core.project_absolute_path(common.home_expand(text))
-          local path_stat, err = system.get_file_info(filename)
-          if err then
-            if err:find("No such file", 1, true) then
-              -- check if the containing directory exists
-              local dirname = common.dirname(filename)
-              local dir_stat = dirname and system.get_file_info(dirname)
-              if not dirname or (dir_stat and dir_stat.type == 'dir') then
-                return true
-              end
-            end
-            core.error("Cannot open file %s: %s", text, err)
-          elseif path_stat.type == 'dir' then
-            core.error("Cannot open %s, is a folder", text)
-          else
-            return true
-          end
-        end,
-    })
+    open_file(config.use_system_file_picker)
+  end,
+
+  ["core:open-file-picker"] = function()
+    open_file(true)
+  end,
+
+  ["core:open-file-commandview"] = function()
+    open_file(false)
   end,
 
   ["core:open-log"] = function()

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -258,6 +258,13 @@ config.skip_plugins_version = false
 ---@type boolean | { font: renderer.font, icon: string } | nil
 config.stonks = true
 
+---Use the system file picker instead of the command palette
+---when opening files.
+---
+---Defaults to false if no sandbox is detected.
+---@type boolean
+config.use_system_file_picker = system.get_sandbox() ~= "none"
+
 -- holds the plugins real config table
 local plugins_config = {}
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -369,6 +369,7 @@ function core.init()
   core.threads = setmetatable({}, { __mode = "k" })
   core.blink_start = system.get_time()
   core.blink_timer = core.blink_start
+  core.active_file_dialogs = {}
   core.redraw = true
   core.visited_files = {}
   core.restart_request = false
@@ -937,6 +938,15 @@ function core.on_event(type, ...)
     core.window_mode = type == "restored" and "normal" or type
   elseif type == "filedropped" then
     core.root_view:on_file_dropped(...)
+  elseif type == "dialogfinished" then
+    local id, status, result = ...
+    local callback = core.active_file_dialogs[id]
+    if not callback then
+      core.error("Invalid dialog id %d", id)
+    else
+      core.active_file_dialogs[id] = nil
+      callback(status, result)
+    end
   elseif type == "focuslost" then
     core.root_view:on_focus_lost(...)
   elseif type == "quit" then
@@ -1106,6 +1116,22 @@ end
 
 function core.blink_reset()
   core.blink_start = system.get_time()
+end
+
+
+local last_file_dialog_tag = 0
+
+---Open the system file picker.
+---
+---Returns immediately.
+---
+---@param window renwindow
+---@param callback fun(status: "accept"|"cancel"|"error"|"unknown", result: string[]|string|nil)
+---@param initial_path? string
+function core.open_file_dialog(window, callback, initial_path)
+  last_file_dialog_tag = last_file_dialog_tag + 1
+  system.open_file_dialog(window, last_file_dialog_tag, initial_path)
+  core.active_file_dialogs[last_file_dialog_tag] = callback
 end
 
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1128,9 +1128,10 @@ local last_file_dialog_tag = 0
 ---@param window renwindow
 ---@param callback fun(status: "accept"|"cancel"|"error"|"unknown", result: string[]|string|nil)
 ---@param initial_path? string
-function core.open_file_dialog(window, callback, initial_path)
+---@param allow_many? boolean
+function core.open_file_dialog(window, callback, initial_path, allow_many)
   last_file_dialog_tag = last_file_dialog_tag + 1
-  system.open_file_dialog(window, last_file_dialog_tag, initial_path)
+  system.open_file_dialog(window, last_file_dialog_tag, initial_path, allow_many)
   core.active_file_dialogs[last_file_dialog_tag] = callback
 end
 

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -52,6 +52,9 @@ system = {}
 --- * "touchreleased" -> x, y, finger_id
 --- * "touchmoved" -> x, y, distance_x, distance_y, finger_id
 ---
+---Dialog events:
+--- * "dialogfinished" -> id, status, result
+---
 ---@return string type
 ---@return any? arg1
 ---@return any? arg2
@@ -373,5 +376,20 @@ function system.path_compare(path1, type1, path2, type2) end
 ---@param val string
 ---@return boolean ok True if call succeeded
 function system.setenv(key, val) end
+
+---
+---Opens a file dialog picker.
+---
+---**NOTE**: don't use this directly, use `core.open_file_dialog` instead.
+---
+---Returns immediately.
+---
+---When the operation completes, an event will be received by the event loop,
+---containing the results.
+---
+---@param window renwindow
+---@param id integer
+---@param initial_path? string
+function system.open_file_dialog(window, id, initial_path) end
 
 return system

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -393,4 +393,10 @@ function system.setenv(key, val) end
 ---@param allow_many? boolean
 function system.open_file_dialog(window, id, initial_path, allow_many) end
 
+---
+---Returns the current sandbox type.
+---
+---@return "none"|"unknown"|"flatpak"|"snap"|"macos"
+function system.get_sandbox() end
+
 return system

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -390,6 +390,7 @@ function system.setenv(key, val) end
 ---@param window renwindow
 ---@param id integer
 ---@param initial_path? string
-function system.open_file_dialog(window, id, initial_path) end
+---@param allow_many? boolean
+function system.open_file_dialog(window, id, initial_path, allow_many) end
 
 return system

--- a/src/api/dirmonitor.c
+++ b/src/api/dirmonitor.c
@@ -52,8 +52,12 @@ static int f_check_dir_callback(int watch_id, const char* path, void* L) {
   return !result;
 }
 
+
 static int dirmonitor_check_thread(void* data) {
   struct dirmonitor* monitor = data;
+  uint32_t event_type = get_custom_event(CUSTOM_EVENT_DIRMONITOR);
+  assert(event_type != 0);
+
   while (monitor->length >= 0) {
     if (monitor->length == 0) {
       int result = get_changes_dirmonitor(monitor->internal, monitor->buffer, sizeof(monitor->buffer));
@@ -63,8 +67,7 @@ static int dirmonitor_check_thread(void* data) {
       SDL_UnlockMutex(monitor->mutex);
     }
     SDL_Delay(1);
-    SDL_Event event = { .type = get_custom_event(CUSTOM_EVENT_DIRMONITOR) };
-    assert(event.type != 0);
+    SDL_Event event = { .type = event_type };
     SDL_PushEvent(&event);
   }
   return 0;

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1255,6 +1255,29 @@ static int f_open_file_dialog(lua_State* L) {
   return 0;
 }
 
+static int f_get_sandbox(lua_State* L) {
+  char *sandbox_name = "unknown";
+  switch (SDL_GetSandbox()) {
+    case SDL_SANDBOX_NONE:
+      sandbox_name = "none";
+      break;
+    case SDL_SANDBOX_UNKNOWN_CONTAINER:
+      sandbox_name = "unknown";
+      break;
+    case SDL_SANDBOX_FLATPAK:
+      sandbox_name = "flatpak";
+      break;
+    case SDL_SANDBOX_SNAP:
+      sandbox_name = "snap";
+      break;
+    case SDL_SANDBOX_MACOS:
+      sandbox_name = "macos";
+      break;
+  }
+  lua_pushstring(L, sandbox_name);
+  return 1;
+}
+
 static const luaL_Reg lib[] = {
   { "poll_event",            f_poll_event            },
   { "wait_event",            f_wait_event            },
@@ -1294,6 +1317,7 @@ static const luaL_Reg lib[] = {
   { "setenv",                f_setenv                },
   { "ftruncate",             f_ftruncate             },
   { "open_file_dialog",      f_open_file_dialog      },
+  { "get_sandbox",           f_get_sandbox           },
   { NULL, NULL }
 };
 

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1248,9 +1248,10 @@ static int f_open_file_dialog(lua_State* L) {
   RenWindow *window_renderer = *(RenWindow**)luaL_checkudata(L, 1, API_TYPE_RENWINDOW);
   uintptr_t id = luaL_checkinteger(L, 2);
   const char *default_path = luaL_optstring(L, 3, NULL);
+  bool allow_many = lua_toboolean(L, 4);
 
   SDL_ShowOpenFileDialog(open_file_dialog_callback, (void *)id,
-                         window_renderer->window, NULL, 0, default_path, true);
+                         window_renderer->window, NULL, 0, default_path, allow_many);
   return 0;
 }
 

--- a/src/custom_events.c
+++ b/src/custom_events.c
@@ -1,0 +1,25 @@
+#include "custom_events.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <SDL3/SDL_events.h>
+
+uint32_t custom_events[CUSTOM_EVENT_LAST];
+
+bool register_custom_events() {
+  uint32_t base_event = SDL_RegisterEvents(CUSTOM_EVENT_LAST);
+  if (base_event == 0) {
+    return false;
+  }
+
+  for (size_t i = 0; i < CUSTOM_EVENT_LAST; i++) {
+    custom_events[i] = base_event + i;
+  }
+  return true;
+}
+
+uint32_t get_custom_event(CustomEventTypes type) {
+  if (type >= CUSTOM_EVENT_LAST) {
+    return 0;
+  }
+  return custom_events[type];
+}

--- a/src/custom_events.h
+++ b/src/custom_events.h
@@ -1,0 +1,15 @@
+#ifndef CUSTOM_EVENTS_H
+#define CUSTOM_EVENTS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef enum {
+  CUSTOM_EVENT_DIRMONITOR = 0,
+  CUSTOM_EVENT_LAST,
+} CustomEventTypes;
+
+bool register_custom_events();
+uint32_t get_custom_event(CustomEventTypes type);
+
+#endif // CUSTOM_EVENTS_H

--- a/src/custom_events.h
+++ b/src/custom_events.h
@@ -6,6 +6,7 @@
 
 typedef enum {
   CUSTOM_EVENT_DIRMONITOR = 0,
+  CUSTOM_EVENT_DIALOG,
   CUSTOM_EVENT_LAST,
 } CustomEventTypes;
 

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include "api/api.h"
 #include "rencache.h"
 #include "renderer.h"
+#include "custom_events.h"
 
 #include <signal.h>
 
@@ -134,6 +135,11 @@ int main(int argc, char **argv) {
 
   if (ren_init() != 0) {
     fprintf(stderr, "Error initializing renderer: %s\n", SDL_GetError());
+  }
+
+  if (!register_custom_events()) {
+    fprintf(stderr, "Error initializing custom events: %s\n", SDL_GetError());
+    exit(1);
   }
 
   int has_restarted = 0;

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ lite_sources = [
     'api/process.c',
     'api/utf8.c',
     'arena_allocator.c',
+    'custom_events.c',
     'renderer.c',
     'renwindow.c',
     'rencache.c',


### PR DESCRIPTION
Supersedes #2070.

This implements:
* Proper custom events registration
* `system.open_file_dialog` to show the SDL file picker
* `system.get_sandbox` to get the current sandbox
* `core.open_file_dialog` to handle results from `system.open_file_dialog`
* Automatic use of the file picker when inside a sandbox

TODO:
* Open directory dialog
* Allow filters maybe?

Avoiding squashing on merge might be appropriate.