### PR TITLE
perf(renderer): O(1) text width for fixed-width fonts over ASCII

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -124,6 +124,7 @@ typedef struct RenFont {
   ERenFontAntialiasing antialiasing;
   ERenFontHinting hinting;
   unsigned char style;
+  bool is_monospace;
   char path[];
 } RenFont;
 
@@ -455,6 +456,7 @@ static int font_set_face_metrics(RenFont *font, FT_Face face) {
   if ((err = FT_Load_Char(face, ' ', (font_set_load_options(font) | FT_LOAD_BITMAP_METRICS_ONLY | FT_LOAD_NO_HINTING) & ~FT_LOAD_FORCE_AUTOHINT)) != 0)
     return err;
   font->space_advance = face->glyph->advance.x / 64.0f;
+  font->is_monospace = FT_IS_FIXED_WIDTH(face);
   return 0;
 }
 
@@ -577,6 +579,32 @@ float font_get_xadvance(RenFont *font, unsigned int codepoint, GlyphMetric *metr
 double ren_font_group_get_width(RenFont **fonts, const char *text, size_t len, RenTab tab, int *x_offset) {
   double width = 0;
   const char* end = text + len;
+  RenFont *first = fonts[0];
+
+  /* Fast path: a fixed-width primary font, over a run with no tab and no
+  ** multibyte character, advances by a constant amount per character -- the
+  ** width is just the character count times that advance, with no per-glyph
+  ** cache lookup. This is the hot path for pathologically long lines. */
+  if (first->is_monospace) {
+    bool simple = true;
+    for (const char *p = text; p < end; p++) {
+      if ((unsigned char) *p >= 0x80 || *p == '\t') { simple = false; break; }
+    }
+    if (simple) {
+      width = (double) len * first->space_advance;
+      if (x_offset) {
+        GlyphMetric *metric = NULL;
+        if (len > 0)
+          font_group_get_glyph(fonts, (unsigned char) text[0], 0, NULL, &metric);
+        *x_offset = metric ? metric->bitmap_left : 0;
+      }
+#ifdef LITE_USE_SDL_RENDERER
+      return width / first->scale;
+#else
+      return width;
+#endif
+    }
+  }
 
   bool set_x_offset = x_offset == NULL;
   while (text < end) {


### PR DESCRIPTION
## What

`ren_font_group_get_width()` sums glyph advances one character at a time,
each through the glyph cache. That's O(n) in the string and shows up as the
dominant cost when `DocView` positions the caret on a very long line
(**#2221** &mdash; End, click, or scroll on a multi&#8209;million&#8209;column line takes
1&ndash;2&nbsp;s).

## Change

A fixed&#8209;width primary font advances by a constant amount for every ASCII
character, so for a run with no tab and no byte &ge; `0x80` the width is just
`len * space_advance` &mdash; no per&#8209;glyph work.

- `ren_font_load` sets `font->is_monospace` from `FT_IS_FIXED_WIDTH(face)`.
- `ren_font_group_get_width` takes the constant&#8209;advance path when the primary
  font is fixed&#8209;width and the run is tab&#8209;free ASCII; otherwise it falls
  through to the existing exact loop unchanged.
- When an `x_offset` is requested (the draw path), one glyph lookup for the
  first character's left bearing replaces the full walk.

The ASCII guard also covers &ldquo;monospace&rdquo; faces that ship double&#8209;width CJK
or ligature glyphs &mdash; those hit the slow path. Proportional fonts,
multibyte text, and tabbed text are untouched.

## Effect

`get_col_x_offset(line, 2000000)` on a 2,000,000&#8209;character line:
**~1700&nbsp;ms &rarr; ~2&nbsp;ms**, identical result. Also trims the per&#8209;frame width
measurement of every visible line for monospace editing generally.

Pairs with a companion change to `DocView`'s offset walk
(`perf/core-long-line-column-offset`); either stands alone.

## Testing

A headless harness (2M&#8209;char line + tab and multibyte lines) times the calls
and checks every result against an independent character&#8209;by&#8209;character
reference &mdash; bit&#8209;identical across ASCII, tab, and multibyte content, and
the `get_col_x_offset` / `get_x_offset_col` round trip holds. Targets
`master`; the same code is on `3.0-preview`.
