### PR TITLE
perf(core): make long-line column offsets cheap

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -171,8 +171,25 @@ end
 
 
 function DocView:get_col_x_offset(line, col)
+  local hl_line = self.doc.highlighter:get_line(line)
   local default_font = self:get_font()
   local _, indent_size = self.doc:get_indent_info()
+
+  -- Per-line memo, keyed by column, kept on the highlighter's line record so
+  -- it is dropped automatically when the line is re-tokenized. The guard
+  -- fields catch a font family / size or tab-width change (the scale plugin
+  -- resizes the syntax fonts together with the default one, so tracking the
+  -- default font's size covers those too).
+  local font_size = default_font:get_size()
+  local memo = hl_line.col_x_offset
+  if not (memo and memo.font == default_font
+          and memo.size == font_size and memo.indent == indent_size) then
+    memo = { font = default_font, size = font_size, indent = indent_size }
+    hl_line.col_x_offset = memo
+  end
+  local cached = memo[col]
+  if cached then return cached end
+
   default_font:set_tab_size(indent_size)
   local column = 1
   local xoffset = 0
@@ -186,7 +203,7 @@ function DocView:get_col_x_offset(line, col)
       xoffset = xoffset + font:get_width(text, opts)
       column = column + length
       if column >= col then
-        return xoffset
+        break
       end
     else
       -- `col` falls inside this token. Measure the prefix up to `col` in a
@@ -200,10 +217,11 @@ function DocView:get_col_x_offset(line, col)
       if rel > 0 then
         xoffset = xoffset + font:get_width(text:sub(1, rel), opts)
       end
-      return xoffset
+      break
     end
   end
 
+  memo[col] = xoffset
   return xoffset
 end
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -176,24 +176,31 @@ function DocView:get_col_x_offset(line, col)
   default_font:set_tab_size(indent_size)
   local column = 1
   local xoffset = 0
+  local opts = { tab_offset = 0 }
   for _, type, text in self.doc.highlighter:each_token(line) do
     local font = style.syntax_fonts[type] or default_font
     if font ~= default_font then font:set_tab_size(indent_size) end
     local length = #text
+    opts.tab_offset = xoffset
     if column + length <= col then
-      xoffset = xoffset + font:get_width(text, {tab_offset = xoffset})
+      xoffset = xoffset + font:get_width(text, opts)
       column = column + length
       if column >= col then
         return xoffset
       end
     else
-      for char in common.utf8_chars(text) do
-        if column >= col then
-          return xoffset
-        end
-        xoffset = xoffset + font:get_width(char, {tab_offset = xoffset})
-        column = column + #char
+      -- `col` falls inside this token. Measure the prefix up to `col` in a
+      -- single call rather than one character at a time (which also
+      -- allocated a table per character); get_width handles any tabs within
+      -- the prefix itself.
+      local rel = col - column
+      while rel < length and common.is_utf8_cont(text, rel + 1) do
+        rel = rel + 1
       end
+      if rel > 0 then
+        xoffset = xoffset + font:get_width(text:sub(1, rel), opts)
+      end
+      return xoffset
     end
   end
 
@@ -208,24 +215,45 @@ function DocView:get_x_offset_col(line, x)
   local default_font = self:get_font()
   local _, indent_size = self.doc:get_indent_info()
   default_font:set_tab_size(indent_size)
+  local opts = { tab_offset = 0 }
   for _, type, text in self.doc.highlighter:each_token(line) do
     local font = style.syntax_fonts[type] or default_font
     if font ~= default_font then font:set_tab_size(indent_size) end
-    local width = font:get_width(text, {tab_offset = xoffset})
+    opts.tab_offset = xoffset
+    local width = font:get_width(text, opts)
     -- Don't take the shortcut if the width matches x,
     -- because we need last_i which should be calculated using utf-8.
     if xoffset + width < x then
       xoffset = xoffset + width
       i = i + #text
     else
-      for char in common.utf8_chars(text) do
-        local w = font:get_width(char, {tab_offset = xoffset})
-        if xoffset + w >= x then
-          return (x <= xoffset + (w / 2)) and i or i + #char
+      -- `x` falls within this token. Binary-search the character boundary
+      -- rather than walking the token one character at a time, then measure
+      -- just the glyph `x` lands in for the half-glyph rounding.
+      local lo, hi = 0, #text -- byte offsets into the token; `lo` stays char-aligned
+      while hi - lo > 1 do
+        local mid = (lo + hi) // 2
+        while mid > lo and common.is_utf8_cont(text, mid + 1) do mid = mid - 1 end
+        if mid == lo then break end
+        opts.tab_offset = xoffset
+        if xoffset + font:get_width(text:sub(1, mid), opts) <= x then
+          lo = mid
+        else
+          hi = mid
         end
-        xoffset = xoffset + w
-        i = i + #char
       end
+      if lo >= #text then
+        return i + #text
+      end
+      opts.tab_offset = xoffset
+      local prefix_w = lo > 0 and font:get_width(text:sub(1, lo), opts) or 0
+      local clen = 1
+      while lo + clen < #text and common.is_utf8_cont(text, lo + clen + 1) do
+        clen = clen + 1
+      end
+      opts.tab_offset = xoffset + prefix_w
+      local w = font:get_width(text:sub(lo + 1, lo + clen), opts)
+      return (x <= xoffset + prefix_w + w / 2) and (i + lo) or (i + lo + clen)
     end
   end
 


### PR DESCRIPTION
Two commits, both narrowing `DocView`'s column&nbsp;&harr;&nbsp;x math on long
lines (**#2221** &mdash; End, click, or scroll on a multi&#8209;million&#8209;column line).

## 1 &mdash; drop the per&#8209;character walk

`get_col_x_offset` and `get_x_offset_col` walked the token that holds the
target column one UTF&#8209;8 character at a time: a `font:get_width` call per
character, and a fresh `{tab_offset = ...}` table each iteration &mdash; O(n)
work plus O(n) garbage.

- `get_col_x_offset` &mdash; measure the token prefix up to the column in one
  `get_width` call (it already accounts for tabs inside the prefix),
  rounding the byte offset up to a character boundary so the result matches
  the old walk exactly.
- `get_x_offset_col` &mdash; binary&#8209;search the character boundary, then measure
  only the glyph `x` lands in, preserving the half&#8209;glyph rounding.
- Both reuse one options table instead of allocating per iteration.

## 2 &mdash; memoize `get_col_x_offset` per line

It's called several times per frame for the caret line
(`get_line_screen_position`, `scroll_to_make_visible` twice, selection
drawing). Each call redid the work; on a long line each still copied a
multi&#8209;megabyte substring to measure it.

Cache the `column -> x` result on the highlighter's per&#8209;line record, so it
is discarded automatically when the line is re&#8209;tokenized. A three&#8209;field
guard (font object, font size, indent size) invalidates it on zoom or a
tab&#8209;width change &mdash; the scale plugin resizes the syntax fonts together
with the default one, so tracking the default font's size covers those too.

## Effect (2,000,000&#8209;character line)

| | before | after |
|---|---|---|
| `get_col_x_offset(line, 2e6)`, first call | ~1700 ms | ~2 ms |
| &hellip; 5 calls/frame during a scroll | ~11 ms/frame | ~0.15 ms/frame, then 0 |
| `get_x_offset_col(line, ~1.5M&nbsp;px)` | ~1350 ms | ~30 ms |

Pairs with the fixed&#8209;width width fast path
(`perf/renderer-fixed-width-ascii-fast-path`); on its own commit&nbsp;1 still
takes `get_col_x_offset` to tens of ms.

## Testing

Headless harness against a 2M&#8209;char line plus tab and multibyte
(`\u{4e2d}\u{6587}`) lines:

- every `get_col_x_offset` / `get_x_offset_col` result checked against an
  independent character&#8209;by&#8209;character reference &mdash; 21 + 16 cases, all match,
  each column queried twice to exercise the memo
- `get_x_offset_col(get_col_x_offset(col))` round&#8209;trips within one character
- after an in&#8209;place edit that shifts the line, the memo returns the new
  value, not a stale one
- manual: navigate / select / type / undo / redo / zoom on a real buffer,
  no misplaced carets

`linewrapping.lua` wraps both functions and delegates to the originals when
wrapping is off. Targets `master`; same code on `3.0-preview`.
