### PR TITLE
fix(renderer): size the window_list memmove in bytes

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -762,7 +762,8 @@ static void ren_remove_window(RenWindow *window_renderer) {
   for (size_t i = 0; i < window_count; ++i) {
     if (window_list[i] == window_renderer) {
       window_count -= 1;
-      memmove(&window_list[i], &window_list[i+1], window_count - i);
+      /* size is a byte count, not an element count */
+      memmove(&window_list[i], &window_list[i+1], (window_count - i) * sizeof(RenWindow*));
       return;
     }
   }


### PR DESCRIPTION
## What

`ren_remove_window()` passed `window_count - i` as the third argument to
`memmove()`, which takes a **byte** count, not an element count. Removing a
window while others remain copies only a fraction of the trailing
`RenWindow*` pointers and leaves `window_list` corrupted (stale / dropped
pointers).

```c
memmove(&window_list[i], &window_list[i+1], window_count - i);
//                                          ^ elements, should be * sizeof(RenWindow*)
```

## Impact

Dormant on `master` — lite-xl runs a single window, so `window_count` is 0
or 1 and the `memmove` is a no-op. It becomes a real corruption the moment a
second window can exist.

## Related

- **#2140** (`Multi-Windows`, open PR) — this bug is directly in that path.

## Fix

One line: multiply the length by `sizeof(RenWindow*)`.

Found by inspection; no separate issue. Targets `master`.
