### PR TITLE
fix(dirmonitor): walk inotify events by their real record size

### DIFF
--- a/src/api/dirmonitor/inotify.c
+++ b/src/api/dirmonitor/inotify.c
@@ -38,9 +38,15 @@ int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, in
 
 
 int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int length, int (*change_callback)(int, const char*, void*), void* data) {
-  for (struct inotify_event* info = (struct inotify_event*)buffer; (char*)info < buffer + length; info = (struct inotify_event*)((char*)info + sizeof(struct inotify_event))) {
+  /* inotify records are variable length: a fixed header followed by `len`
+     bytes of optional name. Advancing by a fixed sizeof(struct inotify_event)
+     misreads every record that follows a named one and walks past
+     `buffer + length`; step by the real record size instead. */
+  for (char* p = buffer; p + sizeof(struct inotify_event) <= buffer + length; ) {
+    struct inotify_event* info = (struct inotify_event*)p;
     if ((info->mask & (~IN_IGNORED)) > 0)
       change_callback(info->wd, NULL, data);
+    p += sizeof(struct inotify_event) + info->len;
   }
   return 0;
 }


### PR DESCRIPTION
## What

`translate_changes_dirmonitor()` (inotify backend) advanced its read cursor
by a fixed `sizeof(struct inotify_event)`. inotify records are variable
length — the fixed header is followed by `len` bytes of optional name. As
soon as one record carries a name — normal for a directory watch — every
following iteration reinterprets name bytes as a header and the loop reads
past `buffer + length`.

## Consequences

- Out-of-bounds read on the tail record.
- `info->wd` is decoded at the wrong offset, so bogus watch ids reach the Lua
  callback — e.g. the filename `file` decodes as wd `0x656c6966` (1701603686).
- When several events arrive in one `read()` (saving multiple files, a
  `git checkout`, a branch switch), the real directory's change is
  misattributed and the tree view silently misses it.

## Repro on `master`

Watch one directory, create 12 files in it: the change callback fires for
watch ids `{1, 1701603686}`. With this change: `{1}`.

## Fix

Step by `sizeof(struct inotify_event) + info->len`, and stop once less than a
full header remains. lite-xl never reads the name, so nothing else changes.

## Related issues

- **#899** (`dir monitor do not update treeview on git commit change`, closed
  for inactivity — "we can assume this is fixed … despite how dirmonitor
  still [gives] us the occasional headaches") — this is a concrete mechanism
  for that class of miss. Left closed; not marked `Fixes`.
- **#1810** (`No "file change outside" detect while in split`, open) — may
  benefit when the missed event is one of a batch.

Scope note: this does **not** touch the separate dirmonitor data race
(**#1559**) or the rename/dangling-ref handling (**#1707**).

## Testing

`dirmonitor` Lua harness (burst of file creations in a watched dir) — bogus
watch ids gone. Manual: no regressions in normal tree-view refresh.

Linux-only backend. Targets `master`; same code on `3.0-preview`.
