### PR TITLE
fix(ci): pin Windows runner to `windows-2022`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
 
   build_windows:
     name: Windows (x86_64) (MSYS)
-    runs-on: windows-latest
+    runs-on: windows-2022
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
Temporary fix. The new 2025 runner doesn't have InnoSetup preinstalled.

I'm pinning this step because:
* It is the only one that requires Inno.
* Having other steps use the newer runner will help us discover other issues.

To properly fix this, we should either install it manually, or via an action.