### PR TITLE
fix(regex): harden the PCRE2 bindings against crashes, hangs and leaks

### DIFF
--- a/src/api/regex.c
+++ b/src/api/regex.c
@@ -7,6 +7,26 @@
 #include <pcre2.h>
 #include <stdbool.h>
 
+/* Bound the work a single match is allowed to do. The PCRE2 defaults
+   (10M each) let a pathological pattern lock the UI for seconds or grow the
+   heap frame vector without bound; these caps turn that into a clean
+   "no match" while staying far above anything a real syntax pattern needs. */
+#define REGEX_MATCH_LIMIT 5000000u
+#define REGEX_DEPTH_LIMIT 10000u
+
+/* Process-lifetime, single-threaded: lite-xl only ever matches from the main
+   thread. Created in luaopen_regex(); a NULL context is valid (PCRE2 falls
+   back to its defaults) so callers don't need to check it. */
+static pcre2_match_context *g_match_context = NULL;
+
+/* Resource-limit failures are recoverable: treat them as "no match" instead
+   of raising, so one bad pattern can't abort a whole tokenize pass. */
+static bool regex_is_limit_error(int rc) {
+  return rc == PCRE2_ERROR_MATCHLIMIT
+      || rc == PCRE2_ERROR_DEPTHLIMIT
+      || rc == PCRE2_ERROR_HEAPLIMIT;
+}
+
 typedef struct RegexState {
   pcre2_code* re;
   pcre2_match_data* match_data;
@@ -58,75 +78,104 @@ static pcre2_code* regex_get_pattern(lua_State *L, bool* should_free) {
 static int regex_gmatch_iterator(lua_State *L) {
   RegexState *state = (RegexState*)lua_touserdata(L, lua_upvalueindex(3));
 
-  if (state->found) {
-    int rc = pcre2_match(
-      state->re,
-      (PCRE2_SPTR)state->subject, state->subject_len,
-      state->offset, 0, state->match_data, NULL
-    );
+  if (!state->found)
+    return 0;
 
-    if (rc < 0) {
-      if (rc != PCRE2_ERROR_NOMATCH) {
-        PCRE2_UCHAR buffer[120];
-        pcre2_get_error_message(rc, buffer, sizeof(buffer));
-        luaL_error(L, "regex matching error %d: %s", rc, buffer);
-      }
-      goto clean;
-    } else {
-      size_t ovector_count = pcre2_get_ovector_count(state->match_data);
-      if (ovector_count > 0) {
-        PCRE2_SIZE* ovector = pcre2_get_ovector_pointer(state->match_data);
-        if (ovector[0] > ovector[1]) {
-          /* We must guard against patterns such as /(?=.\K)/ that use \K in an
-          assertion  to set the start of a match later than its end. In the editor,
-          we just detect this case and give up. */
-          luaL_error(L, "regex matching error: \\K was used in an assertion to "
-          " set the match start after its end");
-          goto clean;
-        }
+  int rc = pcre2_match(
+    state->re,
+    (PCRE2_SPTR)state->subject, state->subject_len,
+    state->offset, 0, state->match_data, g_match_context
+  );
 
-        int index = 0;
-        if (ovector_count > 1) index = 2;
-
-        int total = 0;
-        int total_results = ovector_count * 2;
-        size_t last_offset = 0;
-        for (int i = index; i < total_results; i+=2) {
-          if (ovector[i] == ovector[i+1])
-            lua_pushinteger(L, ovector[i] + 1);
-          else
-            lua_pushlstring(L, state->subject+ovector[i], ovector[i+1] - ovector[i]);
-          last_offset = ovector[i+1];
-          total++;
-        }
-
-        if (last_offset - 1 < state->subject_len)
-          state->offset = last_offset;
-        else
-          state->found = false;
-
-        return total;
-      } else {
-        state->found = false;
-      }
+  if (rc < 0) {
+    if (rc != PCRE2_ERROR_NOMATCH && !regex_is_limit_error(rc)) {
+      PCRE2_UCHAR buffer[120];
+      pcre2_get_error_message(rc, buffer, sizeof(buffer));
+      luaL_error(L, "regex matching error %d: %s", rc, buffer);
     }
+    state->found = false;
+    return 0;
   }
 
-clean:
-  if (state->regex_compiled) pcre2_code_free(state->re);
-  pcre2_match_data_free(state->match_data);
+  size_t ovector_count = pcre2_get_ovector_count(state->match_data);
+  if (ovector_count == 0) {
+    state->found = false;
+    return 0;
+  }
 
-  return 0;  /* not found */
+  PCRE2_SIZE* ovector = pcre2_get_ovector_pointer(state->match_data);
+  if (ovector[0] > ovector[1]) {
+    /* We must guard against patterns such as /(?=.\K)/ that use \K in an
+    assertion  to set the start of a match later than its end. In the editor,
+    we just detect this case and give up. */
+    state->found = false;
+    return luaL_error(L, "regex matching error: \\K was used in an assertion to "
+    " set the match start after its end");
+  }
+
+  int index = 0;
+  if (ovector_count > 1) index = 2;
+
+  int total = 0;
+  int total_results = (int)ovector_count * 2;
+  size_t last_offset = 0;
+
+  /* One integer or string is pushed per group; a many-group pattern can blow
+     past Lua's minimum stack of LUA_MINSTACK slots without this. */
+  if (!lua_checkstack(L, (total_results - index) / 2 + 1)) {
+    state->found = false;
+    return luaL_error(L, "regex has too many captures");
+  }
+
+  for (int i = index; i < total_results; i+=2) {
+    if (ovector[i] == ovector[i+1])
+      lua_pushinteger(L, ovector[i] + 1);
+    else
+      lua_pushlstring(L, state->subject+ovector[i], ovector[i+1] - ovector[i]);
+    last_offset = ovector[i+1];
+    total++;
+  }
+
+  if (last_offset - 1 < state->subject_len)
+    state->offset = last_offset;
+  else
+    state->found = false;
+
+  return total;
+}
+
+/* __gc for the iterator state. Owns match_data unconditionally, and the
+   compiled pattern when gmatch compiled it from a string. Running here (not
+   at the end of iteration) means an abandoned `for m in regex.gmatch(...)`
+   loop no longer leaks. */
+static int f_regex_state_gc(lua_State *L) {
+  RegexState *state = (RegexState*)lua_touserdata(L, 1);
+  if (state->match_data) {
+    pcre2_match_data_free(state->match_data);
+    state->match_data = NULL;
+  }
+  if (state->regex_compiled && state->re) {
+    pcre2_code_free(state->re);
+    state->re = NULL;
+  }
+  return 0;
 }
 
 static size_t regex_offset_relative(lua_Integer pos, size_t len) {
+  size_t out;
   if (pos > 0)
-    return (size_t)pos;
+    out = (size_t)pos;
   else if (pos == 0)
-    return 1;
+    out = 1;
   else if (pos < -(lua_Integer)len)  /* inverted comparison */
-    return 1;  /* clip to 1 */
-  else return len + (size_t)pos + 1;
+    out = 1;  /* clip to 1 */
+  else
+    out = len + (size_t)pos + 1;
+  /* Clamp the upper end too: without this, `offset -= 1; len -= offset` in the
+     match functions underflows size_t and PCRE2 reads far out of bounds. */
+  if (out > len + 1)
+    out = len + 1;
+  return out;
 }
 
 static int f_pcre_gc(lua_State* L) {
@@ -191,13 +240,13 @@ static int f_pcre_match(lua_State *L) {
   len -= offset;
   if (lua_gettop(L) > 3)
     opts = luaL_checknumber(L, 4);
-  lua_rawgeti(L, 1, 1);
   pcre2_match_data* md = pcre2_match_data_create_from_pattern(re, NULL);
-  int rc = pcre2_match(re, (PCRE2_SPTR)&str[offset], len, 0, opts, md, NULL);
+  int rc = pcre2_match(re, (PCRE2_SPTR)&str[offset], len, 0, opts, md, g_match_context);
   if (rc < 0) {
+    bool limit = regex_is_limit_error(rc);
     if (regex_compiled) pcre2_code_free(re);
     pcre2_match_data_free(md);
-    if (rc != PCRE2_ERROR_NOMATCH) {
+    if (rc != PCRE2_ERROR_NOMATCH && !limit) {
       PCRE2_UCHAR buffer[120];
       pcre2_get_error_message(rc, buffer, sizeof(buffer));
       luaL_error(L, "regex matching error %d: %s", rc, buffer);
@@ -209,11 +258,17 @@ static int f_pcre_match(lua_State *L) {
     /* We must guard against patterns such as /(?=.\K)/ that use \K in an
     assertion  to set the start of a match later than its end. In the editor,
     we just detect this case and give up. */
-    luaL_error(L, "regex matching error: \\K was used in an assertion to "
-    " set the match start after its end");
     if (regex_compiled) pcre2_code_free(re);
     pcre2_match_data_free(md);
-    return 0;
+    return luaL_error(L, "regex matching error: \\K was used in an assertion to "
+    " set the match start after its end");
+  }
+  /* rc pairs of offsets get pushed; guard the Lua stack for many-group
+     patterns before touching it. */
+  if (!lua_checkstack(L, rc * 2)) {
+    if (regex_compiled) pcre2_code_free(re);
+    pcre2_match_data_free(md);
+    return luaL_error(L, "regex has too many captures");
   }
   for (int i = 0; i < rc*2; i++)
     lua_pushinteger(L, ovector[i]+offset+1);
@@ -242,14 +297,20 @@ static int f_pcre_gmatch(lua_State *L) {
 
   RegexState *state;
   state = (RegexState*)lua_newuserdata(L, sizeof(RegexState));
-
   state->re = re;
-  state->match_data = pcre2_match_data_create_from_pattern(re, NULL);
+  state->match_data = NULL;
   state->subject = subject;
   state->subject_len = subject_len;
   state->offset = offset;
   state->found = true;
   state->regex_compiled = regex_compiled;
+  /* set the metatable before the next allocation so that if it throws, the
+     already-created state (and its owned pattern) is still freed by __gc */
+  luaL_setmetatable(L, "regex_state");
+
+  state->match_data = pcre2_match_data_create_from_pattern(re, NULL);
+  if (!state->match_data)
+    return luaL_error(L, "regex gmatch: out of memory");
 
   lua_pushcclosure(L, regex_gmatch_iterator, 3);
   return 1;
@@ -271,13 +332,14 @@ static int f_pcre_gsub(lua_State *L) {
 
   size_t buffer_size = 1024;
   char *output = (char *)SDL_malloc(buffer_size);
+  bool oom = output == NULL;
 
   int options = PCRE2_SUBSTITUTE_OVERFLOW_LENGTH | PCRE2_SUBSTITUTE_EXTENDED;
   if (limit == 0) options |= PCRE2_SUBSTITUTE_GLOBAL;
 
   int results_count = 0;
   int limit_count = 0;
-  bool done = false;
+  bool done = oom;
   size_t offset = 0;
   PCRE2_SIZE outlen = buffer_size;
   while (!done) {
@@ -285,7 +347,7 @@ static int f_pcre_gsub(lua_State *L) {
       re,
       (PCRE2_SPTR)subject, subject_len,
       offset, options,
-      match_data, NULL,
+      match_data, g_match_context,
       (PCRE2_SPTR)replacement, replacement_len,
       (PCRE2_UCHAR*)output, &outlen
     );
@@ -313,6 +375,7 @@ static int f_pcre_gsub(lua_State *L) {
             subject = output;
             subject_len = outlen;
             output = (char *)SDL_malloc(buffer_size);
+            if (!output) { oom = true; done = true; }
             outlen = buffer_size;
           }
         } else {
@@ -324,18 +387,23 @@ static int f_pcre_gsub(lua_State *L) {
         }
       }
     } else {
+      /* Grow through SDL_realloc, not realloc(): `output` came from SDL_malloc
+         and is later handed to SDL_free -- mixing allocators is UB when SDL is
+         built with a custom allocator. */
       buffer_size = outlen;
-      output = (char *)realloc(output, buffer_size);
+      char *grown = (char *)SDL_realloc(output, buffer_size);
+      if (!grown) { oom = true; done = true; }
+      else output = grown;
     }
   }
 
   int return_count = 0;
 
-  if (results_count > 0) {
+  if (!oom && results_count > 0) {
     lua_pushlstring(L, (const char*) output, outlen);
     lua_pushinteger(L, results_count);
     return_count = 2;
-  } else if (results_count == 0) {
+  } else if (!oom && results_count == 0) {
     lua_pushlstring(L, subject, subject_len);
     lua_pushinteger(L, 0);
     return_count = 2;
@@ -345,6 +413,9 @@ static int f_pcre_gsub(lua_State *L) {
   pcre2_match_data_free(match_data);
   if (regex_compiled)
     pcre2_code_free(re);
+
+  if (oom)
+    return luaL_error(L, "regex substitute: out of memory");
 
   if (results_count < 0) {
     PCRE2_UCHAR errmsg[256];
@@ -365,6 +436,20 @@ static const luaL_Reg lib[] = {
 };
 
 int luaopen_regex(lua_State *L) {
+  if (!g_match_context) {
+    g_match_context = pcre2_match_context_create(NULL);
+    if (g_match_context) {
+      pcre2_set_match_limit(g_match_context, REGEX_MATCH_LIMIT);
+      pcre2_set_depth_limit(g_match_context, REGEX_DEPTH_LIMIT);
+    }
+  }
+
+  /* metatable for the gmatch iterator state */
+  luaL_newmetatable(L, "regex_state");
+  lua_pushcfunction(L, f_regex_state_gc);
+  lua_setfield(L, -2, "__gc");
+  lua_pop(L, 1);
+
   luaL_newlib(L, lib);
   lua_pushliteral(L, "regex");
   lua_setfield(L, -2, "__name");
@@ -372,7 +457,7 @@ int luaopen_regex(lua_State *L) {
   lua_setfield(L, LUA_REGISTRYINDEX, "regex");
   lua_pushinteger(L, PCRE2_ANCHORED);
   lua_setfield(L, -2, "ANCHORED");
-  lua_pushinteger(L, PCRE2_ANCHORED) ;
+  lua_pushinteger(L, PCRE2_ENDANCHORED);
   lua_setfield(L, -2, "ENDANCHORED");
   lua_pushinteger(L, PCRE2_NOTBOL);
   lua_setfield(L, -2, "NOTBOL");


### PR DESCRIPTION
## What

Hardens `src/api/regex.c` against crashes, UI hangs and leaks reachable from
untrusted input (file contents, user-supplied syntax patterns). No behaviour
change for valid input.

## Memory safety

- **Out-of-range start offset → OOB read → SIGSEGV.** `regex_offset_relative()`
  clamped only the negative end. An offset past the end of the subject made
  `offset -= 1; len -= offset` underflow `size_t`, and `pcre2_match()` then
  read from `&str[offset]` for `~2^64` bytes.
  Repro on `master`: `regex.cmatch(regex.compile("a"), "abc", 999999)` → core dump.
  Fixed by clamping to `len + 1`.

- **Captures pushed without `lua_checkstack`.** `f_pcre_match()` and the
  `gmatch` iterator push one Lua value per capture group with no stack-space
  check; past `LUA_MINSTACK` (20) this writes past the Lua stack. Release
  builds `#define`-out `api_check`, so it does not fault immediately, but it
  is an out-of-bounds write.

- **`regex.gmatch` iterator state had no `__gc`.** `pcre2_match_data` (and, for
  a string pattern, the compiled `pcre2_code`) leaked whenever the loop was
  abandoned early or unwound by an error. Added a `__gc`; the iterator no
  longer frees inline.

- **Leak on the `\K`-assertion error path** in `f_pcre_match()` — the
  `pcre2_*_free()` calls sat after a non-returning `luaL_error()`.

- **Allocator mismatch in `f_pcre_gsub()`** — the output buffer was grown with
  libc `realloc()` but allocated/freed through `SDL_*` (UB with a custom SDL
  allocator). Now `SDL_realloc()`, with OOM handling.

## Responsiveness

- **Unbounded backtracking froze the UI.** The three match sites now share a
  `pcre2_match_context` with `match_limit` / `depth_limit` (5,000,000 /
  10,000 — far above any real syntax pattern). `MATCHLIMIT` / `DEPTHLIMIT` /
  `HEAPLIMIT` are reported as a normal non-match by `cmatch`/`gmatch` instead
  of raising, so one bad pattern can't abort a tokenize pass.
  Repro on `master`: `regex.find("(a+)+$", ("a"):rep(42).."X")` hangs
  indefinitely; with this change it returns `nil` in ~20 ms.

## Also

- `regex.ENDANCHORED` was set to `PCRE2_ANCHORED`; corrected to `PCRE2_ENDANCHORED`.
- Removed a dead `lua_rawgeti()` in `f_pcre_match()`.

## Related issues

- **#2217** (`IDE Crashes On Patterns That Use Capture`, open) — likely
  addressed: this rewrites the capture and offset paths in `f_pcre_match()`,
  the exact code a capturing syntax pattern drives. Not marked `Fixes` — I
  couldn't reproduce from the F# pattern info in the issue.
- **#542** (`Regex capture groups cause lite-xl crash`, closed 2021) — same
  area; captures have a crash history.

## Behaviour change

`regex.find` / `regex.match` return `nil` on a resource-limit hit rather than
raising. Every in-tree caller (`core.tokenizer`, `core.syntax`,
`plugins.detectindent`, `plugins.projectsearch`) already handles `nil`.

## Testing

11-case Lua harness (offsets, captures, backtracking, `gsub` buffer growth,
`gmatch` early break, `\K` guard, `ENDANCHORED`) — all pass; on unpatched
`master` the offset case core-dumps and the backtracking case hangs. Manual:
open C/Lua/Markdown files (heavy tokenizer/regex use), no regressions.

Targets `master`; the same code is on `3.0-preview` — happy to retarget.
