### PR TITLE
fix(tokenizer): don't use a `type` table as a token type

### DIFF
--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -47,7 +47,14 @@ local function push_tokens(t, syn, pattern, full_text, find_results)
   else
     local start, fin = find_results[1], find_results[2]
     local text = full_text:usub(start, fin)
-    push_token(t, syn.symbols[text] or pattern.type, text)
+    -- A delimited pair whose `type` is a table but whose matched delimiter has
+    -- no captures lands here (e.g. a subsyntax `{ "()def", ":" }` closing on
+    -- its `:`). Take the first declared type -- the same "fallback group"
+    -- convention the multi-capture branch and the subsyntax middle use -- so a
+    -- token type is always a string, never the type table itself.
+    local ptype = pattern.type
+    if type(ptype) == "table" then ptype = ptype[1] end
+    push_token(t, syn.symbols[text] or ptype, text)
   end
 end
 


### PR DESCRIPTION
## Problem

A delimited pattern with a `type` table —

```lua
{ pattern = { "^%s*()def%f[%s]", ":" }, type = { "normal", "keyword" }, syntax = python_func }
```

— whose *matched delimiter* produced no captures (here the closing `":"`)
reaches `push_tokens`' single-token branch:

```lua
push_token(t, syn.symbols[text] or pattern.type, text)
```

`pattern.type` is the table, so a token goes into the stream with a **table**
as its type.

Every consumer treats a token type as a string:

- `DocView:draw_line_text` does `style.syntax[type]` — a table key always
  misses, so the token silently renders in the default colour;
- `tokenizer.each_token` hands plugins a table where they expect a string.

Reproduces on any Python file with a `def`/`for`/`if`/… block header that
closes its `:` on the same line, and on JS regex literals.

## Fix

Use `pattern.type[1]` — the same "first entry is the fallback group"
convention the multi-capture branch and a subsyntax pair's *middle* token
already use (`type(p.type) == "table" and p.type[1] or p.type`). One line
plus a comment; token types are now always strings.

Before / after for `def p(self):`:

```
before:  keyword="    def" | function=" p" | normal="(" | keyword2=self | normal=")" | <table>=":"
after:   keyword="    def" | function=" p" | normal="(" | keyword2=self | normal="):"
```