### PR TITLE
refactor(tokenizer): precompile syntax patterns once in syntax.add

### DIFF
--- a/data/core/syntax.lua
+++ b/data/core/syntax.lua
@@ -7,57 +7,75 @@ syntax.items = {}
 syntax.plain_text_syntax = { name = "Plain Text", patterns = {}, symbols = {} }
 
 
----Checks whether the pattern / regex compiles correctly and matches something.
----A pattern / regex must not match an empty string.
----@param pattern_type "regex"|"pattern"
----@param pattern string
----@return boolean ok
----@return string? error
-local function check_pattern(pattern_type, pattern)
-  local ok, err, mstart, mend
-  if pattern_type == "regex" then
-    ok, err = regex.compile(pattern)
-    if ok then
-      mstart, mend = regex.find_offsets(ok, "")
-      if mstart and mstart > mend then
-        ok, err = false, "Regex matches an empty string"
-      end
-    end
+-- Turn one delimiter of a pattern entry into the form the tokenizer executes:
+-- a leading '^' (the "match only at the start of the line" marker) is split
+-- off into `whole_line` and stripped from the body, and a regex body is
+-- compiled once here rather than on every match. `err` is set, and left for
+-- the caller to report, if the delimiter does not compile or matches "".
+---@param is_regex boolean
+---@param raw string
+local function compile_delimiter(is_regex, raw)
+  local whole_line = raw:umatch("^%^") ~= nil
+  local body = whole_line and raw:usub(2) or raw
+  local d = { regex = is_regex, whole_line = whole_line }
+  if is_regex then
+    local rx, cerr = regex.compile(body)
+    if not rx then d.err = cerr or "Malformed regex"; return d end
+    d.rx = rx
+    local mstart, mend = regex.find_offsets(rx, "")
+    if mstart and mstart > mend then d.err = "Regex matches an empty string" end
   else
-    ok, mstart, mend = pcall(string.ufind, "", pattern)
-    if ok and mstart and mstart > mend then
-      ok, err = false, "Pattern matches an empty string"
-    elseif not ok then
-      err = mstart --[[@as string]]
+    d.lua = body
+    d.lua_anchored = "^" .. body
+    local ok, mstart, mend = pcall(string.ufind, "", body)
+    if not ok then
+      d.err = mstart --[[@as string]]
+    elseif mstart and mstart > mend then
+      d.err = "Pattern matches an empty string"
     end
   end
-  return ok --[[@as boolean]], err
+  return d
+end
+
+---Precompile a pattern entry into `entry._compiled` (idempotent):
+---  { [1] = <delimiter>, [2] = <delimiter|nil>, esc_byte = <int|nil>,
+---    err = <string|nil> }
+---A malformed entry is also marked `disabled`, exactly as before. Exposed so
+---the tokenizer can compile an entry a plugin injected after `syntax.add`.
+---@param entry table
+---@return table compiled
+function syntax.precompile_pattern(entry)
+  if entry._compiled then return entry._compiled end
+  local raw = entry.pattern or entry.regex
+  local is_regex = entry.regex ~= nil
+  local c
+  if type(raw) == "table" then
+    if type(raw[1]) ~= "string" or type(raw[2]) ~= "string" then
+      c = { err = "A delimited pattern needs a start and an end string" }
+    else
+      c = {
+        compile_delimiter(is_regex, raw[1]),
+        compile_delimiter(is_regex, raw[2]),
+      }
+      if type(raw[3]) == "string" and #raw[3] > 0 then c.esc_byte = raw[3]:byte() end
+    end
+  elseif type(raw) == "string" then
+    c = { compile_delimiter(is_regex, raw) }
+  else
+    c = { err = "Missing pattern or regex" }
+  end
+  for j = 1, 2 do
+    if c[j] and c[j].err then c.err = c.err or c[j].err end
+  end
+  if c.err then entry.disabled = true end
+  entry._compiled = c
+  return c
 end
 
 function syntax.add(t)
   if type(t.space_handling) ~= "boolean" then t.space_handling = true end
 
   if t.patterns then
-    -- do a sanity check on the patterns / regex to make sure they are actually correct
-    for i, pattern in ipairs(t.patterns) do
-      local p, ok, err, name = pattern.pattern or pattern.regex, nil, nil, nil
-      if type(p) == "table" then
-        for j = 1, 2 do
-          ok, err = check_pattern(pattern.pattern and "pattern" or "regex", p[j])
-          if not ok then name = string.format("#%d:%d <%s>", i, j, p[j]) end
-        end
-      elseif type(p) == "string" then
-        ok, err = check_pattern(pattern.pattern and "pattern" or "regex", p)
-        if not ok then name = string.format("#%d <%s>", i, p) end
-      else
-        ok, err, name = false, "Missing pattern or regex", "#"..i
-      end
-      if not ok then
-        pattern.disabled = true
-        core.warn("Malformed pattern %s in %s language plugin: %s", name, t.name, err)
-      end
-    end
-
     -- the rule %s+ gives us a performance gain for the tokenizer in lines with
     -- long amounts of consecutive spaces, can be disabled by plugins where it
     -- causes conflicts by declaring the table property: space_handling = false
@@ -71,6 +89,16 @@ function syntax.add(t)
     -- lot slower since iteration occurs in lua instead of C and adding to that
     -- it will also try to match every pattern to a single char (same as spaces)
     table.insert(t.patterns, { pattern = "%w+%f[%s]", type = "normal" })
+
+    -- compile every pattern up front, so the tokenizer never rewrites an entry
+    -- mid-scan, and report the malformed ones
+    for i, pattern in ipairs(t.patterns) do
+      local c = syntax.precompile_pattern(pattern)
+      if c.err then
+        core.warn("Malformed pattern #%d <%s> in %s language plugin: %s",
+          i, tostring(pattern.pattern or pattern.regex), t.name or "?", c.err)
+      end
+    end
   end
 
   table.insert(syntax.items, t)

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -200,57 +200,44 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
   end
 
   local function find_text(text, p, offset, at_start, close)
-    local target, res = p.pattern or p.regex, { 1, offset - 1 }
-    local p_idx = close and 2 or 1
-    local code = type(target) == "table" and target[p_idx] or target
     if p.disabled then return end
-
-    if p.whole_line == nil then p.whole_line = { } end
-    if p.whole_line[p_idx] == nil then
-      -- Match patterns that start with '^'
-      p.whole_line[p_idx] = code:umatch("^%^") and true or false
-      if p.whole_line[p_idx] then
-        -- Remove '^' from the beginning of the pattern
-        if type(target) == "table" then
-          target[p_idx] = code:usub(2)
-          code = target[p_idx]
-        else
-          p.pattern = p.pattern and code:usub(2)
-          p.regex = p.regex and code:usub(2)
-          code = p.pattern or p.regex
-        end
-      end
-    end
-
-    if p.regex and type(p.regex) ~= "table" then
-      p._regex = p._regex or regex.compile(p.regex)
-      code = p._regex
-    end
+    -- `syntax.add` compiles every pattern; a plugin that appends one after the
+    -- fact gets it compiled here on first use.
+    local c = p._compiled or syntax.precompile_pattern(p)
+    if p.disabled then return end
+    -- The compiled delimiter: [2] for the closing pattern of a pair, [1]
+    -- otherwise (a plain pattern has no [2], and used it for both ends).
+    local d = (close and c[2]) or c[1]
+    local anchored = at_start or d.whole_line
+    local res = { 1, offset - 1 }
 
     repeat
       local next = res[2] + 1
-      -- If the pattern contained '^', allow matching only the whole line
-      if p.whole_line[p_idx] and next > 1 then
+      -- A '^'-anchored pattern may only match at the very start of the line
+      if d.whole_line and next > 1 then
         return
       end
-      res = p.pattern and { text:ufind((at_start or p.whole_line[p_idx]) and "^" .. code or code, next) }
-        or { regex.find(code, text, text:ucharpos(next), (at_start or p.whole_line[p_idx]) and regex.ANCHORED or 0) }
-      if p.regex and #res > 0 then -- set correct utf8 len for regex result
-        local char_pos_1 = res[1] > next and string.ulen(text:sub(1, res[1])) or next
-        local char_pos_2 = string.ulen(text:sub(1, res[2]))
-        for i=3,#res do
-          res[i] = string.ulen(text:sub(1, res[i] - 1)) + 1
+      if d.regex then
+        res = { regex.find(d.rx, text, text:ucharpos(next), anchored and regex.ANCHORED or 0) }
+        if #res > 0 then -- translate the byte offsets regex returns to utf8 offsets
+          local char_pos_1 = res[1] > next and string.ulen(text:sub(1, res[1])) or next
+          local char_pos_2 = string.ulen(text:sub(1, res[2]))
+          for i=3,#res do
+            res[i] = string.ulen(text:sub(1, res[i] - 1)) + 1
+          end
+          res[1] = char_pos_1
+          res[2] = char_pos_2
         end
-        res[1] = char_pos_1
-        res[2] = char_pos_2
+      else
+        res = { text:ufind(anchored and d.lua_anchored or d.lua, next) }
       end
       if not res[1] then return end
-      if res[1] and target[3] then
-        -- Check to see if the escaped character is there,
-        -- and if it is not itself escaped.
+      if c.esc_byte then
+        -- Confirm the match is not preceded by an odd number of escape
+        -- characters (i.e. is not itself escaped).
         local count = 0
         for i = res[1] - 1, 1, -1 do
-          if text:ubyte(i) ~= target[3]:ubyte() then break end
+          if text:ubyte(i) ~= c.esc_byte then break end
           count = count + 1
         end
         if count % 2 == 0 then
@@ -261,7 +248,7 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
           res[1] = false
         end
       end
-    until at_start or not close or not target[3]
+    until at_start or not close or not c.esc_byte
     return table.unpack(res)
   end
 


### PR DESCRIPTION
## Problem

`find_text` (in `tokenizer.tokenize`) does first-use bookkeeping on every
pattern entry it touches:

- detect a leading `^` and **strip it in place**, rewriting `p.pattern` /
  `p.regex` / `p.pattern[n]`;
- cache that on a lazily-created `p.whole_line` table;
- lazily `regex.compile` a non-table regex into `p._regex`.

So a pattern entry is mutated during the first tokenize pass, and stays
mutated. Separately, `syntax.add` compiles every regex / tests every Lua
pattern once purely to validate it, then discards that work.

Consequences: shared syntax-table state is written from inside the scan
(awkward for anything that wants to run tokenization off the main thread
later), a reader of `syntax.patterns` sees a different pattern string
depending on whether a tokenize pass has happened yet, and every regex is
compiled twice.

## Change

Compile each pattern **once**, in `syntax.add`, into an immutable record
`entry._compiled`:

```lua
{ [1] = <delimiter>, [2] = <delimiter | nil>,   -- open, close
  esc_byte = <int | nil> }                       -- first byte of pattern[3]
```

A `<delimiter>` carries `whole_line` (did it start with `^`), the
`^`-stripped Lua `body` (plus `body` with `^` re-prepended for the anchored
case), or a compiled `rx`. `find_text` now just reads the record — no
probing, no rewriting, no lazy compile.

`check_pattern`'s throwaway compile is folded in: the compile that
validates a pattern is the compile the tokenizer runs. Malformed entries
are still marked `disabled` and still produce one `core.warn`, as before.

A pattern a plugin appends to `syntax.patterns` *after* `syntax.add` (e.g.
via `table.insert`) is compiled by `find_text` on first use through the
same, now-exported `syntax.precompile_pattern`.

`find_text` drops from ~65 lines to ~44.

## No behavioural change

- **Golden-token corpus** (#2250 — `test/tokenizer/`, 13 files / 940 lines,
  incl. HTML→JS/CSS and Markdown-fence subsyntaxes, regex-literal JS,
  nested Lua long brackets, unterminated comment/string at EOF): token
  streams and end states **byte-identical**.
- **Whole `data/` tree** (76 files, ~18.6k lines of
  C/C++/Lua/Python/CSS/HTML/JS/XML/MD/JSON): tokenized line-by-line with
  state threaded through — **byte-identical** old vs new.
- 310 bundled patterns compile with **no new warnings**; 0 disabled.
- Injecting a raw pattern after `syntax.add` still tokenizes (lazy path).

Incidental: because entries are no longer rewritten in place, `detectindent`
and any other reader of `syntax.patterns` now always sees a pattern as the
plugin wrote it, instead of depending on tokenize order.

## Depends on

Nothing to merge, but the corpus in #2250 is what gates this — recommend
landing #2250 first so CI can run `test/tokenizer/run.sh`.
