### PR TITLE
fix(tokenizer): tokenize lines containing invalid UTF-8

### DIFF
--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -236,10 +236,11 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
       res = p.pattern and { text:ufind((at_start or p.whole_line[p_idx]) and "^" .. code or code, next) }
         or { regex.find(code, text, text:ucharpos(next), (at_start or p.whole_line[p_idx]) and regex.ANCHORED or 0) }
       if p.regex and #res > 0 then -- set correct utf8 len for regex result
-        local char_pos_1 = res[1] > next and string.ulen(text:sub(1, res[1])) or next
-        local char_pos_2 = string.ulen(text:sub(1, res[2]))
+        -- `lax` so a stray invalid byte in the line is one character, not an error
+        local char_pos_1 = res[1] > next and string.ulen(text:sub(1, res[1]), 1, -1, true) or next
+        local char_pos_2 = string.ulen(text:sub(1, res[2]), 1, -1, true)
         for i=3,#res do
-          res[i] = string.ulen(text:sub(1, res[i] - 1)) + 1
+          res[i] = string.ulen(text:sub(1, res[i] - 1), 1, -1, true) + 1
         end
         res[1] = char_pos_1
         res[2] = char_pos_2
@@ -250,7 +251,7 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
         -- and if it is not itself escaped.
         local count = 0
         for i = res[1] - 1, 1, -1 do
-          if text:ubyte(i) ~= target[3]:ubyte() then break end
+          if text:usub(i, i) ~= target[3] then break end
           count = count + 1
         end
         if count % 2 == 0 then
@@ -265,7 +266,9 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
     return table.unpack(res)
   end
 
-  local text_len = text:ulen()
+  -- `lax` so a line containing an invalid UTF-8 byte tokenizes (that byte
+  -- counts as one character) rather than returning nil and crashing the caller
+  local text_len = text:ulen(1, -1, true)
   local start_time = system.get_time()
   local starting_i = i
   while i <= text_len do

--- a/src/api/utf8.c
+++ b/src/api/utf8.c
@@ -266,6 +266,23 @@ static const char *utf8_safe_decode (lua_State *L, const char *p, utfint *pval) 
   return p;
 }
 
+/* Like utf8_safe_decode but never raises. An invalid sequence is reported as
+   one opaque codepoint equal to its lead byte, spanning the lead byte plus
+   any trailing continuation bytes -- the same span utf8_next() would walk, so
+   the two stay in step. The pattern matcher uses this so string.ufind /
+   string.umatch over a buffer that contains invalid UTF-8 (any real file may)
+   match over it rather than aborting tokenization. Relies on the input being
+   NUL-terminated, as Lua strings always are. */
+static const char *utf8_lax_decode (const char *p, utfint *pval) {
+  const char *np = utf8_decode(p, pval, 0);
+  if (np == NULL) {
+    *pval = (unsigned char)*p++;
+    while (iscont(p)) p++;
+    return p;
+  }
+  return np;
+}
+
 static void add_utf8char (luaL_Buffer *b, utfint ch) {
   char buff[UTF8_BUFFSZ];
   size_t n = utf8_encode(buff, ch);
@@ -739,7 +756,7 @@ static int capture_to_close (MatchState *ms) {
 
 static const char *classend (MatchState *ms, const char *p) {
   utfint ch = 0;
-  p = utf8_safe_decode(ms->L, p, &ch);
+  p = utf8_lax_decode(p, &ch);
   switch (ch) {
     case L_ESC: {
       if (p == ms->p_end)
@@ -785,16 +802,16 @@ static int matchbracketclass (MatchState *ms, utfint c, const char *p, const cha
   }
   while (p < ec) {
     utfint ch = 0;
-    p = utf8_safe_decode(ms->L, p, &ch);
+    p = utf8_lax_decode(p, &ch);
     if (ch == L_ESC) {
-      p = utf8_safe_decode(ms->L, p, &ch);
+      p = utf8_lax_decode(p, &ch);
       if (match_class(c, ch))
         return sig;
     } else {
       utfint next = 0;
-      const char *np = utf8_safe_decode(ms->L, p, &next);
+      const char *np = utf8_lax_decode(p, &next);
       if (next == '-' && np < ec) {
-        p = utf8_safe_decode(ms->L, np, &next);
+        p = utf8_lax_decode(np, &next);
         if (ch <= c && c <= next)
           return sig;
       }
@@ -809,11 +826,11 @@ static int singlematch (MatchState *ms, const char *s, const char *p, const char
     return 0;
   else {
     utfint ch=0, pch=0;
-    utf8_safe_decode(ms->L, s, &ch);
-    p = utf8_safe_decode(ms->L, p, &pch);
+    utf8_lax_decode(s, &ch);
+    p = utf8_lax_decode(p, &pch);
     switch (pch) {
       case '.': return 1;  /* matches any char */
-      case L_ESC: utf8_safe_decode(ms->L, p, &pch);
+      case L_ESC: utf8_lax_decode(p, &pch);
                   return match_class(ch, pch);
       case '[': return matchbracketclass(ms, ch, p-1, ep-1);
       default:  return pch == ch;
@@ -823,17 +840,17 @@ static int singlematch (MatchState *ms, const char *s, const char *p, const char
 
 static const char *matchbalance (MatchState *ms, const char *s, const char **p) {
   utfint ch=0, begin=0, end=0;
-  *p = utf8_safe_decode(ms->L, *p, &begin);
+  *p = utf8_lax_decode(*p, &begin);
   if (*p >= ms->p_end)
     luaL_error(ms->L, "malformed pattern "
                       "(missing arguments to " LUA_QL("%%b") ")");
-  *p = utf8_safe_decode(ms->L, *p, &end);
-  s = utf8_safe_decode(ms->L, s, &ch);
+  *p = utf8_lax_decode(*p, &end);
+  s = utf8_lax_decode(s, &ch);
   if (ch != begin) return NULL;
   else {
     int cont = 1;
     while (s < ms->src_end) {
-      s = utf8_safe_decode(ms->L, s, &ch);
+      s = utf8_lax_decode(s, &ch);
       if (ch == end) {
         if (--cont == 0) return s;
       }
@@ -906,7 +923,7 @@ static const char *match (MatchState *ms, const char *s, const char *p) {
   init: /* using goto's to optimize tail recursion */
   if (p != ms->p_end) {  /* end of pattern? */
     utfint ch = 0;
-    utf8_safe_decode(ms->L, p, &ch);
+    utf8_lax_decode(p, &ch);
     switch (ch) {
       case '(': {  /* start capture */
         if (*(p + 1) == ')')  /* position capture? */
@@ -927,7 +944,7 @@ static const char *match (MatchState *ms, const char *s, const char *p) {
       }
       case L_ESC: {  /* escaped sequence not in the format class[*+?-]? */
         const char *prev_p = p;
-        p = utf8_safe_decode(ms->L, p+1, &ch);
+        p = utf8_lax_decode(p+1, &ch);
         switch (ch) {
           case 'b': {  /* balanced string? */
             s = matchbalance(ms, s, &p);
@@ -1172,11 +1189,11 @@ static void add_s (MatchState *ms, luaL_Buffer *b, const char *s, const char *e)
   const char *new_end, *news = to_utf8(ms->L, 3, &new_end);
   while (news < new_end) {
     utfint ch = 0;
-    news = utf8_safe_decode(ms->L, news, &ch);
+    news = utf8_lax_decode(news, &ch);
     if (ch != L_ESC)
       add_utf8char(b, ch);
     else {
-      news = utf8_safe_decode(ms->L, news, &ch); /* skip ESC */
+      news = utf8_lax_decode(news, &ch); /* skip ESC */
       if (!utf8_isdigit(ch)) {
         if (ch != L_ESC)
           luaL_error(ms->L, "invalid use of " LUA_QL("%c")


### PR DESCRIPTION
Fixes #1484, fixes #1870, fixes #2023.

## Problem

Opening a file that contains a single invalid byte (e.g. `0x8a`, Mac Roman `ä`)
crashes the editor:

```
tokenizer.lua: attempt to compare number with nil
```

Two independent causes, both in the tokenize path:

1. `text:ulen()` returns `nil` when the line contains an invalid byte, and the
   result is then used in `for i = 1, text_len` / `while` comparisons.
2. The Lua pattern matcher (`string.ufind` / `string.umatch`, implemented in
   `src/api/utf8.c`) raises `invalid UTF-8 code` from deep inside `match()` the
   moment it decodes a bad byte.

## Fix

**`src/api/utf8.c`** — add `utf8_lax_decode()`: an invalid sequence decodes as
one opaque codepoint equal to its lead byte, spanning the same bytes
`utf8_next()` would walk (lead byte + trailing continuation bytes), so the two
stay in step. The pattern matcher's 16 decode sites — all `MatchState`-local —
use it instead of the raising `utf8_safe_decode()`. A match over invalid text
now scans past the bad bytes instead of aborting.

The public `utf8.byte` / `utf8.codepoint` / `utf8.codes` / `utf8.reverse` are
untouched and keep their documented strict `"invalid UTF-8 code"` contract.

**`data/core/tokenizer.lua`** — pass `lax=true` to the `text:ulen` /
`string.ulen` calls that compute line and match offsets (they can no longer
return `nil`), and compare the escape character with `text:usub(i, i)` rather
than the raising `text:ubyte(i)`.

## Result

An invalid byte renders as a replacement glyph and tokenization continues;
highlighting of the rest of the line and file is unaffected.

## Pairs with #2247

#2247 gives the **regex** matcher the same tolerance. This PR fixes the Lua
pattern path; #2247 fixes the PCRE2 path. Syntaxes that use `regex` patterns
need both. Each stands alone (no merge dependency).

## Testing

- `ninja -C build` — clean, no new warnings; `luac` parse of `tokenizer.lua` OK.
- **Regression:** token-stream hashes over the editor's own C / Lua / Python /
  Markdown sources are **byte-identical** before and after.
- **Crash cases:** 7 lines each containing a different invalid sequence (`0x8a`,
  bare `0xff`, truncated 3-byte lead, lone continuation byte, …) now tokenize
  without error; the concatenated token text reconstructs the input line
  byte-for-byte in every case.
- Opening a file with invalid bytes in the real editor: no `error.txt`,
  replacement glyphs shown, surrounding syntax highlighting intact.
