### PR TITLE
perf(renderer): hoist loop-invariant work out of the glyph blit loop

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -652,19 +652,20 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
     if (!is_whitespace(codepoint) && font_surface && color.a > 0 && end_x >= clip.x && start_x < clip_end_x) {
       uint8_t* source_pixels = font_surface->pixels;
       const SDL_PixelFormatDetails* font_surface_format = SDL_GetPixelFormatDetails(font_surface->format);
+      // horizontal clipping is independent of the scanline; do it once here
+      if (start_x + (glyph_end - glyph_start) >= clip_end_x)
+        glyph_end = glyph_start + (clip_end_x - start_x);
+      if (start_x < clip.x) {
+        int offset = clip.x - start_x;
+        start_x += offset;
+        glyph_start += offset;
+      }
       for (int line = metric->y0; line < metric->y1; ++line) {
         int target_y = line - metric->y0 + y - metric->bitmap_top + (fonts[0]->baseline * surface_scale);
         if (target_y < clip.y)
           continue;
         if (target_y >= clip_end_y)
           break;
-        if (start_x + (glyph_end - glyph_start) >= clip_end_x)
-          glyph_end = glyph_start + (clip_end_x - start_x);
-        if (start_x < clip.x) {
-          int offset = clip.x - start_x;
-          start_x += offset;
-          glyph_start += offset;
-        }
 
         uint32_t* destination_pixel = (uint32_t*)&(destination_pixels[surface->pitch * target_y + start_x * surface_format->bytes_per_pixel]);
         uint8_t* source_pixel = &source_pixels[line * font_surface->pitch + glyph_start * font_surface_format->bytes_per_pixel];

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -628,6 +628,9 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
   const char* end = text + len;
   uint8_t* destination_pixels = surface->pixels;
   int clip_end_x = clip.x + clip.w, clip_end_y = clip.y + clip.h;
+  /* format details are a pure function of the format; look them up once here
+  ** instead of once per glyph scanline in the blit loop below */
+  const SDL_PixelFormatDetails* surface_format = SDL_GetPixelFormatDetails(surface->format);
 
   RenFont* last = NULL;
   double last_pen_x = x;
@@ -648,6 +651,7 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
       ren_draw_rect(rs, (RenRect){ start_x + 1, y, font->space_advance - 1, ren_font_group_get_height(fonts) }, color);
     if (!is_whitespace(codepoint) && font_surface && color.a > 0 && end_x >= clip.x && start_x < clip_end_x) {
       uint8_t* source_pixels = font_surface->pixels;
+      const SDL_PixelFormatDetails* font_surface_format = SDL_GetPixelFormatDetails(font_surface->format);
       for (int line = metric->y0; line < metric->y1; ++line) {
         int target_y = line - metric->y0 + y - metric->bitmap_top + (fonts[0]->baseline * surface_scale);
         if (target_y < clip.y)
@@ -661,9 +665,6 @@ double ren_draw_text(RenSurface *rs, RenFont **fonts, const char *text, size_t l
           start_x += offset;
           glyph_start += offset;
         }
-        
-        const SDL_PixelFormatDetails* surface_format = SDL_GetPixelFormatDetails(surface->format);
-        const SDL_PixelFormatDetails* font_surface_format = SDL_GetPixelFormatDetails(font_surface->format);
 
         uint32_t* destination_pixel = (uint32_t*)&(destination_pixels[surface->pitch * target_y + start_x * surface_format->bytes_per_pixel]);
         uint8_t* source_pixel = &source_pixels[line * font_surface->pitch + glyph_start * font_surface_format->bytes_per_pixel];


### PR DESCRIPTION
## What

Two loop-invariant computations inside `ren_draw_text()`'s glyph blit that
ran per scanline of every glyph.

### 1. Pixel-format lookups (`perf(renderer): hoist pixel-format lookups...`)

`SDL_GetPixelFormatDetails()` was called for the destination **and** the
glyph surface once per scanline. The result depends only on the pixel
format — fixed for the destination across the whole call, fixed per glyph
surface. Now: destination format once at the top, glyph-surface format once
per glyph. ~40 lookups/glyph → 1.

### 2. Horizontal clipping (`perf(renderer): hoist horizontal glyph clipping...`)

The left/right clip adjustment of `start_x` / `glyph_start` / `glyph_end`
doesn't depend on the scanline either, but sat in the `for (line …)` loop
and re-ran (idempotently) every row. Moved above the loop.

## No behaviour change

Same pointers, same clip math, just evaluated once instead of per row. The
nearby `// needs to be investigated` comments on the blend arithmetic show
this loop is already known to be hot.

## Related

- **#113** (`High CPU and Memory usage on large projects`) — trims the
  text-blit cost that dominates redraws. Partial; that issue also has
  indexing/cache causes.
- **#2221** (`Very slow performance on text files with 2M columns`) — helps
  the redraw component.

## Testing

Open C / Lua / Markdown buffers with syntax highlighting; zoom in/out
(rebuilds the glyph cache), scroll, page up/down, End, repeated window
resizes (full repaints), subpixel and grayscale AA — rendering
pixel-identical, no regressions. Targets `master`; same code on
`3.0-preview`.
