### PR TITLE
fix(regex): match against subjects containing invalid UTF-8

### DIFF
--- a/src/api/regex.c
+++ b/src/api/regex.c
@@ -7,6 +7,15 @@
 #include <pcre2.h>
 #include <stdbool.h>
 
+/* PCRE2_MATCH_INVALID_UTF (PCRE2 10.34+) lets a pattern match against a
+   subject that contains invalid UTF-8 -- any real file may -- instead of
+   returning a UTF error. Fall back to plain UTF validation on older libs. */
+#ifdef PCRE2_MATCH_INVALID_UTF
+  #define LITE_PCRE2_UTF (PCRE2_UTF | PCRE2_MATCH_INVALID_UTF)
+#else
+  #define LITE_PCRE2_UTF PCRE2_UTF
+#endif
+
 typedef struct RegexState {
   pcre2_code* re;
   pcre2_match_data* match_data;
@@ -33,7 +42,7 @@ static pcre2_code* regex_get_pattern(lua_State *L, bool* should_free) {
 
     re = pcre2_compile(
       (PCRE2_SPTR)pattern,
-      pattern_len, PCRE2_UTF,
+      pattern_len, LITE_PCRE2_UTF,
       &errornumber, &erroroffset, NULL
     );
 
@@ -141,7 +150,7 @@ static int f_pcre_compile(lua_State *L) {
   size_t len;
   PCRE2_SIZE errorOffset;
   int errorNumber;
-  int pattern = PCRE2_UTF;
+  int pattern = LITE_PCRE2_UTF;
   const char* str = luaL_checklstring(L, 1, &len);
   if (lua_gettop(L) > 1) {
     const char* options = luaL_checkstring(L, 2);


### PR DESCRIPTION
## Problem

`pcre2_compile()` is called with only `PCRE2_UTF`, so `pcre2_match()` returns a
UTF-error (a negative return code) as soon as the *subject* contains a byte that
isn't valid UTF-8 — which any real file may. `regex.c` turns that into a Lua
error, which aborts whatever was matching:

- A syntax tokenize pass that uses a `regex` pattern stops on the first stray
  byte, so the rest of the file loses highlighting.
- Find/replace and project-wide search error out over files with mixed or
  broken encodings.

## Fix

Compile with `PCRE2_MATCH_INVALID_UTF` (PCRE2 10.34+, fully JIT-supported) in
addition to `PCRE2_UTF`. An invalid sequence in the subject simply does not
match, and matching resynchronises past it — no error, no aborted pass.

Guarded with `#ifdef PCRE2_MATCH_INVALID_UTF` so an older PCRE2 still builds and
falls back to today's behaviour:

```c
#ifdef PCRE2_MATCH_INVALID_UTF
  #define LITE_PCRE2_UTF (PCRE2_UTF | PCRE2_MATCH_INVALID_UTF)
#else
  #define LITE_PCRE2_UTF PCRE2_UTF
#endif
```

The pattern itself is still required to be valid UTF-8; only the subject
tolerance changes.

## Pairs with

#2248 — the Lua tokenizer needs the same tolerance in the Lua pattern
matcher for the non-regex path. This PR is what makes `regex`-based syntax
patterns (and search) survive invalid bytes; it stands alone but the two
together are what fully fixes #1484 / #1870 / #2023.

## Testing

- `ninja -C build` — clean, no new warnings.
- Tokenized 7 lines each containing an invalid byte (0x8a, bare 0xff, truncated
  multibyte lead, …) through a `regex` number pattern: previously raised
  `-22: UTF-8 error: isolated byte with 0x80 bit set`; now matches cleanly and
  the reconstructed token stream is byte-identical to the input.
- Token-stream hashes over the editor's own C / Lua / Python / Markdown sources
  are unchanged for valid input.
