### PR TITLE
fix(tokenizer): warn instead of error on token-type count mismatch

### DIFF
--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -361,7 +361,10 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
             "Token type is a table, but a string was expected.")
           p.type = p.type[1]
         elseif #find_results - 1 > n_types then
-          report_bad_pattern(core.error, current_syntax, n,
+          -- The surplus captures fall through to the "normal" type (see
+          -- push_tokens), same graceful degradation as the too-many-types
+          -- branch below -- a plugin-authoring mistake, not an editor error.
+          report_bad_pattern(core.warn, current_syntax, n,
             "Not enough token types: got %d needed %d.", n_types, #find_results - 1)
         elseif #find_results - 1 < n_types then
           report_bad_pattern(core.warn, current_syntax, n,


### PR DESCRIPTION
## Problem

When a syntax pattern produces more capture spans than it declares token
types, `tokenizer.tokenize` calls `core.error` — a red status-bar message
plus a full backtrace written to the log — once per affected pattern, on
every file that uses it.

That is disproportionate. The mismatch is already handled gracefully:

- the surplus spans get a `nil` type and `push_tokens` renders them as
  `normal`;
- the mirror-image case (`#find_results - 1 < n_types`, more declared types
  than captures) three lines below only calls `core.warn`.

Both are the same kind of plugin-authoring mistake with the same graceful
fallback, so they should report at the same severity.

## Change

One line: `core.error` → `core.warn` for the `#find_results - 1 > n_types`
branch (plus a comment noting why it's only a warning).

## Testing

Tokenized `abc123!!` against `{ pattern = "()%a+()%d+()%p+()", type = { "keyword", "number" } }`
(4 position captures, 2 declared types) on a headless build, before and after:

| | token stream | log level | Lua error raised |
|---|---|---|---|
| master | `number:abc \| normal:123!!` | `ERROR` | — (not raised, just logged) |
| this PR | `number:abc \| normal:123!!` | `WARN` | — |

Token output is byte-identical; only the diagnostic severity changes.
`report_bad_pattern`'s once-per-pattern dedup still applies, so the warning
is not repeated.
