### PR TITLE
perf(rencache): skip commands that don't touch the dirty rect

### DIFF
--- a/src/rencache.c
+++ b/src/rencache.c
@@ -312,6 +312,11 @@ void rencache_end_frame(RenWindow *window_renderer) {
 
     cmd = NULL;
     while (next_command(window_renderer, &cmd)) {
+      /* commands whose bounds miss this dirty rect can only produce fully
+      ** clipped pixels -- skip their (often per-glyph) work. SET_CLIP still
+      ** runs so the clip state stays correct across the replay. */
+      if (cmd->type != SET_CLIP && !rects_overlap(r, cmd->command[0]))
+        continue;
       SetClipCommand *ccmd = (SetClipCommand*)&cmd->command;
       DrawRectCommand *rcmd = (DrawRectCommand*)&cmd->command;
       DrawTextCommand *tcmd = (DrawTextCommand*)&cmd->command;


### PR DESCRIPTION
## What

`rencache_end_frame()` redraws each dirty rectangle by replaying the **entire**
command list and letting the clip rect discard the out-of-bounds work:

```c
for (each dirty rect r) {
  ren_set_clip_rect(r);
  while (next_command(&cmd))
    switch (cmd->type) { ... }   // every DRAW_TEXT re-walks its whole string
}
```

A `DRAW_TEXT` command still pays for a full UTF-8 walk and a per-glyph metric
lookup even when none of its pixels fall inside `r`. With many small dirty
regions (typing, a blinking cursor, scrolling a split) that is
`O(rects x commands)`.

## Change

Skip any non-`SET_CLIP` command whose bounding rect doesn't overlap the
current dirty rect:

```c
if (cmd->type != SET_CLIP && !rects_overlap(r, cmd->command[0]))
  continue;
```

`cmd->command[0]` is the leading `RenRect` every command starts with — the
same rect the cell-hashing pass already uses to decide which cells a command
dirties, so the cull is consistent with how dirtiness was computed.
`SET_CLIP` is always processed so the clip state stays correct across the
replay. Redraw cost drops toward `O(rects x overlapping-commands)`.

## Related

- **#113** (`High CPU and Memory usage on large projects`) — directly reduces
  per-frame redraw CPU. Partial; that issue also has non-render causes.
- **#2221** (`Very slow performance on text files with 2M columns`) — helps
  the redraw side.

## Testing

Manual: typing, cursor blink, tab switches, repeated window resizes (full
invalidation) across C / Lua / Markdown buffers with syntax highlighting and
a split — rendering correct, no missing or stale glyphs, no artifacts.
Targets `master`; same code on `3.0-preview`.
