### PR TITLE
Clarify stack traces for require

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -888,9 +888,15 @@ end
 function core.try(fn, ...)
   local err
   local ok, res = xpcall(fn, function(msg)
-    local item = core.error("%s", msg)
-    item.info = debug.traceback("", 2):gsub("\t", "")
-    err = msg
+    if type(msg) == 'table' and msg.message then
+      local item = core.error("%s", msg.message)
+      item.info = msg.stack:gsub("\t", "")
+      err = msg.message
+    else 
+      local item = core.error("%s", msg)
+      item.info = debug.traceback("", 2):gsub("\t", "")
+      err = msg
+    end
   end, ...)
   if ok then
     return true, res

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -96,22 +96,22 @@ function require(modname, ...)
 
   table.insert(require_stack, modname)
   local ok, result, loaderdata
-  local stacktrace
-  ok, result, loaderdata = xpcall(function(...) return lua_require(modname, ...) end, function(err)
+  local stacktrace, error_result
+  ok, result, loaderdata = xpcall(lua_require, function(err)
     if type(err) == "table" and err.message then
       stacktrace = err.stack
-      return err.message
+      error_result = err.message
     else
-      stacktrace = debug.traceback()
-      return err
+      stacktrace = debug.traceback(nil, 2)
+      error_result = err
     end
-  end, ...)
+  end, modname, ...)
   table.remove(require_stack)
 
   if not ok then
-    return error({ message = result, stack = stacktrace })
+    return error({ message = error_result, stack = stacktrace }, 0)
   end
-  return result, loaderdata
+  return error_result or result, loaderdata
 end
 
 ---Returns the current `require` path.


### PR DESCRIPTION
Calling `require` from inside a plugin would result in unhelp stacktraces.

Before:

![image](https://github.com/user-attachments/assets/da76fb49-9168-4cf4-8e54-7205d613f1b6)

After:

![image](https://github.com/user-attachments/assets/f30db333-bc74-4008-b498-d864fef90baa)
