### PR TITLE
fix: harden allocation-failure and fd-exhaustion paths in the C bindings

### DIFF
--- a/src/api/dirmonitor.c
+++ b/src/api/dirmonitor.c
@@ -79,18 +79,23 @@ static int f_dirmonitor_new(lua_State* L) {
   memset(monitor, 0, sizeof(struct dirmonitor));
   monitor->mutex = SDL_CreateMutex();
   monitor->internal = init_dirmonitor();
+  if (!monitor->mutex || !monitor->internal)
+    return luaL_error(L, "cannot create directory monitor");
   return 1;
 }
 
 
 static int f_dirmonitor_gc(lua_State* L) {
   struct dirmonitor* monitor = luaL_checkudata(L, 1, API_TYPE_DIRMONITOR);
-  SDL_LockMutex(monitor->mutex);
-  monitor->length = -1;
-  deinit_dirmonitor(monitor->internal);
-  SDL_UnlockMutex(monitor->mutex);
-  SDL_WaitThread(monitor->thread, NULL);
-  SDL_free(monitor->internal);
+  // monitor->internal can be NULL if f_dirmonitor_new failed to initialize it
+  if (monitor->internal) {
+    SDL_LockMutex(monitor->mutex);
+    monitor->length = -1;
+    deinit_dirmonitor(monitor->internal);
+    SDL_UnlockMutex(monitor->mutex);
+    SDL_WaitThread(monitor->thread, NULL);
+    SDL_free(monitor->internal);
+  }
   SDL_DestroyMutex(monitor->mutex);
   return 0;
 }

--- a/src/api/dirmonitor/inotify.c
+++ b/src/api/dirmonitor/inotify.c
@@ -15,18 +15,27 @@ struct dirmonitor_internal {
 
 struct dirmonitor_internal* init_dirmonitor() {
   struct dirmonitor_internal* monitor = SDL_calloc(1, sizeof(struct dirmonitor_internal));
+  if (!monitor)
+    return NULL;
   monitor->fd = inotify_init();
-  pipe(monitor->sig);
-  fcntl(monitor->sig[0], F_SETFD, FD_CLOEXEC);
-  fcntl(monitor->sig[1], F_SETFD, FD_CLOEXEC);
+  // keep the fds at -1 when unavailable so deinit_dirmonitor() doesn't
+  // close(0)/close(1) if inotify_init() or pipe() fails
+  if (pipe(monitor->sig) != 0) {
+    monitor->sig[0] = monitor->sig[1] = -1;
+  } else {
+    fcntl(monitor->sig[0], F_SETFD, FD_CLOEXEC);
+    fcntl(monitor->sig[1], F_SETFD, FD_CLOEXEC);
+  }
   return monitor;
 }
 
 
 void deinit_dirmonitor(struct dirmonitor_internal* monitor) {
-  close(monitor->fd);
-  close(monitor->sig[0]);
-  close(monitor->sig[1]);
+  // fds are -1 rather than 0 when inotify_init()/pipe() failed, so this
+  // never closes stdin/stdout by accident
+  if (monitor->fd >= 0) close(monitor->fd);
+  if (monitor->sig[0] >= 0) close(monitor->sig[0]);
+  if (monitor->sig[1] >= 0) close(monitor->sig[1]);
 }
 
 

--- a/src/api/renwindow.c
+++ b/src/api/renwindow.c
@@ -36,6 +36,11 @@ static int f_renwin_create(lua_State *L) {
     }
   }
 
+  // create the userdata first: if this throws (OOM) there's no window to leak
+  RenWindow **window_renderer = (RenWindow**)lua_newuserdata(L, sizeof(RenWindow*));
+  *window_renderer = NULL;
+  luaL_setmetatable(L, API_TYPE_RENWINDOW);
+
   SDL_Window *window = SDL_CreateWindow(
     title, width, height,
     SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY | SDL_WINDOW_HIDDEN
@@ -45,9 +50,6 @@ static int f_renwin_create(lua_State *L) {
   }
   init_window_icon(window);
 
-  RenWindow **window_renderer = (RenWindow**)lua_newuserdata(L, sizeof(RenWindow*));
-  luaL_setmetatable(L, API_TYPE_RENWINDOW);
-
   *window_renderer = ren_create(window);
 
   return 1;
@@ -55,7 +57,7 @@ static int f_renwin_create(lua_State *L) {
 
 static int f_renwin_gc(lua_State *L) {
   RenWindow *window_renderer = *(RenWindow**)luaL_checkudata(L, 1, API_TYPE_RENWINDOW);
-  if (window_renderer != persistant_window)
+  if (window_renderer && window_renderer != persistant_window)
     ren_destroy(window_renderer);
 
   return 0;

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1383,6 +1383,7 @@ static int open_dialog(lua_State* L, SDL_FileDialogType type) {
 
   DialogData *dd = SDL_calloc(1, sizeof(DialogData));
   if (dd == NULL) {
+    SDL_DestroyProperties(props);
     return luaL_error(L, "Unable to allocate DialogData memory");
   }
   dd->id = id;
@@ -1391,6 +1392,7 @@ static int open_dialog(lua_State* L, SDL_FileDialogType type) {
 
   if (dd->filters == NULL) {
     SDL_free(dd);
+    SDL_DestroyProperties(props);
     return luaL_error(L, "Unable to allocate SDL_DialogFileFilter memory");
   }
 
@@ -1403,6 +1405,7 @@ static int open_dialog(lua_State* L, SDL_FileDialogType type) {
       free_dialog_filters(dd->filters, i);
       SDL_free(dd->filters);
       SDL_free(dd);
+      SDL_DestroyProperties(props);
       return luaL_error(L, "Unable to allocate memory for SDL_DialogFileFilter values");
     }
   }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -754,7 +754,7 @@ void ren_draw_rect(RenSurface *rs, RenRect rect, RenColor color) {
 /*************** Window Management ****************/
 static void ren_add_window(RenWindow *window_renderer) {
   window_count += 1;
-  window_list = SDL_realloc(window_list, window_count * sizeof(RenWindow*));
+  window_list = check_alloc(SDL_realloc(window_list, window_count * sizeof(RenWindow*)));
   window_list[window_count-1] = window_renderer;
 }
 
@@ -808,11 +808,14 @@ int ren_init(void) {
 void ren_free(void) {
   SDL_DestroySurface(draw_rect_surface);
   FT_Done_FreeType(library);
+  SDL_free(window_list);
+  window_list = NULL;
+  window_count = 0;
 }
 
 RenWindow* ren_create(SDL_Window *win) {
   assert(win);
-  RenWindow* window_renderer = SDL_calloc(1, sizeof(RenWindow));
+  RenWindow* window_renderer = check_alloc(SDL_calloc(1, sizeof(RenWindow)));
 
   window_renderer->window = win;
   renwin_init_surface(window_renderer);


### PR DESCRIPTION
## What

Five small robustness gaps in the C bindings, rolled into one commit. None
is reachable without an allocation failure or fd exhaustion, but the outcomes
range from a leak to **closing stdin**.

### dirmonitor (inotify)

`init_dirmonitor()` ignored the return of `SDL_calloc()`, `inotify_init()`
and `pipe()`. On `pipe()` failure `sig[]` stayed `{0, 0}` (zeroed by calloc)
and `deinit_dirmonitor()` then `close()`d fd `0` and `1`.

- fds are left at `-1` and only closed when valid
- `f_dirmonitor_new()` raises if init failed
- `f_dirmonitor_gc()` tolerates a NULL `internal`

### system

`open_dialog()` leaked the `SDL_PropertiesID` on each of its three
allocation-failure `luaL_error()` paths (`SDL_DestroyProperties` never
called).

### renwindow

`f_renwin_create()` created the `SDL_Window` *before* the Lua userdata, so an
OOM in the following `lua_newuserdata()` leaked the window. Create the
userdata first (initialised to `NULL`, `__gc` cleans up); `f_renwin_gc()`
now null-checks.

### renderer

`ren_create()` and `ren_add_window()` used raw `SDL_calloc` / `SDL_realloc`
where the rest of the file uses `check_alloc()` — a failure dereferenced
NULL. `ren_free()` now also frees `window_list`.

## Testing

Normal window creation, dirmonitor watch + change detection, full regression
of the editor — no behaviour change. Found by inspection. Targets `master`;
same code on `3.0-preview`.
